### PR TITLE
Fast-path FreeJoint integration for identity joint frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,10 @@ compatibility remains on the active DART 6 LTS branch._
 - Fixed retained rigid-IPC solver scratch reuse so lagged-friction objective
   assembly keeps the active barrier Hessian while adding friction and dynamics
   terms.
+- Added identity-joint-frame fast paths to `FreeJoint` position integration,
+  relative transform, and Jacobian updates (forward-ported from the DART 6 LTS
+  line), skipping the general inverse/compose when the child (and optionally
+  parent) joint frame is identity. Guarded by an equivalence regression test.
 - Added and hardened DART 7 deformable, VBD, AVBD, FEM, IPC/barrier, and
   variational solver paths behind the `World` and executor model.
 - Added compute-executor and backend-boundary work so CPU threading, optional

--- a/dart/dynamics/free_joint.cpp
+++ b/dart/dynamics/free_joint.cpp
@@ -44,6 +44,16 @@
 namespace dart {
 namespace dynamics {
 
+namespace {
+
+//==============================================================================
+bool isIdentityTransform(const Eigen::Isometry3d& transform)
+{
+  return transform.matrix().isIdentity(0.0);
+}
+
+} // namespace
+
 //==============================================================================
 FreeJoint::~FreeJoint()
 {
@@ -701,6 +711,33 @@ void FreeJoint::integratePositions(double _dt)
   const Eigen::Isometry3d& childBodyToJoint
       = Joint::mAspectProperties.mT_ChildBodyToJoint;
 
+  if (isIdentityTransform(childBodyToJoint)) {
+    Eigen::Isometry3d nextQ = Eigen::Isometry3d::Identity();
+    if (parentBodyToJoint.linear().isIdentity(0.0)) {
+      nextQ.linear() = nextRelativeTransform.linear();
+      nextQ.translation() = nextRelativeTransform.translation()
+                            - parentBodyToJoint.translation();
+    } else {
+      const Eigen::Matrix3d parentRotationTranspose
+          = parentBodyToJoint.linear().transpose();
+      nextQ.linear().noalias()
+          = parentRotationTranspose * nextRelativeTransform.linear();
+      nextQ.translation().noalias() = parentRotationTranspose
+                                      * (nextRelativeTransform.translation()
+                                         - parentBodyToJoint.translation());
+    }
+
+    if (getCoordinateChart() == CoordinateChart::EXP_MAP) {
+      Eigen::Vector6d nextPositions;
+      nextPositions.head<3>() = math::logMap(nextQ.linear());
+      nextPositions.tail<3>() = nextQ.translation();
+      setPositionsStatic(nextPositions);
+    } else {
+      setPositionsStatic(convertToPositions(nextQ, getCoordinateChart()));
+    }
+    return;
+  }
+
   const Eigen::Isometry3d nextQ
       = parentBodyToJoint.inverse() * nextRelativeTransform * childBodyToJoint;
 
@@ -801,8 +838,21 @@ void FreeJoint::updateRelativeTransform() const
 {
   mQ = convertToTransform(getPositionsStatic(), getCoordinateChart());
 
-  mT = Joint::mAspectProperties.mT_ParentBodyToJoint * mQ
-       * Joint::mAspectProperties.mT_ChildBodyToJoint.inverse();
+  const Eigen::Isometry3d& parentBodyToJoint
+      = Joint::mAspectProperties.mT_ParentBodyToJoint;
+  const Eigen::Isometry3d& childBodyToJoint
+      = Joint::mAspectProperties.mT_ChildBodyToJoint;
+
+  if (isIdentityTransform(childBodyToJoint)) {
+    if (parentBodyToJoint.linear().isIdentity(0.0)) {
+      mT = mQ;
+      mT.translation() += parentBodyToJoint.translation();
+    } else {
+      mT = parentBodyToJoint * mQ;
+    }
+  } else {
+    mT = parentBodyToJoint * mQ * childBodyToJoint.inverse();
+  }
 
   if (!math::verifyTransform(mT)) {
     DART_WARN_ONCE(
@@ -818,8 +868,17 @@ void FreeJoint::updateRelativeJacobian(bool) const
 {
   const Eigen::Matrix3d rotationTranspose
       = getRelativeTransform().linear().transpose();
-  const Eigen::Matrix6d baseJac
-      = math::getAdTMatrix(Joint::mAspectProperties.mT_ChildBodyToJoint);
+  const Eigen::Isometry3d& childBodyToJoint
+      = Joint::mAspectProperties.mT_ChildBodyToJoint;
+
+  if (isIdentityTransform(childBodyToJoint)) {
+    mJacobian.setZero();
+    mJacobian.topLeftCorner<3, 3>() = rotationTranspose;
+    mJacobian.bottomRightCorner<3, 3>() = rotationTranspose;
+    return;
+  }
+
+  const Eigen::Matrix6d baseJac = math::getAdTMatrix(childBodyToJoint);
 
   mJacobian.topRows<3>() = rotationTranspose * baseJac.topRows<3>();
   mJacobian.bottomRows<3>() = rotationTranspose * baseJac.bottomRows<3>();
@@ -830,14 +889,22 @@ void FreeJoint::updateRelativeJacobianTimeDeriv() const
 {
   const Eigen::Matrix3d rotationTranspose
       = getRelativeTransform().linear().transpose();
-  const Eigen::Matrix6d baseJac
-      = math::getAdTMatrix(Joint::mAspectProperties.mT_ChildBodyToJoint);
+  const Eigen::Isometry3d& childBodyToJoint
+      = Joint::mAspectProperties.mT_ChildBodyToJoint;
 
   const Eigen::Vector3d omega = getRelativeSpatialVelocity().head<3>();
   const Eigen::Matrix3d rotationDeriv
       = -math::makeSkewSymmetric(omega) * rotationTranspose;
 
   mJacobianDeriv.setZero();
+  if (isIdentityTransform(childBodyToJoint)) {
+    mJacobianDeriv.topLeftCorner<3, 3>() = rotationDeriv;
+    mJacobianDeriv.bottomRightCorner<3, 3>() = rotationDeriv;
+    return;
+  }
+
+  const Eigen::Matrix6d baseJac = math::getAdTMatrix(childBodyToJoint);
+
   mJacobianDeriv.topRows<3>() = rotationDeriv * baseJac.topRows<3>();
   mJacobianDeriv.bottomRows<3>() = rotationDeriv * baseJac.bottomRows<3>();
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -232,6 +232,7 @@ dart_add_test("unit" UNIT_constraint_NonFiniteContact constraint/test_nonfinite_
 dart_add_test("unit" UNIT_dynamics_Inertia dynamics/test_inertia.cpp)
 dart_add_test("unit" UNIT_dynamics_ScrewJoint dynamics/test_screw_joint.cpp)
 dart_add_test("unit" UNIT_dynamics_BallJoint dynamics/test_ball_joint.cpp)
+dart_add_test("unit" UNIT_dynamics_FreeJoint dynamics/test_free_joint.cpp)
 dart_add_test("unit" UNIT_dynamics_UniversalJoint dynamics/test_universal_joint.cpp)
 dart_add_test("unit" UNIT_dynamics_ShapeNodePtr dynamics/test_shape_node_ptr.cpp)
 dart_add_test("unit" UNIT_dynamics_BodyNodePtr dynamics/test_body_node_ptr.cpp)

--- a/tests/unit/dynamics/test_free_joint.cpp
+++ b/tests/unit/dynamics/test_free_joint.cpp
@@ -113,4 +113,93 @@ TEST(FreeJoint, IntegratePositionsMatchesVectorOverload)
 
   expectMatchesVectorOverload(
       parentBodyToJoint, childBodyToJoint, "offset joint frames");
+
+  // Identity child frame but a rotated parent frame exercises the
+  // identity-child / non-identity-parent-rotation fast-path branch.
+  expectMatchesVectorOverload(
+      parentBodyToJoint,
+      Eigen::Isometry3d::Identity(),
+      "rotated parent + identity child");
+}
+
+//==============================================================================
+// Identity child frame selects the fast paths in updateRelativeTransform(),
+// updateRelativeJacobian(), and updateRelativeJacobianTimeDeriv(). Verify those
+// paths run for both identity and rotated parent frames and produce the
+// expected block-diagonal Jacobian structure (R^T on the diagonal 3x3 blocks,
+// zero off-diagonal blocks).
+TEST(FreeJoint, IdentityChildFrameFastPaths)
+{
+  auto makeJoint = [](const Eigen::Isometry3d& parent) {
+    auto skel = Skeleton::create("fj_fastpath");
+    auto [joint, body] = skel->createJointAndBodyNodePair<FreeJoint>();
+    (void)body;
+    joint->setTransformFromParentBodyNode(parent);
+    joint->setTransformFromChildBodyNode(Eigen::Isometry3d::Identity());
+
+    Eigen::Vector6d q;
+    q << 0.2, -0.1, 0.05, 0.4, -0.2, 0.3;
+    Eigen::Vector6d v;
+    v << 0.17, -0.11, 0.07, 0.4, -0.2, 0.1;
+    joint->setPositions(q);
+    joint->setVelocities(v);
+    return std::make_pair(skel, joint);
+  };
+
+  Eigen::Isometry3d rotatedParent = Eigen::Isometry3d::Identity();
+  rotatedParent.linear()
+      = Eigen::AngleAxisd(0.21, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  rotatedParent.translation() = Eigen::Vector3d(0.05, -0.03, 0.02);
+
+  for (const auto& parent : {Eigen::Isometry3d::Identity(), rotatedParent}) {
+    auto [skel, joint] = makeJoint(parent);
+    (void)skel;
+
+    const Eigen::Isometry3d T = joint->getRelativeTransform();
+    EXPECT_TRUE(T.matrix().allFinite());
+
+    const Eigen::Matrix3d Rt = T.linear().transpose();
+
+    const Eigen::Matrix6d J = joint->getRelativeJacobian();
+    EXPECT_TRUE(J.allFinite());
+    // Extra parens: the comma in topLeftCorner<3, 3> would otherwise split the
+    // gtest macro argument.
+    EXPECT_TRUE((J.topLeftCorner<3, 3>().isApprox(Rt, 1e-12)));
+    EXPECT_TRUE((J.bottomRightCorner<3, 3>().isApprox(Rt, 1e-12)));
+    EXPECT_TRUE((J.topRightCorner<3, 3>().isZero()));
+    EXPECT_TRUE((J.bottomLeftCorner<3, 3>().isZero()));
+
+    const Eigen::Matrix6d Jdot = joint->getRelativeJacobianTimeDeriv();
+    EXPECT_TRUE(Jdot.allFinite());
+    EXPECT_TRUE((Jdot.topRightCorner<3, 3>().isZero()));
+    EXPECT_TRUE((Jdot.bottomLeftCorner<3, 3>().isZero()));
+  }
+}
+
+//==============================================================================
+// The identity-child integratePositions fast path supports non-EXP_MAP
+// coordinate charts via its convertToPositions() branch. Exercise that branch
+// and confirm the integration stays finite.
+TEST(FreeJoint, IntegratePositionsFastPathNonExpMapChart)
+{
+  for (auto chart :
+       {FreeJoint::CoordinateChart::EULER_XYZ,
+        FreeJoint::CoordinateChart::EULER_ZYX}) {
+    auto skel = Skeleton::create("fj_chart");
+    auto [joint, body] = skel->createJointAndBodyNodePair<FreeJoint>();
+    (void)body;
+    joint->setCoordinateChart(chart);
+    joint->setTransformFromParentBodyNode(Eigen::Isometry3d::Identity());
+    joint->setTransformFromChildBodyNode(Eigen::Isometry3d::Identity());
+
+    Eigen::Vector6d q;
+    q << 0.15, -0.07, 0.04, 0.2, -0.1, 0.05;
+    Eigen::Vector6d v;
+    v << 0.1, -0.05, 0.03, 0.2, -0.1, 0.05;
+    joint->setPositions(q);
+    joint->setVelocities(v);
+
+    skel->integratePositions(0.003);
+    EXPECT_TRUE(joint->getPositions().allFinite());
+  }
 }

--- a/tests/unit/dynamics/test_free_joint.cpp
+++ b/tests/unit/dynamics/test_free_joint.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/dynamics/free_joint.hpp>
+#include <dart/dynamics/joint.hpp>
+#include <dart/dynamics/skeleton.hpp>
+
+#include <Eigen/Geometry>
+#include <gtest/gtest.h>
+
+using namespace dart::dynamics;
+
+//==============================================================================
+// The in-place FreeJoint::integratePositions(dt) has identity-frame fast paths
+// (added when forward-porting the DART 6 LTS optimization). This verifies it
+// stays equivalent to the unchanged reference vector overload
+// Joint::integratePositions(q0, v, dt) across identity, translated-parent, and
+// fully-offset joint frames.
+TEST(FreeJoint, IntegratePositionsMatchesVectorOverload)
+{
+  auto expectMatchesVectorOverload
+      = [](const Eigen::Isometry3d& parentBodyToJoint,
+           const Eigen::Isometry3d& childBodyToJoint,
+           const char* label) {
+          SkeletonPtr skel = Skeleton::create(label);
+
+          auto [freeJoint, freeBody]
+              = skel->createJointAndBodyNodePair<FreeJoint>();
+          (void)freeBody;
+
+          freeJoint->setTransformFromParentBodyNode(parentBodyToJoint);
+          freeJoint->setTransformFromChildBodyNode(childBodyToJoint);
+
+          Eigen::Isometry3d initialTransform = Eigen::Isometry3d::Identity();
+          initialTransform.linear()
+              = (Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitX())
+                 * Eigen::AngleAxisd(-0.1, Eigen::Vector3d::UnitY())
+                 * Eigen::AngleAxisd(0.05, Eigen::Vector3d::UnitZ()))
+                    .toRotationMatrix();
+          initialTransform.translation() = Eigen::Vector3d(0.4, -0.2, 0.3);
+
+          const Eigen::Vector6d q0
+              = FreeJoint::convertToPositions(initialTransform);
+          Eigen::Vector6d v;
+          v << 0.17, -0.11, 0.07, 0.4, -0.2, 0.1;
+
+          freeJoint->setPositions(q0);
+          freeJoint->setVelocities(v);
+
+          const double dt = 0.003;
+          const Eigen::VectorXd expected
+              = static_cast<const Joint*>(freeJoint)->integratePositions(
+                  q0, v, dt);
+          skel->integratePositions(dt);
+
+          EXPECT_TRUE(freeJoint->getPositions().isApprox(expected, 1e-12))
+              << label << "\nexpected: " << expected.transpose()
+              << "\nactual: " << freeJoint->getPositions().transpose();
+        };
+
+  expectMatchesVectorOverload(
+      Eigen::Isometry3d::Identity(),
+      Eigen::Isometry3d::Identity(),
+      "identity joint frames");
+
+  Eigen::Isometry3d parentBodyToJoint = Eigen::Isometry3d::Identity();
+  parentBodyToJoint.linear()
+      = Eigen::AngleAxisd(0.13, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  parentBodyToJoint.translation() = Eigen::Vector3d(0.03, -0.05, 0.07);
+
+  Eigen::Isometry3d translatedParentBodyToJoint = Eigen::Isometry3d::Identity();
+  translatedParentBodyToJoint.translation()
+      = Eigen::Vector3d(0.03, -0.05, 0.07);
+
+  expectMatchesVectorOverload(
+      translatedParentBodyToJoint,
+      Eigen::Isometry3d::Identity(),
+      "translated parent joint frame");
+
+  Eigen::Isometry3d childBodyToJoint = Eigen::Isometry3d::Identity();
+  childBodyToJoint.linear()
+      = Eigen::AngleAxisd(-0.08, Eigen::Vector3d::UnitY()).toRotationMatrix();
+  childBodyToJoint.translation() = Eigen::Vector3d(-0.02, 0.04, -0.06);
+
+  expectMatchesVectorOverload(
+      parentBodyToJoint, childBodyToJoint, "offset joint frames");
+}


### PR DESCRIPTION
## Summary

Forward-ports the DART 6 LTS `FreeJoint` integration fast-path (release-6.20
#3193) to DART 7. When a `FreeJoint`'s child joint frame is identity — the common
case for a free-floating body with default frames — position integration,
relative-transform, and Jacobian updates skip the general
`inverse()`/compose / `getAdTMatrix()` work.

## Motivation / Problem

`FreeJoint` is on the per-step hot path for every free-floating body. The general
implementation always computes `parentBodyToJoint.inverse() * Q * childBodyToJoint`
and an `AdT` matrix even when the joint frames are identity (the default). The DART
6 LTS line added identity-frame fast paths; since this is a performance change it
was never dual-PR'd, so `main` still runs the general path.

## Changes / Key Changes

`dart/dynamics/free_joint.cpp` (anonymous-namespace `isIdentityTransform` helper):

- `integratePositions(double dt)` — identity-`childBodyToJoint` fast path, with a
  further branch when `parentBodyToJoint` rotation is identity; EXP_MAP chart
  uses a direct `logMap`/translation pack.
- `updateRelativeTransform()` — `mT = mQ (+parent translation)` or
  `parentBodyToJoint * mQ` instead of the full triple product.
- `updateRelativeJacobian()` / `updateRelativeJacobianTimeDeriv()` — write the
  block-diagonal `rotationTranspose` / `rotationDeriv` directly instead of
  multiplying through `getAdTMatrix(childBodyToJoint)`.

## Testing

- New `tests/unit/dynamics/test_free_joint.cpp`
  (`FreeJoint.IntegratePositionsMatchesVectorOverload`) asserts the fast-pathed
  in-place `integratePositions(dt)` matches the **unchanged** reference vector
  overload `Joint::integratePositions(q0, v, dt)` to `1e-12` across identity,
  translated-parent, and fully-offset joint frames. Passes.
- `pixi run lint` — clean, including the DART 7 legacy-freeze check.
- After merging current `main` (`c7f3c5235c5`):
  - `pixi run lint`
  - `cmake --build build/default/cpp/Release --target UNIT_dynamics_FreeJoint UNIT_dynamics_BallJoint --parallel 8`
  - `ctest --test-dir build/default/cpp/Release --output-on-failure -R 'UNIT_dynamics_(FreeJoint|BallJoint)
- `dart` builds; `UNIT_dynamics_FreeJoint` and `UNIT_dynamics_BallJoint` pass.
  Targeted local subset; full `pixi run test-all` left to CI.

## Breaking Changes

- [x] None

The fast path is behavior-preserving but **not byte-exact** for the fast branch
(it skips the general `inverse()`/multiply, so results can differ at the ULP
level) — this is why it is a separate PR from the bit-exact batch (#3205) and
ships with the equivalence test above as its guard. No public API change.

## Related Issues / PRs (backports)

- Forward-port of `release-6.20` commit `45d026447ce` (#3193).
- Companion to #3204 (actuator override fix) and #3205 (bit-exact core-dynamics
  perf batch).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md`
- [x] Add unit tests for new functionality (equivalence regression test)
- [x] Document new methods and classes (internal helper documented inline)
- [x] Add Python bindings (dartpy) if applicable (N/A — no API change)

` — 2/2 passed.
- `dart` builds; `UNIT_dynamics_FreeJoint` and `UNIT_dynamics_BallJoint` pass.
  Targeted local subset; full `pixi run test-all` left to CI.

## Breaking Changes

- [x] None

The fast path is behavior-preserving but **not byte-exact** for the fast branch
(it skips the general `inverse()`/multiply, so results can differ at the ULP
level) — this is why it is a separate PR from the bit-exact batch (#3205) and
ships with the equivalence test above as its guard. No public API change.

## Related Issues / PRs (backports)

- Forward-port of `release-6.20` commit `45d026447ce` (#3193).
- Companion to #3204 (actuator override fix) and #3205 (bit-exact core-dynamics
  perf batch).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md`
- [x] Add unit tests for new functionality (equivalence regression test)
- [x] Document new methods and classes (internal helper documented inline)
- [x] Add Python bindings (dartpy) if applicable (N/A — no API change)

