### PR TITLE
Relocate bundled ImGui to dart/gui/imgui and bump to v1.92.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@
     an explicit system ImGui opt-in path:
     [#3081](https://github.com/dartsim/dart/pull/3081)
 
+  * Relocate the bundled `external-imgui` build from `dart/external/imgui` to
+    `dart/gui/imgui` and remove the now-empty `dart/external` source directory,
+    update the bundled FetchContent ImGui to `v1.92.8`, and rebase the DART
+    compatibility patch onto it. Source builds default to the FetchContent copy
+    (`DART_USE_SYSTEM_IMGUI=OFF`) so building from source needs no system ImGui
+    package; Pixi and the conda-forge recipe opt into the system ImGui. The
+    `external-imgui` component and the installed `include/dart/external/imgui`
+    compatibility include path are unchanged:
+    [#3198](https://github.com/dartsim/dart/pull/3198)
+
   * Update the math user-defined literal declarations to the C++23 spelling
     accepted by newer AppleClang warning-as-error builds.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,7 +805,9 @@ if(DOXYGEN_FOUND)
   set(DOXYGEN_INCLUDE_PATH "${PROJECT_SOURCE_DIR}")
   set(DOXYGEN_INPUT_ROOT "${PROJECT_SOURCE_DIR}/dart")
   set(DOXYGEN_EXTRA_INPUTS "${PROJECT_SOURCE_DIR}/docs/doxygen/mainpage.dox")
-  set(DOXYGEN_EXCLUDE "${PROJECT_SOURCE_DIR}/dart/external")
+  # No in-tree third-party sources to exclude: the bundled ImGui is fetched into
+  # the build tree (or taken from the system package), not vendored under dart/.
+  set(DOXYGEN_EXCLUDE "")
   set(DOXYGEN_STRIP_FROM_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
   # Generate a Doxyfile. This uses the variables:

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory(external)
-
 # Enable multi-threaded compilation.
 # We do this here and not in the root folder since the examples and the
 # tutorials do not have enough source files to benefit from this.

--- a/dart/external/CMakeLists.txt
+++ b/dart/external/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(imgui)

--- a/dart/gui/CMakeLists.txt
+++ b/dart/gui/CMakeLists.txt
@@ -1,4 +1,7 @@
 # The legacy dart-gui component has been removed. OpenSceneGraph remains
 # available through the dart-gui-osg component.
 
+# The bundled ImGui (the external-imgui compatibility component) is consumed by
+# the OSG GUI, so configure it before the osg subdirectory.
+add_subdirectory(imgui)
 add_subdirectory(osg)

--- a/dart/gui/imgui/CMakeLists.txt
+++ b/dart/gui/imgui/CMakeLists.txt
@@ -415,6 +415,36 @@ else()
   include(FetchContent)
 
   set(IMGUI_TARGET_VERSION "v1.92.8")
+
+  # DART applies its compatibility patch directly inside the FetchContent
+  # checkout, which leaves that working tree dirty. If the requested tag changed
+  # since this build tree was last configured, FetchContent's in-place
+  # re-checkout to the new tag fails on the local patch hunks (configure stops
+  # until the cached source is deleted by hand). Detect a tag change via a stamp
+  # file and drop the cached download so the new tag is fetched from a clean
+  # state.
+  set(dart_imgui_src_dir "${DART_BINARY_DIR}/_deps/imgui-src")
+  set(dart_imgui_tag_stamp "${DART_BINARY_DIR}/_deps/dart_imgui_tag.txt")
+  set(dart_imgui_cached_tag "")
+  if(EXISTS "${dart_imgui_tag_stamp}")
+    file(READ "${dart_imgui_tag_stamp}" dart_imgui_cached_tag)
+    string(STRIP "${dart_imgui_cached_tag}" dart_imgui_cached_tag)
+  endif()
+  if(
+    EXISTS "${dart_imgui_src_dir}"
+    AND NOT dart_imgui_cached_tag STREQUAL IMGUI_TARGET_VERSION
+  )
+    message(
+      STATUS
+      "Bundled ImGui tag changed to ${IMGUI_TARGET_VERSION}; refreshing cached download"
+    )
+    # The source uses a custom SOURCE_DIR (imgui-src); the FetchContent sub-build
+    # and build trees are named after the declared content (dart_imgui-*). Remove
+    # all of them so the next populate re-clones the new tag from scratch.
+    file(GLOB dart_imgui_fetch_dirs "${DART_BINARY_DIR}/_deps/dart_imgui-*")
+    file(REMOVE_RECURSE "${dart_imgui_src_dir}" ${dart_imgui_fetch_dirs})
+  endif()
+
   message(STATUS "Fetching ImGui ${IMGUI_TARGET_VERSION} from GitHub...")
 
   FetchContent_Declare(
@@ -514,6 +544,10 @@ else()
       endif()
     endif()
   endforeach()
+
+  # Record the tag now that the matching ImGui sources are populated and patched
+  # so a later tag change can refresh the cached download (see above).
+  file(WRITE "${dart_imgui_tag_stamp}" "${IMGUI_TARGET_VERSION}\n")
 
   set(
     imgui_core_sources

--- a/dart/gui/imgui/CMakeLists.txt
+++ b/dart/gui/imgui/CMakeLists.txt
@@ -2,7 +2,8 @@ set(target_name ${PROJECT_NAME}-external-imgui)
 set(component_name external-imgui)
 set(component_dependency_packages OpenGL)
 
-set(imgui_header_names
+set(
+  imgui_header_names
   imconfig.h
   imgui.h
   imgui_internal.h
@@ -18,11 +19,13 @@ function(dart_find_imgui_header out_var header_name)
       continue()
     endif()
 
-    foreach(candidate_dir
-        "${search_dir}"
-        "${search_dir}/imgui"
-        "${search_dir}/imgui/backends"
-        "${search_dir}/backends")
+    foreach(
+      candidate_dir
+      "${search_dir}"
+      "${search_dir}/imgui"
+      "${search_dir}/imgui/backends"
+      "${search_dir}/backends"
+    )
       if(EXISTS "${candidate_dir}/${header_name}")
         set(${out_var} "${candidate_dir}/${header_name}" PARENT_SCOPE)
         return()
@@ -32,7 +35,8 @@ function(dart_find_imgui_header out_var header_name)
 
   string(MAKE_C_IDENTIFIER "${header_name}" header_cache_name)
   set(resolved_header_var "resolved_${header_cache_name}")
-  find_file(${resolved_header_var}
+  find_file(
+    ${resolved_header_var}
     NAMES "${header_name}"
     PATH_SUFFIXES imgui imgui/backends backends
   )
@@ -49,11 +53,13 @@ function(dart_try_find_imgui_header out_var header_name)
       continue()
     endif()
 
-    foreach(candidate_dir
-        "${search_dir}"
-        "${search_dir}/imgui"
-        "${search_dir}/imgui/backends"
-        "${search_dir}/backends")
+    foreach(
+      candidate_dir
+      "${search_dir}"
+      "${search_dir}/imgui"
+      "${search_dir}/imgui/backends"
+      "${search_dir}/backends"
+    )
       if(EXISTS "${candidate_dir}/${header_name}")
         set(${out_var} "${candidate_dir}/${header_name}" PARENT_SCOPE)
         return()
@@ -70,21 +76,23 @@ function(dart_find_imgui_source out_var source_name)
       continue()
     endif()
 
-    foreach(candidate_dir
-        "${search_dir}"
-        "${search_dir}/imgui"
-        "${search_dir}/imgui/backends"
-        "${search_dir}/backends"
-        "${search_dir}/../share/imgui"
-        "${search_dir}/../share/imgui/backends"
-        "${search_dir}/../share/imgui/examples"
-        "${search_dir}/../share/imgui/examples/backends"
-        "${search_dir}/../share/doc/imgui/examples"
-        "${search_dir}/../share/doc/imgui/examples/backends"
-        "${search_dir}/../share/doc/libimgui-dev/examples/backends"
-        "${search_dir}/../../share/doc/imgui/examples"
-        "${search_dir}/../../share/doc/imgui/examples/backends"
-        "${search_dir}/../../share/doc/libimgui-dev/examples/backends")
+    foreach(
+      candidate_dir
+      "${search_dir}"
+      "${search_dir}/imgui"
+      "${search_dir}/imgui/backends"
+      "${search_dir}/backends"
+      "${search_dir}/../share/imgui"
+      "${search_dir}/../share/imgui/backends"
+      "${search_dir}/../share/imgui/examples"
+      "${search_dir}/../share/imgui/examples/backends"
+      "${search_dir}/../share/doc/imgui/examples"
+      "${search_dir}/../share/doc/imgui/examples/backends"
+      "${search_dir}/../share/doc/libimgui-dev/examples/backends"
+      "${search_dir}/../../share/doc/imgui/examples"
+      "${search_dir}/../../share/doc/imgui/examples/backends"
+      "${search_dir}/../../share/doc/libimgui-dev/examples/backends"
+    )
       if(EXISTS "${candidate_dir}/${source_name}")
         set(${out_var} "${candidate_dir}/${source_name}" PARENT_SCOPE)
         return()
@@ -94,7 +102,8 @@ function(dart_find_imgui_source out_var source_name)
 
   string(MAKE_C_IDENTIFIER "${source_name}" source_cache_name)
   set(resolved_source_var "resolved_${source_cache_name}")
-  find_file(${resolved_source_var}
+  find_file(
+    ${resolved_source_var}
     NAMES "${source_name}"
     HINTS ${ARGN}
     PATH_SUFFIXES
@@ -130,20 +139,24 @@ endfunction()
 
 function(dart_patch_imgui_opengl2_backend out_var source_path)
   file(READ "${source_path}" imgui_opengl2_contents)
-  string(FIND
-    "${imgui_opengl2_contents}"
+  string(
+    FIND "${imgui_opengl2_contents}"
     "glPushClientAttrib(GL_VERTEX_ARRAY | GL_TEXTURE_COORD_ARRAY | GL_COLOR_ARRAY)"
     imgui_opengl2_push_marker
   )
-  string(FIND
-    "${imgui_opengl2_contents}"
+  string(
+    FIND "${imgui_opengl2_contents}"
     "glPopClientAttrib()"
     imgui_opengl2_pop_marker
   )
 
   if(imgui_opengl2_push_marker EQUAL -1)
-    message(STATUS "Applying DART ImGui OpenGL2 client-state patch: ${source_path}")
-    string(REPLACE
+    message(
+      STATUS
+      "Applying DART ImGui OpenGL2 client-state patch: ${source_path}"
+    )
+    string(
+      REPLACE
       "    glEnableClientState(GL_VERTEX_ARRAY);"
       "    glPushClientAttrib(GL_VERTEX_ARRAY | GL_TEXTURE_COORD_ARRAY | GL_COLOR_ARRAY);\n    glEnableClientState(GL_VERTEX_ARRAY);"
       imgui_opengl2_contents
@@ -151,7 +164,8 @@ function(dart_patch_imgui_opengl2_backend out_var source_path)
     )
   endif()
   if(imgui_opengl2_pop_marker EQUAL -1)
-    string(REPLACE
+    string(
+      REPLACE
       "    glBindTexture(GL_TEXTURE_2D, (GLuint)last_texture);"
       "    glPopClientAttrib();\n    glBindTexture(GL_TEXTURE_2D, (GLuint)last_texture);"
       imgui_opengl2_contents
@@ -159,13 +173,13 @@ function(dart_patch_imgui_opengl2_backend out_var source_path)
     )
   endif()
 
-  string(FIND
-    "${imgui_opengl2_contents}"
+  string(
+    FIND "${imgui_opengl2_contents}"
     "glPushClientAttrib(GL_VERTEX_ARRAY | GL_TEXTURE_COORD_ARRAY | GL_COLOR_ARRAY)"
     imgui_opengl2_push_marker
   )
-  string(FIND
-    "${imgui_opengl2_contents}"
+  string(
+    FIND "${imgui_opengl2_contents}"
     "glPopClientAttrib()"
     imgui_opengl2_pop_marker
   )
@@ -193,7 +207,10 @@ function(dart_configure_imgui_compat_headers out_var)
       "${imgui_compat_header_dir}/${imgui_header_name}"
       COPYONLY
     )
-    list(APPEND compat_headers "${imgui_compat_header_dir}/${imgui_header_name}")
+    list(
+      APPEND compat_headers
+      "${imgui_compat_header_dir}/${imgui_header_name}"
+    )
   endforeach()
 
   set(${out_var} ${compat_headers} PARENT_SCOPE)
@@ -212,31 +229,31 @@ macro(dart_try_find_system_imgui)
       pkg_check_modules(PC_imgui imgui QUIET)
     endif()
 
-    find_path(_dart_imgui_include_dir
+    find_path(
+      _dart_imgui_include_dir
       NAMES imgui.h
       HINTS ${PC_imgui_INCLUDEDIR}
       PATHS
         "${CMAKE_INSTALL_PREFIX}/include"
         "${CMAKE_INSTALL_PREFIX}/include/imgui"
     )
-    find_path(_dart_imgui_backends_include_dir
+    find_path(
+      _dart_imgui_backends_include_dir
       NAMES imgui_impl_opengl2.h
-      HINTS
-        ${PC_imgui_INCLUDEDIR}
-        ${PC_imgui_INCLUDEDIR}/backends
+      HINTS ${PC_imgui_INCLUDEDIR} ${PC_imgui_INCLUDEDIR}/backends
       PATHS
         "${CMAKE_INSTALL_PREFIX}/include"
         "${CMAKE_INSTALL_PREFIX}/include/imgui/backends"
     )
-    find_library(_dart_imgui_library
-      NAMES imgui
-      HINTS ${PC_imgui_LIBDIR}
-    )
+    find_library(_dart_imgui_library NAMES imgui HINTS ${PC_imgui_LIBDIR})
 
-    if(_dart_imgui_include_dir
-        AND _dart_imgui_backends_include_dir
-        AND _dart_imgui_library)
-      set(imgui_INCLUDE_DIRS
+    if(
+      _dart_imgui_include_dir
+      AND _dart_imgui_backends_include_dir
+      AND _dart_imgui_library
+    )
+      set(
+        imgui_INCLUDE_DIRS
         ${_dart_imgui_include_dir}
         ${_dart_imgui_backends_include_dir}
       )
@@ -247,9 +264,11 @@ macro(dart_try_find_system_imgui)
 
   if(imgui_FOUND AND NOT TARGET imgui::imgui)
     add_library(imgui::imgui INTERFACE IMPORTED)
-    set_target_properties(imgui::imgui PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${imgui_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${imgui_LIBRARIES}"
+    set_target_properties(
+      imgui::imgui
+      PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${imgui_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES "${imgui_LIBRARIES}"
     )
   endif()
 endmacro()
@@ -277,7 +296,9 @@ if(DART_USE_SYSTEM_IMGUI)
 
   set(imgui_header_search_dirs ${imgui_INCLUDE_DIRS})
   get_target_property(
-    imgui_target_include_dirs imgui::imgui INTERFACE_INCLUDE_DIRECTORIES
+    imgui_target_include_dirs
+    imgui::imgui
+    INTERFACE_INCLUDE_DIRECTORIES
   )
   if(imgui_target_include_dirs)
     list(APPEND imgui_header_search_dirs ${imgui_target_include_dirs})
@@ -295,10 +316,15 @@ if(DART_USE_SYSTEM_IMGUI)
     endif()
   endforeach()
   if(imgui_missing_compat_headers AND NOT DART_BUILD_GUI_OSG)
-    string(REPLACE ";" ", " imgui_missing_compat_headers_text
+    string(
+      REPLACE
+      ";"
+      ", "
+      imgui_missing_compat_headers_text
       "${imgui_missing_compat_headers}"
     )
-    message(STATUS
+    message(
+      STATUS
       "Skipping dart-external-imgui: system ImGui compatibility headers were "
       "not found (${imgui_missing_compat_headers_text})"
     )
@@ -308,8 +334,12 @@ if(DART_USE_SYSTEM_IMGUI)
   dart_configure_imgui_compat_headers(
     imgui_compat_headers ${imgui_header_search_dirs}
   )
-  set(imgui_compat_source "${CMAKE_CURRENT_BINARY_DIR}/external_imgui_compat.cpp")
-  file(WRITE "${imgui_compat_source}"
+  set(
+    imgui_compat_source
+    "${CMAKE_CURRENT_BINARY_DIR}/external_imgui_compat.cpp"
+  )
+  file(
+    WRITE "${imgui_compat_source}"
     "namespace dart_external_imgui { void keep_component() {} }\n"
   )
 
@@ -346,7 +376,8 @@ if(DART_USE_SYSTEM_IMGUI)
 
   if(NOT DART_SYSTEM_IMGUI_HAS_OPENGL2_BACKEND)
     if(NOT DART_BUILD_GUI_OSG)
-      message(STATUS
+      message(
+        STATUS
         "Skipping dart-external-imgui: system ImGui OpenGL2 backend was not found"
       )
       return()
@@ -365,10 +396,9 @@ if(DART_USE_SYSTEM_IMGUI)
   endif()
 
   dart_add_library(${target_name} ${imgui_compat_sources} ${imgui_compat_headers})
-  target_include_directories(${target_name}
-    PUBLIC
-      $<BUILD_INTERFACE:${DART_BINARY_DIR}>
-      $<INSTALL_INTERFACE:include>
+  target_include_directories(
+    ${target_name}
+    PUBLIC $<BUILD_INTERFACE:${DART_BINARY_DIR}> $<INSTALL_INTERFACE:include>
   )
   target_link_libraries(${target_name} PUBLIC imgui::imgui OpenGL::GL)
 else()
@@ -384,7 +414,7 @@ else()
 
   include(FetchContent)
 
-  set(IMGUI_TARGET_VERSION "v1.91.9")
+  set(IMGUI_TARGET_VERSION "v1.92.8")
   message(STATUS "Fetching ImGui ${IMGUI_TARGET_VERSION} from GitHub...")
 
   FetchContent_Declare(
@@ -392,7 +422,8 @@ else()
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG ${IMGUI_TARGET_VERSION}
     GIT_SHALLOW TRUE
-    SOURCE_DIR "${DART_BINARY_DIR}/_deps/imgui-src"
+    SOURCE_DIR
+    "${DART_BINARY_DIR}/_deps/imgui-src"
   )
 
   FetchContent_GetProperties(dart_imgui)
@@ -401,9 +432,7 @@ else()
   endif()
 
   find_package(Git REQUIRED)
-  set(imgui_patch_files
-    "${CMAKE_CURRENT_LIST_DIR}/../imgui_patches/dart-compat.patch"
-  )
+  set(imgui_patch_files "${CMAKE_CURRENT_LIST_DIR}/dart-compat.patch")
   foreach(imgui_patch IN LISTS imgui_patch_files)
     execute_process(
       COMMAND
@@ -416,7 +445,9 @@ else()
     if(imgui_patch_check_result EQUAL 0)
       message(STATUS "Applying DART ImGui compatibility patch: ${imgui_patch}")
       execute_process(
-        COMMAND "${GIT_EXECUTABLE}" -C "${dart_imgui_SOURCE_DIR}" apply "${imgui_patch}"
+        COMMAND
+          "${GIT_EXECUTABLE}" -C "${dart_imgui_SOURCE_DIR}" apply
+          "${imgui_patch}"
         RESULT_VARIABLE imgui_patch_result
         OUTPUT_VARIABLE imgui_patch_output
         ERROR_VARIABLE imgui_patch_error
@@ -429,54 +460,63 @@ else()
       endif()
     else()
       file(READ "${dart_imgui_SOURCE_DIR}/imgui_draw.cpp" imgui_draw_contents)
-      file(READ "${dart_imgui_SOURCE_DIR}/imgui_internal.h" imgui_internal_contents)
-      file(READ "${dart_imgui_SOURCE_DIR}/imgui_widgets.cpp" imgui_widgets_contents)
-      file(READ
-        "${dart_imgui_SOURCE_DIR}/backends/imgui_impl_opengl2.cpp"
+      file(
+        READ "${dart_imgui_SOURCE_DIR}/imgui_internal.h"
+        imgui_internal_contents
+      )
+      file(
+        READ "${dart_imgui_SOURCE_DIR}/imgui_widgets.cpp"
+        imgui_widgets_contents
+      )
+      file(
+        READ "${dart_imgui_SOURCE_DIR}/backends/imgui_impl_opengl2.cpp"
         imgui_opengl2_contents
       )
-      string(FIND
-        "${imgui_draw_contents}"
+      string(
+        FIND "${imgui_draw_contents}"
         "Guard against null/empty input (issue #2516)"
         imgui_draw_ttf_patch_marker
       )
-      string(FIND
-        "${imgui_draw_contents}"
+      string(
+        FIND "${imgui_draw_contents}"
         "Guard against null/empty input to prevent SEGV in stb_decompress (issue #2516)"
         imgui_draw_compressed_ttf_patch_marker
       )
-      string(FIND
-        "${imgui_draw_contents}"
+      string(
+        FIND "${imgui_draw_contents}"
         "Guard against null input (issue #2516)"
         imgui_draw_base85_patch_marker
       )
-      string(FIND
-        "${imgui_internal_contents}"
+      string(
+        FIND "${imgui_internal_contents}"
         "IMGUI_INTERNAL_FORMAT_API"
         imgui_internal_patch_marker
       )
-      string(FIND
-        "${imgui_widgets_contents}"
+      string(
+        FIND "${imgui_widgets_contents}"
         "issue #2668"
         imgui_widgets_patch_marker
       )
-      string(FIND
-        "${imgui_opengl2_contents}"
+      string(
+        FIND "${imgui_opengl2_contents}"
         "glPushClientAttrib(GL_VERTEX_ARRAY | GL_TEXTURE_COORD_ARRAY | GL_COLOR_ARRAY)"
         imgui_opengl2_patch_marker
       )
-      if(imgui_draw_ttf_patch_marker EQUAL -1
-          OR imgui_draw_compressed_ttf_patch_marker EQUAL -1
-          OR imgui_draw_base85_patch_marker EQUAL -1
-          OR imgui_internal_patch_marker EQUAL -1
-          OR imgui_widgets_patch_marker EQUAL -1
-          OR imgui_opengl2_patch_marker EQUAL -1)
+      if(
+        imgui_draw_ttf_patch_marker EQUAL -1
+        OR imgui_draw_compressed_ttf_patch_marker EQUAL -1
+        OR imgui_draw_base85_patch_marker EQUAL -1
+        OR imgui_internal_patch_marker EQUAL -1
+        OR imgui_widgets_patch_marker EQUAL -1
+        OR imgui_opengl2_patch_marker EQUAL -1
+      )
         message(FATAL_ERROR "DART ImGui patch is incompatible: ${imgui_patch}")
       endif()
     endif()
   endforeach()
 
-  set(imgui_core_sources
+  set(
+    imgui_core_sources
     "${dart_imgui_SOURCE_DIR}/imgui.cpp"
     "${dart_imgui_SOURCE_DIR}/imgui_draw.cpp"
     "${dart_imgui_SOURCE_DIR}/imgui_tables.cpp"
@@ -490,7 +530,8 @@ else()
   )
 
   dart_add_library(${target_name} ${imgui_core_sources} ${imgui_compat_headers})
-  target_include_directories(${target_name}
+  target_include_directories(
+    ${target_name}
     PUBLIC
       $<BUILD_INTERFACE:${DART_BINARY_DIR}>
       $<BUILD_INTERFACE:${dart_imgui_SOURCE_DIR}>
@@ -508,7 +549,10 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   target_compile_options(${target_name} PRIVATE -w)
 endif()
 if(NOT DART_USE_SYSTEM_IMGUI)
-  target_compile_definitions(${target_name} PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS)
+  target_compile_definitions(
+    ${target_name}
+    PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+  )
 endif()
 
 add_component(${PROJECT_NAME} ${component_name})

--- a/dart/gui/imgui/dart-compat.patch
+++ b/dart/gui/imgui/dart-compat.patch
@@ -1,18 +1,38 @@
+diff --git a/backends/imgui_impl_opengl2.cpp b/backends/imgui_impl_opengl2.cpp
+index 6cbaaac..1c1edbc 100644
+--- a/backends/imgui_impl_opengl2.cpp
++++ b/backends/imgui_impl_opengl2.cpp
+@@ -122,6 +122,7 @@ static void ImGui_ImplOpenGL2_SetupRenderState(ImDrawData* draw_data, int fb_wid
+     glDisable(GL_LIGHTING);
+     glDisable(GL_COLOR_MATERIAL);
+     glEnable(GL_SCISSOR_TEST);
++    glPushClientAttrib(GL_VERTEX_ARRAY | GL_TEXTURE_COORD_ARRAY | GL_COLOR_ARRAY);
+     glEnableClientState(GL_VERTEX_ARRAY);
+     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+     glEnableClientState(GL_COLOR_ARRAY);
+@@ -247,6 +248,7 @@ void ImGui_ImplOpenGL2_RenderDrawData(ImDrawData* draw_data)
+     glDisableClientState(GL_COLOR_ARRAY);
+     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+     glDisableClientState(GL_VERTEX_ARRAY);
++    glPopClientAttrib();
+     glBindTexture(GL_TEXTURE_2D, (GLuint)last_texture);
+     glMatrixMode(GL_MODELVIEW);
+     glPopMatrix();
 diff --git a/imgui_draw.cpp b/imgui_draw.cpp
-index 84d81492..f1cfc453 100644
+index cfea11c..a6a399c 100644
 --- a/imgui_draw.cpp
 +++ b/imgui_draw.cpp
-@@ -2685,6 +2685,9 @@ ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels,
+@@ -3250,6 +3250,9 @@ ImFont* ImFontAtlas::AddFontFromFileTTF(const char* filename, float size_pixels,
  ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* font_data, int font_data_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges)
  {
-     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas between NewFrame() and EndFrame/Render()!");
+     IM_ASSERT(!Locked && "Cannot modify a locked ImFontAtlas!");
 +    // [DART patch] Guard against null/empty input (issue #2516)
 +    if (font_data == NULL || font_data_size <= 0)
 +        return NULL;
      ImFontConfig font_cfg = font_cfg_template ? *font_cfg_template : ImFontConfig();
      IM_ASSERT(font_cfg.FontData == NULL);
      IM_ASSERT(font_data_size > 100 && "Incorrect value for font_data_size!"); // Heuristic to prevent accidentally passing a wrong value to font_data_size.
-@@ -2697,6 +2700,10 @@ ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* font_data, int font_data_size, f
+@@ -3263,6 +3266,10 @@ ImFont* ImFontAtlas::AddFontFromMemoryTTF(void* font_data, int font_data_size, f
  
  ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, const ImFontConfig* font_cfg_template, const ImWchar* glyph_ranges)
  {
@@ -23,7 +43,7 @@ index 84d81492..f1cfc453 100644
      const unsigned int buf_decompressed_size = stb_decompress_length((const unsigned char*)compressed_ttf_data);
      unsigned char* buf_decompressed_data = (unsigned char*)IM_ALLOC(buf_decompressed_size);
      stb_decompress(buf_decompressed_data, (const unsigned char*)compressed_ttf_data, (unsigned int)compressed_ttf_size);
-@@ -2709,6 +2716,10 @@ ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_d
+@@ -3275,6 +3282,10 @@ ImFont* ImFontAtlas::AddFontFromMemoryCompressedTTF(const void* compressed_ttf_d
  
  ImFont* ImFontAtlas::AddFontFromMemoryCompressedBase85TTF(const char* compressed_ttf_data_base85, float size_pixels, const ImFontConfig* font_cfg, const ImWchar* glyph_ranges)
  {
@@ -35,10 +55,10 @@ index 84d81492..f1cfc453 100644
      void* compressed_ttf = IM_ALLOC((size_t)compressed_ttf_size);
      Decode85((const unsigned char*)compressed_ttf_data_base85, (unsigned char*)compressed_ttf);
 diff --git a/imgui_internal.h b/imgui_internal.h
-index 5e346dd4..5a8882a2 100644
+index d66b6a9..e450f44 100644
 --- a/imgui_internal.h
 +++ b/imgui_internal.h
-@@ -396,8 +396,16 @@ static inline bool      ImCharIsXdigitA(char c)         { return (c >= '0' && c
+@@ -408,8 +408,16 @@ inline bool             ImCharIsXdigitA(char c)         { return (c >= '0' && c
  IM_MSVC_RUNTIME_CHECKS_RESTORE
  
  // Helpers: Formatting
@@ -58,10 +78,10 @@ index 5e346dd4..5a8882a2 100644
  IMGUI_API void          ImFormatStringToTempBufferV(const char** out_buf, const char** out_buf_end, const char* fmt, va_list args) IM_FMTLIST(3);
  IMGUI_API const char*   ImParseFormatFindStart(const char* format);
 diff --git a/imgui_widgets.cpp b/imgui_widgets.cpp
-index 17a62692..b23ac956 100644
+index ea792f9..d758da7 100644
 --- a/imgui_widgets.cpp
 +++ b/imgui_widgets.cpp
-@@ -5771,6 +5771,10 @@ static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2
+@@ -6069,6 +6069,10 @@ static void RenderArrowsForVerticalBar(ImDrawList* draw_list, ImVec2 pos, ImVec2
  // FIXME: this is trying to be aware of style.Alpha but not fully correct. Also, the color wheel will have overlapping glitches with (style.Alpha < 1.0)
  bool ImGui::ColorPicker4(const char* label, float col[4], ImGuiColorEditFlags flags, const float* ref_col)
  {
@@ -72,23 +92,3 @@ index 17a62692..b23ac956 100644
      ImGuiContext& g = *GImGui;
      ImGuiWindow* window = GetCurrentWindow();
      if (window->SkipItems)
-diff --git a/backends/imgui_impl_opengl2.cpp b/backends/imgui_impl_opengl2.cpp
-index b8c7e4b2..c1fbc29a 100644
---- a/backends/imgui_impl_opengl2.cpp
-+++ b/backends/imgui_impl_opengl2.cpp
-@@ -143,6 +143,7 @@ static void ImGui_ImplOpenGL2_SetupRenderState(ImDrawData* draw_data, int fb_wid
-     glDisable(GL_LIGHTING);
-     glDisable(GL_COLOR_MATERIAL);
-     glEnable(GL_SCISSOR_TEST);
-+    glPushClientAttrib(GL_VERTEX_ARRAY | GL_TEXTURE_COORD_ARRAY | GL_COLOR_ARRAY);
-     glEnableClientState(GL_VERTEX_ARRAY);
-     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-     glEnableClientState(GL_COLOR_ARRAY);
-@@ -246,6 +247,7 @@ void ImGui_ImplOpenGL2_RenderDrawData(ImDrawData* draw_data)
-     glDisableClientState(GL_COLOR_ARRAY);
-     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-     glDisableClientState(GL_VERTEX_ARRAY);
-+    glPopClientAttrib();
-     glBindTexture(GL_TEXTURE_2D, (GLuint)last_texture);
-     glMatrixMode(GL_MODELVIEW);
-     glPopMatrix();


### PR DESCRIPTION
## Summary

After the `convhull_3d`/`ikfast`/`lodepng`/`odelcpsolver` removals, `dart/external`
held only the bundled ImGui build driver. This relocates it and refreshes the
bundled ImGui:

- **Relocate** the `external-imgui` driver + its DART compatibility patch from
  `dart/external/imgui` to `dart/gui/imgui` (configured from `dart/gui` before the
  `osg` subdirectory), and **delete the now-empty `dart/external` source directory**.
- **Bump** the bundled FetchContent ImGui `v1.91.9 → v1.92.8` and **rebase** the DART
  compatibility patch onto it.
- Source builds keep `DART_USE_SYSTEM_IMGUI` defaulting **OFF** (self-contained
  FetchContent — building from source needs no system ImGui, which is not packaged on
  every platform); Pixi and the conda-forge recipe opt into the system package via
  `-DDART_USE_SYSTEM_IMGUI=ON`.

## Why the patch can't just be dropped

All four DART fixes are still **absent upstream** in v1.92.8, so the patch is rebased,
not removed:

| Fix | Where |
| --- | --- |
| issue #2516 — null/empty font input guards (×3) | `imgui_draw.cpp` |
| issue #2668 — `ColorPicker4` missing-context guard | `imgui_widgets.cpp` |
| hidden-visibility `ImFormatString`/`V` | `imgui_internal.h` |
| OpenGL2 client-attrib save/restore | `backends/imgui_impl_opengl2.cpp` |

## Compatibility

The public surface is unchanged: the `external-imgui` component, the
`dart-external-imgui` target, and the installed `include/dart/external/imgui`
compatibility include path all stay. All DART code routes through the single
`dart/gui/osg/IncludeImGui.hpp` shim, so **no consuming source needed editing**.

(The relocated `CMakeLists.txt` also leaves the `lint_cmake.py` `external` skip list, so
it is now gersemi-formatted — hence the larger reformat diff on that file.)

## Verification (Linux)

- **FetchContent path** (`-DDART_USE_SYSTEM_IMGUI=OFF`): configure fetches v1.92.8 and
  applies the rebased patch cleanly; `dart-external-imgui` and `dart-gui-osg` build.
- **System path** (`-DDART_USE_SYSTEM_IMGUI=ON`): configure + `dart-external-imgui` build.
- **Regression tests** `test_Issue2516`, `test_Issue2668`, `test_Issue2671`: **3/3 pass**.
