### PR TITLE
Stop fmt 12.2 deprecation warning leaking through DART logging headers

### DIFF
--- a/dart/common/detail/logging-impl.hpp
+++ b/dart/common/detail/logging-impl.hpp
@@ -43,13 +43,11 @@
   #include <concepts>
   #include <type_traits>
   #include <utility>
-  // Check if spdlog is using fmt or std::format backend
-  #if defined(SPDLOG_USE_STD_FORMAT)
-    // spdlog uses std::format - no need for runtime wrapper
-    #define DART_SPDLOG_RUNTIME(str) str
-  #else
-    // spdlog uses fmt - need its compatibility macro for non-compile-time
-    // strings across supported fmt versions.
+  // These fmt helpers back normalize() below and are needed for the fmt
+  // backend, which is the configuration DART builds against. spdlog's
+  // std::format backend is not currently supported here (normalize() is
+  // referenced unconditionally at the call site below).
+  #if !defined(SPDLOG_USE_STD_FORMAT)
     #include <fmt/ostream.h>
     #include <spdlog/fmt/fmt.h>
     #include <spdlog/fmt/ostr.h>
@@ -109,7 +107,6 @@ auto normalize(T&& arg)
 
 } // namespace detail_log_arg
 
-    #define DART_SPDLOG_RUNTIME(str) SPDLOG_FMT_RUNTIME(str)
   #endif
 #else
   #include <iostream>
@@ -268,6 +265,30 @@ void log(
     const S& format_str,
     Args&&... args)
 {
+#if DART_HAVE_spdlog
+  // Hand spdlog a ready-made string rather than a format string: format with
+  // fmt up front. spdlog's variadic log() funnels the format string through
+  // spdlog::details::to_string_view(), whose implicit fmt::format_string ->
+  // string_view conversion was deprecated in fmt 12.2.0 ("use
+  // format_string::get() instead"). Routing through it makes that deprecation
+  // warning surface in every downstream that instantiates DART's logging
+  // templates against fmt >= 12.2.0 (e.g. gz-physics, see
+  // https://github.com/gazebosim/gz-physics/issues/1018). Pre-formatting
+  // sidesteps the deprecated conversion entirely.
+  //
+  // Skip all work for a fully disabled message: no prefix, no allocation and
+  // no formatting (cheaper than the previous code path, which always built the
+  // format string before spdlog's internal level check). should_backtrace()
+  // preserves the behaviour of the prior spdlog::*() calls, which still
+  // recorded below-level messages into spdlog's backtrace ring when one is
+  // enabled.
+  auto* const logger = spdlog::default_logger_raw();
+  const spdlog::level::level_enum spdlog_level = toSpdlogLevel(level);
+  if (!logger->should_log(spdlog_level) && !logger->should_backtrace()) {
+    return;
+  }
+#endif
+
   const std::string prefix = makeLogPrefix(file, line, function);
   fmt::basic_string_view<char> fmt_view(format_str);
   std::string final_format;
@@ -280,10 +301,20 @@ void log(
   }
 
 #if DART_HAVE_spdlog
-  spdlog::log(
-      toSpdlogLevel(level),
-      DART_SPDLOG_RUNTIME(final_format),
-      detail_log_arg::normalize(std::forward<Args>(args))...);
+  // A logging call must never throw, so a malformed format string (only caught
+  // at runtime, since the format is not a compile-time constant) falls back to
+  // logging the raw format string instead of propagating the fmt error.
+  try {
+    logger->log(
+        spdlog_level,
+        fmt::format(
+            fmt::runtime(final_format),
+            detail_log_arg::normalize(std::forward<Args>(args))...));
+  } catch (const std::exception& e) {
+    logger->log(
+        spdlog_level,
+        fmt::format("[log format error: {}] {}", e.what(), final_format));
+  }
 #else
   auto& stream = (level == LogLevel::Error || level == LogLevel::Fatal)
                      ? std::cerr


### PR DESCRIPTION
## Problem

When DART is built against **fmt >= 12.2.0**, downstream consumers get a
`-Wdeprecated-declarations` warning that originates inside DART's public,
header-only logging templates:

```
spdlog/logger.h:80: warning: 'operator const fmt::basic_string_view<char>&' is deprecated
  ... in instantiation of dart::common::warn<...> requested from GenericJoint.hpp
```

Reported downstream as gazebosim/gz-physics#1018.

### Root cause

`dart::common::{trace,debug,info,warn,error,fatal}` call spdlog's variadic
`log()`, which routes the format string through
`spdlog::details::to_string_view()`. With fmt 12.2.0 that performs an implicit
`fmt::format_string -> string_view` conversion that fmt now marks deprecated
("use `format_string::get()` instead"). Because the logging functions are
header-only and instantiated by downstream code, the warning surfaces in
every consumer compiled against fmt >= 12.2.0 — not in DART's own CI, which
pins `fmt < 12`.

The defect ultimately lives in spdlog (it still uses the deprecated conversion
on its fmt backend, while already using `.get()` on its std::format backend),
but DART is the right layer to stop leaking it to consumers, and can do so
without waiting on an spdlog release.

## Fix

Stop handing spdlog a format string. `detail::log()` now formats the message
with fmt up front and passes spdlog a ready-made `std::string` via its
non-format `log(level, msg)` overload, so the deprecated conversion is never
instantiated — a structural fix rather than a `-Wdeprecated-declarations`
suppression (which would be include-order fragile and compiler-dependent).

While here:

- **Gate on `should_log()` first**, exactly as spdlog's own
  `SPDLOG_LOGGER_CALL` macros do, so a disabled level builds no prefix, makes
  no allocation and does no formatting. This is also cheaper than the previous
  path, which always built the format string before spdlog's internal level
  check. Trade-off (matching those macros): messages below the active level are
  not fed to spdlog's backtrace ring buffer.
- **Guard the runtime `format()`** so a malformed format string logs a fallback
  instead of throwing out of a logging call (the format is not a compile-time
  constant, so this can only be caught at runtime).
- Remove the now-unused `DART_SPDLOG_RUNTIME` macro.

Public API and all six logging signatures are unchanged.

## Verification

Built a faithful reproduction against **fmt 12.2.0 + spdlog 1.15.3** through
DART's real `<dart/common/logging.hpp>`:

- `-Wdeprecated-declarations`: **2 → 0** on g++ 15.2 and clang 22.1.
- Compiles clean; no regression against fmt < 12 (conda spdlog); non-spdlog
  config (`DART_HAVE_spdlog=0`) clean under `-Wall -Wextra`.
- Runtime check confirms correct formatting, level gating (disabled levels emit
  nothing), the no-throw fallback on a bad format, and that braces in formatted
  data are not re-parsed (i.e. the plain-message overload is selected).

CI is the place to confirm the MSVC and macOS/AppleClang lanes, which the local
environment could not exercise.

## Follow-up

A backport to `release-6.20` will be a separate PR — that branch predates the
logging refactor, so the change there is structurally different.
