### PR TITLE
Fix ODE tangent cylinder support contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,12 @@
     velocity work, and avoiding threaded contact allocation on cold starts:
     [#3056](https://github.com/dartsim/dart/issues/3056)
 
+  * Speed up ODE-backed settled cylinder workloads by falling back from native
+    ODE cylinders when exact support contacts are unreliable and by
+    supplementing exact cylinder-vs-plane support contacts that ODE's broadphase
+    can skip:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
   * Speed up DART-native collision transform setup for identity-relative
     `ShapeNode` collision objects by reusing the owning `BodyNode` world
     transform while refreshing the fast path when shape-node geometry changes:

--- a/dart/collision/ode/OdeCollisionDetector.cpp
+++ b/dart/collision/ode/OdeCollisionDetector.cpp
@@ -55,8 +55,11 @@
 #include <algorithm>
 #include <deque>
 #include <functional>
+#include <limits>
 #include <utility>
 #include <vector>
+
+#include <cmath>
 
 namespace dart {
 namespace collision {
@@ -79,6 +82,13 @@ Contact convertContact(
     OdeCollisionObject* b1,
     OdeCollisionObject* b2,
     const CollisionOption& option);
+
+std::size_t reportCylinderPlaneSupportContacts(
+    const std::vector<OdeCollisionObject*>& cylinders,
+    const std::vector<OdeCollisionObject*>& planes,
+    const CollisionOption& option,
+    CollisionResult* result,
+    bool cylinderFirst = true);
 
 #if DART_ODE_HAS_LIBCCD_BOX_CYL
 void alignBoxCylinderNormal(Contact& contact);
@@ -270,6 +280,12 @@ bool OdeCollisionDetector::collide(
   data.history = &mContactHistory;
 
   dSpaceCollide(odeGroup->getOdeSpaceId(), &data, CollisionCallback);
+  data.numContacts += reportCylinderPlaneSupportContacts(
+      odeGroup->getCylinderCollisionObjects(),
+      odeGroup->getPlaneCollisionObjects(),
+      option,
+      result,
+      true);
 
   if (result) {
     pruneContactHistory(*result);
@@ -300,6 +316,18 @@ bool OdeCollisionDetector::collide(
       reinterpret_cast<dGeomID>(odeGroup2->getOdeSpaceId()),
       &data,
       CollisionCallback);
+  data.numContacts += reportCylinderPlaneSupportContacts(
+      odeGroup1->getCylinderCollisionObjects(),
+      odeGroup2->getPlaneCollisionObjects(),
+      option,
+      result,
+      true);
+  data.numContacts += reportCylinderPlaneSupportContacts(
+      odeGroup2->getCylinderCollisionObjects(),
+      odeGroup1->getPlaneCollisionObjects(),
+      option,
+      result,
+      false);
 
   if (result) {
     pruneContactHistory(*result);
@@ -617,6 +645,140 @@ Contact convertContact(
   }
 
   return contact;
+}
+
+//==============================================================================
+bool resultHasContactForPair(
+    const CollisionResult* result,
+    const OdeCollisionObject* object1,
+    const OdeCollisionObject* object2)
+{
+  if (!result)
+    return false;
+
+  for (const auto& contact : result->getContacts()) {
+    if ((contact.collisionObject1 == object1
+         && contact.collisionObject2 == object2)
+        || (contact.collisionObject1 == object2
+            && contact.collisionObject2 == object1)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+//==============================================================================
+bool reportCylinderPlaneSupportContact(
+    OdeCollisionObject* cylinderObject,
+    OdeCollisionObject* planeObject,
+    const CollisionOption& option,
+    CollisionResult* result,
+    bool cylinderFirst)
+{
+  const auto* cylinderShape
+      = cylinderObject->getShape()->as<dynamics::CylinderShape>();
+  const auto* planeShape = planeObject->getShape()->as<dynamics::PlaneShape>();
+
+  if (!(cylinderShape && planeShape))
+    return false;
+
+  const auto& filter = option.collisionFilter;
+  if (filter && filter->ignoresCollision(cylinderObject, planeObject))
+    return false;
+
+  if (option.getEffectiveMaxNumContactsPerPair() == 0u)
+    return false;
+
+  if (resultHasContactForPair(result, cylinderObject, planeObject))
+    return false;
+
+  const Eigen::Vector3d rawNormal
+      = planeObject->getTransform().linear() * planeShape->getNormal();
+  const double normalNorm = rawNormal.norm();
+  if (!std::isfinite(normalNorm)
+      || normalNorm <= std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  const Eigen::Vector3d worldNormal = rawNormal / normalNorm;
+  const double planeOffset
+      = planeShape->getOffset()
+        + planeObject->getTransform().translation().dot(worldNormal);
+
+  const Eigen::Isometry3d& cylinderTf = cylinderObject->getTransform();
+  const Eigen::Vector3d rawAxis
+      = cylinderTf.linear() * Eigen::Vector3d::UnitZ();
+  const double axisNorm = rawAxis.norm();
+  if (!std::isfinite(axisNorm)
+      || axisNorm <= std::numeric_limits<double>::epsilon()) {
+    return false;
+  }
+
+  const Eigen::Vector3d axis = rawAxis / axisNorm;
+  const Eigen::Vector3d center = cylinderTf.translation();
+  const double centerDistance = worldNormal.dot(center) - planeOffset;
+  const double axisProjection = worldNormal.dot(axis);
+  const double perpendicularProjection
+      = std::sqrt(std::max(0.0, 1.0 - axisProjection * axisProjection));
+  const double radius = cylinderShape->getRadius();
+  const double halfHeight = 0.5 * cylinderShape->getHeight();
+  const double supportDistance = halfHeight * std::abs(axisProjection)
+                                 + radius * perpendicularProjection;
+  const double clearance = centerDistance - supportDistance;
+  const double tolerance
+      = 1e-9 * std::max({1.0, radius, cylinderShape->getHeight()});
+
+  if (!std::isfinite(clearance) || clearance > tolerance)
+    return false;
+
+  const double axisOffset = axisProjection >= 0.0 ? -halfHeight : halfHeight;
+  Eigen::Vector3d radialOffset = Eigen::Vector3d::Zero();
+  if (perpendicularProjection > std::numeric_limits<double>::epsilon()) {
+    const Eigen::Vector3d radialDirection
+        = (worldNormal - axisProjection * axis) / perpendicularProjection;
+    radialOffset = -radius * radialDirection;
+  }
+
+  if (!result || result->getNumContacts() >= option.maxNumContacts)
+    return true;
+
+  Contact contact;
+  contact.collisionObject1 = cylinderFirst ? cylinderObject : planeObject;
+  contact.collisionObject2 = cylinderFirst ? planeObject : cylinderObject;
+
+  if (option.enableContact) {
+    contact.point = center + axisOffset * axis + radialOffset;
+    contact.normal = cylinderFirst ? worldNormal : -worldNormal;
+    contact.penetrationDepth = std::max(0.0, -clearance);
+  }
+
+  result->addContact(contact);
+  return true;
+}
+
+//==============================================================================
+std::size_t reportCylinderPlaneSupportContacts(
+    const std::vector<OdeCollisionObject*>& cylinders,
+    const std::vector<OdeCollisionObject*>& planes,
+    const CollisionOption& option,
+    CollisionResult* result,
+    bool cylinderFirst)
+{
+  if (cylinders.empty() || planes.empty())
+    return 0u;
+
+  std::size_t reported = 0u;
+  for (auto* cylinder : cylinders) {
+    for (auto* plane : planes) {
+      if (reportCylinderPlaneSupportContact(
+              cylinder, plane, option, result, cylinderFirst)) {
+        ++reported;
+      }
+    }
+  }
+
+  return reported;
 }
 
 #if DART_ODE_HAS_LIBCCD_BOX_CYL

--- a/dart/collision/ode/OdeCollisionGroup.cpp
+++ b/dart/collision/ode/OdeCollisionGroup.cpp
@@ -35,11 +35,38 @@
 #include "dart/collision/ode/OdeCollisionDetector.hpp"
 #include "dart/collision/ode/OdeCollisionObject.hpp"
 #include "dart/common/Macros.hpp"
+#include "dart/dynamics/CylinderShape.hpp"
+#include "dart/dynamics/PlaneShape.hpp"
 
+#include <algorithm>
 #include <memory>
 
 namespace dart {
 namespace collision {
+
+namespace {
+
+//==============================================================================
+void eraseCollisionObject(
+    std::vector<OdeCollisionObject*>& objects, OdeCollisionObject* object)
+{
+  objects.erase(
+      std::remove(objects.begin(), objects.end(), object), objects.end());
+}
+
+//==============================================================================
+bool isCylinderCollisionObject(const OdeCollisionObject* object)
+{
+  return object && object->getShape()->as<dynamics::CylinderShape>();
+}
+
+//==============================================================================
+bool isPlaneCollisionObject(const OdeCollisionObject* object)
+{
+  return object && object->getShape()->as<dynamics::PlaneShape>();
+}
+
+} // namespace
 
 //==============================================================================
 OdeCollisionGroup::OdeCollisionGroup(
@@ -82,6 +109,11 @@ void OdeCollisionGroup::addCollisionObjectToEngine(CollisionObject* object)
   auto geomId = casted->getOdeGeomId();
   dSpaceAdd(mSpaceId, geomId);
 
+  if (isCylinderCollisionObject(casted))
+    mCylinderCollisionObjects.push_back(casted);
+  else if (isPlaneCollisionObject(casted))
+    mPlaneCollisionObjects.push_back(casted);
+
   initializeEngineData();
 }
 
@@ -93,6 +125,11 @@ void OdeCollisionGroup::addCollisionObjectsToEngine(
     auto casted = static_cast<OdeCollisionObject*>(collObj);
     auto geomId = casted->getOdeGeomId();
     dSpaceAdd(mSpaceId, geomId);
+
+    if (isCylinderCollisionObject(casted))
+      mCylinderCollisionObjects.push_back(casted);
+    else if (isPlaneCollisionObject(casted))
+      mPlaneCollisionObjects.push_back(casted);
   }
 
   initializeEngineData();
@@ -108,6 +145,8 @@ void OdeCollisionGroup::removeCollisionObjectFromEngine(CollisionObject* object)
 
   auto casted = static_cast<OdeCollisionObject*>(object);
   auto geomId = casted->getOdeGeomId();
+  eraseCollisionObject(mCylinderCollisionObjects, casted);
+  eraseCollisionObject(mPlaneCollisionObjects, casted);
   dSpaceRemove(mSpaceId, geomId);
 
   initializeEngineData();
@@ -122,6 +161,8 @@ void OdeCollisionGroup::removeAllCollisionObjectsFromEngine()
   }
 
   dSpaceClean(mSpaceId);
+  mCylinderCollisionObjects.clear();
+  mPlaneCollisionObjects.clear();
 
   initializeEngineData();
 }
@@ -136,6 +177,20 @@ void OdeCollisionGroup::updateCollisionGroupEngineData()
 dSpaceID OdeCollisionGroup::getOdeSpaceId() const
 {
   return mSpaceId;
+}
+
+//==============================================================================
+const std::vector<OdeCollisionObject*>&
+OdeCollisionGroup::getCylinderCollisionObjects() const
+{
+  return mCylinderCollisionObjects;
+}
+
+//==============================================================================
+const std::vector<OdeCollisionObject*>&
+OdeCollisionGroup::getPlaneCollisionObjects() const
+{
+  return mPlaneCollisionObjects;
 }
 
 } // namespace collision

--- a/dart/collision/ode/OdeCollisionGroup.hpp
+++ b/dart/collision/ode/OdeCollisionGroup.hpp
@@ -37,8 +37,12 @@
 
 #include <ode/ode.h>
 
+#include <vector>
+
 namespace dart {
 namespace collision {
+
+class OdeCollisionObject;
 
 class OdeCollisionGroup : public CollisionGroup
 {
@@ -76,9 +80,21 @@ protected:
   /// Returns ODE space id associated with this collision group
   dSpaceID getOdeSpaceId() const;
 
+  /// Returns the ODE cylinder collision objects in this group.
+  const std::vector<OdeCollisionObject*>& getCylinderCollisionObjects() const;
+
+  /// Returns the ODE plane collision objects in this group.
+  const std::vector<OdeCollisionObject*>& getPlaneCollisionObjects() const;
+
 protected:
   /// Top-level space for all sub-spaces/collisions
   dSpaceID mSpaceId;
+
+  /// ODE cylinder collision objects in this group.
+  std::vector<OdeCollisionObject*> mCylinderCollisionObjects;
+
+  /// ODE plane collision objects in this group.
+  std::vector<OdeCollisionObject*> mPlaneCollisionObjects;
 };
 
 } // namespace collision

--- a/dart/collision/ode/OdeCollisionObject.cpp
+++ b/dart/collision/ode/OdeCollisionObject.cpp
@@ -106,6 +106,45 @@ bool hasAlignedContactNormal(
   return false;
 }
 
+struct ProbeCollisionData
+{
+  dContactGeom contacts[4];
+  int numContacts = 0;
+};
+
+void ProbeCollisionCallback(void* data, dGeomID o1, dGeomID o2)
+{
+  auto* probeData = static_cast<ProbeCollisionData*>(data);
+  const int remaining
+      = static_cast<int>(
+            sizeof(probeData->contacts) / sizeof(probeData->contacts[0]))
+        - probeData->numContacts;
+  if (remaining <= 0)
+    return;
+
+  probeData->numContacts += dCollide(
+      o1,
+      o2,
+      remaining,
+      &probeData->contacts[probeData->numContacts],
+      sizeof(probeData->contacts[0]));
+}
+
+ProbeCollisionData probeBroadphaseCollision(dGeomID geom1, dGeomID geom2)
+{
+  ProbeCollisionData data;
+  dSpaceID space = dHashSpaceCreate(0);
+  DART_ASSERT(space);
+  dHashSpaceSetLevels(space, -2, 8);
+  dSpaceAdd(space, geom1);
+  dSpaceAdd(space, geom2);
+  dSpaceCollide(space, &data, ProbeCollisionCallback);
+  dSpaceRemove(space, geom1);
+  dSpaceRemove(space, geom2);
+  dSpaceDestroy(space);
+  return data;
+}
+
 // Some ODE builds report cylinder contacts with incorrect normals.
 bool probeCylinderCollisionSupport()
 {
@@ -149,7 +188,47 @@ bool probeCylinderCollisionSupport()
     dGeomDestroy(plane);
   }
 
-  return cylinderCylinderOk && cylinderPlaneOk;
+  bool tangentCylinderPlaneOk = false;
+  {
+    dGeomID cylinder = dCreateCylinder(0, 1.0, 1.0);
+    dGeomID plane = dCreatePlane(0, 0.0, 0.0, 1.0, 0.0);
+
+    dGeomSetPosition(cylinder, 0.0, 0.0, 0.5);
+
+    const auto data = probeBroadphaseCollision(cylinder, plane);
+    tangentCylinderPlaneOk = hasAlignedContactNormal(
+        data.contacts,
+        data.numContacts,
+        2,
+        kMinAxisAlignment,
+        kMaxOtherAlignment);
+
+    dGeomDestroy(cylinder);
+    dGeomDestroy(plane);
+  }
+
+  bool tangentCylinderBoxOk = false;
+  {
+    dGeomID cylinder = dCreateCylinder(0, 0.5, 1.0);
+    dGeomID box = dCreateBox(0, 10.0, 10.0, 0.002);
+
+    dGeomSetPosition(cylinder, 0.0, 0.0, 0.5);
+    dGeomSetPosition(box, 0.0, 0.0, -0.001);
+
+    const auto data = probeBroadphaseCollision(cylinder, box);
+    tangentCylinderBoxOk = hasAlignedContactNormal(
+        data.contacts,
+        data.numContacts,
+        2,
+        kMinAxisAlignment,
+        kMaxOtherAlignment);
+
+    dGeomDestroy(cylinder);
+    dGeomDestroy(box);
+  }
+
+  return cylinderCylinderOk && cylinderPlaneOk && tangentCylinderPlaneOk
+         && tangentCylinderBoxOk;
 }
 
 bool cylinderCollisionSupported()

--- a/tests/integration/test_Collision.cpp
+++ b/tests/integration/test_Collision.cpp
@@ -3759,6 +3759,94 @@ TEST_F(Collision, Factory)
 
 #if HAVE_ODE
 //==============================================================================
+TEST(Issue3056, OdeReportsTangentCylinderPlaneContact)
+{
+  auto detector = OdeCollisionDetector::create();
+  auto group = detector->createCollisionGroup();
+
+  auto cylinderFrame
+      = std::make_shared<SimpleFrame>(Frame::World(), "cylinder");
+  auto planeFrame = std::make_shared<SimpleFrame>(Frame::World(), "plane");
+  auto horizontalCylinderFrame
+      = std::make_shared<SimpleFrame>(Frame::World(), "horizontal_cylinder");
+
+  cylinderFrame->setShape(std::make_shared<CylinderShape>(0.5, 1.0));
+  cylinderFrame->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.5));
+  planeFrame->setShape(
+      std::make_shared<PlaneShape>(Eigen::Vector3d::UnitZ(), 0.0));
+  horizontalCylinderFrame->setShape(std::make_shared<CylinderShape>(0.5, 1.0));
+
+  Eigen::Isometry3d horizontalTf = Eigen::Isometry3d::Identity();
+  horizontalTf.linear()
+      = Eigen::AngleAxisd(0.5 * constantsd::pi(), Eigen::Vector3d::UnitY())
+            .toRotationMatrix();
+  horizontalTf.translation() = Eigen::Vector3d(2.0, 0.0, 0.5);
+  horizontalCylinderFrame->setTransform(horizontalTf);
+
+  group->addShapeFrame(cylinderFrame.get());
+  group->addShapeFrame(planeFrame.get());
+  group->addShapeFrame(horizontalCylinderFrame.get());
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 8u;
+  option.maxNumContactsPerPair = 4u;
+
+  CollisionResult result;
+  ASSERT_TRUE(group->collide(option, &result));
+  ASSERT_GE(result.getNumContacts(), 2u);
+
+  auto sawVerticalCylinder = false;
+  auto sawHorizontalCylinder = false;
+  for (const auto& contact : result.getContacts()) {
+    const auto* frame1 = contact.collisionObject1->getShapeFrame();
+    const auto* frame2 = contact.collisionObject2->getShapeFrame();
+    if (frame1 == cylinderFrame.get() || frame2 == cylinderFrame.get()) {
+      sawVerticalCylinder = true;
+      EXPECT_NEAR(0.0, contact.point.z(), 1e-12);
+    } else if (
+        frame1 == horizontalCylinderFrame.get()
+        || frame2 == horizontalCylinderFrame.get()) {
+      sawHorizontalCylinder = true;
+      EXPECT_NEAR(0.0, contact.point.z(), 1e-12);
+    }
+    EXPECT_NEAR(0.0, contact.penetrationDepth, 1e-12);
+    EXPECT_NEAR(
+        1.0, std::abs(contact.normal.dot(Eigen::Vector3d::UnitZ())), 1e-12);
+  }
+
+  EXPECT_TRUE(sawVerticalCylinder);
+  EXPECT_TRUE(sawHorizontalCylinder);
+
+  auto cylinderGroup = detector->createCollisionGroup(cylinderFrame.get());
+  auto planeGroup = detector->createCollisionGroup(planeFrame.get());
+
+  result.clear();
+  ASSERT_TRUE(planeGroup->collide(cylinderGroup.get(), option, &result));
+  ASSERT_EQ(1u, result.getNumContacts());
+  EXPECT_EQ(
+      planeFrame.get(), result.getContact(0).collisionObject1->getShapeFrame());
+  EXPECT_TRUE(
+      result.getContact(0).normal.isApprox(-Eigen::Vector3d::UnitZ(), 1e-12));
+
+  result.clear();
+  ASSERT_TRUE(cylinderGroup->collide(planeGroup.get(), option, &result));
+  ASSERT_EQ(1u, result.getNumContacts());
+  EXPECT_EQ(
+      cylinderFrame.get(),
+      result.getContact(0).collisionObject1->getShapeFrame());
+  EXPECT_TRUE(
+      result.getContact(0).normal.isApprox(Eigen::Vector3d::UnitZ(), 1e-12));
+
+  cylinderFrame->setTranslation(Eigen::Vector3d(0.0, 0.0, 0.5001));
+  horizontalTf.translation() = Eigen::Vector3d(2.0, 0.0, 0.5001);
+  horizontalCylinderFrame->setTransform(horizontalTf);
+  result.clear();
+  EXPECT_FALSE(group->collide(option, &result));
+  EXPECT_EQ(0u, result.getNumContacts());
+}
+
+//==============================================================================
 TEST(Issue1654, OdeContactHistoryClearsOnObjectRemoval)
 {
   auto detector = OdeCollisionDetector::create();


### PR DESCRIPTION
## Summary

- Fix ODE exact-support cylinder contacts so settled cylinder workloads can enter sleep immediately instead of simulating hundreds of unnecessary active steps.
- Fall back from native ODE cylinders when ODE's broadphase/native cylinder path misses exact support contacts, and supplement exact cylinder-vs-plane support contacts that ODE can skip.
- Add ODE regression coverage for vertical and horizontal tangent cylinder-plane contacts, cross-group contact ordering, and lifted non-contact cases.

## Motivation / Problem

Issue #3056 still had an ODE-specific gap after the DART-native, FCL, and Bullet paths were completed: the 3003-body settled scene reached only about 0.05 RTF with `--collision ode --sdf-plane-shapes`, and generated finite-floor scenes left the cylinder lane active. The root cause was exact tangent cylinder support contacts being missed by ODE, so those cylinders did not join collision islands and delayed automatic sleeping.

## Changes / Key Changes

- Track ODE cylinder and plane collision objects in `OdeCollisionGroup` so ODE can cheaply supplement only cylinder-plane support pairs after the normal `dSpaceCollide` pass.
- Add a geometric cylinder-vs-plane support contact supplement that respects collision filters, contact caps, transformed planes, cylinder orientation, and caller group ordering.
- Extend ODE's cylinder support probe with broadphase exact-support checks; if native ODE cylinders are unreliable for exact support contacts, keep using DART's existing cylinder mesh fallback.
- Update the DART 6.20 changelog for the ODE-backed settled-cylinder performance fix.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test` (115/115 passed)
- `build/default/cpp/Release/tests/integration/test_Collision --gtest_filter='Issue3056.*:Issue1654.*'`
- Benchmarks below, run locally on baseline commit `382254394d7`, parent commit `282c7ee583a`, and PR commit `e2dd771318d`.

### Performance comparison

Common benchmark flags unless noted: `--steps 3000 --warmup 0 --checkpoint 0 --quiet --world-threads 16 --max-contacts 12000 --max-contacts-per-pair 4`.

| Scenario | Baseline `382254394d7` | Parent `282c7ee583a` | PR `e2dd771318d` |
| --- | ---: | ---: | ---: |
| `3k_shapes.sdf`, ODE, `--sdf-plane-shapes` | RTF 0.0514834; resting 3003/3003; hash `0x4e5f6556657720` | RTF 0.0494599; resting 3003/3003; hash `0x4e5f6556657720` | RTF 18.1005; resting 3003/3003; hash `0x8e0225af027daf53` |
| Generated 900, ODE finite floor | RTF 0.0792758; resting 741/900; contacts 2700; hash `0xc3115f8967c223de` | RTF 0.0766812; resting 741/900; contacts 2700; hash `0xc3115f8967c223de` | RTF 72.2664; resting 900/900; contacts 0; hash `0x9f2ffcd1156e99ee` |
| Generated 90, ODE finite floor, `--world-threads 1` | RTF 2.50285; resting 75/90; contacts 270; hash `0xffb5ed43aa3cbb7d` | RTF 2.35848; resting 75/90; contacts 270; hash `0xffb5ed43aa3cbb7d` | RTF 585.591; resting 90/90; contacts 0; hash `0x62e738924a288539` |
| `3k_shapes.sdf`, DART-native, `--sdf-plane-shapes` | RTF 80.6328; resting 3003/3003; hash `0x131b6af79a44ff90` | RTF 72.9867; resting 3003/3003; hash `0x131b6af79a44ff90` | RTF 65.073; resting 3003/3003; hash `0x131b6af79a44ff90` |
| `3k_shapes.sdf`, FCL primitive, `--primitive-shapes --sdf-plane-shapes` | RTF 80.1384; resting 3003/3003; hash `0x266da31836a314a6` | RTF 68.4542; resting 3003/3003; hash `0x266da31836a314a6` | RTF 61.9909; resting 3003/3003; hash `0x266da31836a314a6` |
| `3k_shapes.sdf`, Bullet, `--sdf-plane-shapes` | RTF 8.9212; resting 3003/3003; hash `0x2375f1927218cd43` | RTF 8.4207; resting 3003/3003; hash `0x2375f1927218cd43` | RTF 8.41855; resting 3003/3003; hash `0x2375f1927218cd43` |

The DART/FCL/Bullet rows are anti-overfitting guardrails: this PR does not touch those backends, and their state hashes/resting counts stayed unchanged across the compared commits. The main ODE rows cover both the original SDF PlaneShape scene and generated finite-floor scenes at two scales/thread configurations.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Addresses #3056
- Builds on #3199

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
