### PR TITLE
Packaging 6.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,50 @@
 
 ## DART 6
 
-### [DART 6.19.3 (TBD)](https://github.com/dartsim/dart/milestone/101?closed=1)
+### [DART 6.19.3 (2026-06-27)](https://github.com/dartsim/dart/milestone/101?closed=1)
+
+DART 6.19.3 is a patch release on the DART 6 LTS line. It hardens contact
+handling against invalid geometry and silences an fmt 12.2 deprecation warning
+that leaked through DART's logging headers, both addressing issues reported
+through gz-physics. It also recovers from two upstream toolchain regressions,
+restoring the Linux Python wheels and compilation on the latest Clang.
 
 * Simulation
 
-  * Harden contact handling against invalid geometry, fixing a crash reported
-    through gz-physics. `BoxShape`, `CylinderShape`, `CapsuleShape`,
-    `EllipsoidShape`, `ConeShape`, and `PyramidShape` now reject non-finite
-    (NaN/Inf) or non-positive dimensions like `SphereShape` already did, and
-    `ConstraintSolver` skips contacts whose point, normal, or penetration depth
-    is non-finite before contact-constraint creation. Together these stop an
-    invalid shape dimension (or a non-finite contact from a mesh or collision
-    backend) from crashing `ContactConstraint` on a `mSpatialNormalA` assertion
-    or corrupting the LCP solve with NaN/Inf:
+  * Reject invalid shape geometry and non-finite contacts instead of crashing.
+    `BoxShape`, `CylinderShape`, `CapsuleShape`, `EllipsoidShape`, `ConeShape`,
+    and `PyramidShape` now reject non-finite (NaN/Inf) or non-positive
+    dimensions, matching `SphereShape`, and `ConstraintSolver` drops any contact
+    whose point, normal, or penetration depth is non-finite before building a
+    contact constraint. Together these keep a bad shape dimension or a
+    non-finite contact (from a mesh or a collision backend) from tripping the
+    `ContactConstraint` `mSpatialNormalA` assertion or feeding NaN/Inf into the
+    LCP solve:
+    [#3117](https://github.com/dartsim/dart/pull/3117),
     [gazebosim/gz-physics#1010](https://github.com/gazebosim/gz-physics/issues/1010)
 
 * Build
 
-  * Stop a deprecation warning from leaking out of DART's header-only logging
-    templates when building against fmt 12.2.0 or newer. spdlog's variadic
-    `log()` routes the format string through a `fmt::format_string` ->
-    `string_view` conversion deprecated in fmt 12.2.0, so the warning surfaced
-    in every downstream that instantiates DART's logging. DART now pre-formats
-    messages and hands spdlog a ready-made string, sidestepping the deprecated
-    conversion:
+  * Stop an fmt 12.2 deprecation warning from leaking out of DART's header-only
+    logging. spdlog's variadic `log()` routes the format string through a
+    `fmt::format_string` -> `string_view` conversion that fmt 12.2.0 deprecated,
+    so the warning surfaced in every downstream that instantiates DART logging.
+    DART now pre-formats the message and hands spdlog a ready-made string:
+    [#3201](https://github.com/dartsim/dart/pull/3201),
     [gazebosim/gz-physics#1018](https://github.com/gazebosim/gz-physics/issues/1018)
+
+  * Restore the Linux `manylinux` Python wheels. The wheel build installs the
+    newest CMake at build time, and CMake 4.3.4 stopped detecting `freeglut3`
+    in the build container, which dropped the `dart-gui` target the dartpy wheel
+    links and broke configuration. The build now caps CMake below 4.3.4 until a
+    fixed release ships:
+    [#3197](https://github.com/dartsim/dart/pull/3197)
+
+  * Compile cleanly on the latest Clang. Recent Clang (such as the current
+    `macos-latest` image) rejects the deprecated whitespace form of
+    user-defined-literal operators under `-Werror`, so the `_pi`, `_rad`, and
+    `_deg` suffixes now use the non-deprecated `operator""_x` spelling:
+    [#3197](https://github.com/dartsim/dart/pull/3197)
 
 ### [DART 6.19.2 (2026-06-19)](https://github.com/dartsim/dart/milestone/100?closed=1)
 

--- a/dart/common/detail/Logging-impl.hpp
+++ b/dart/common/detail/Logging-impl.hpp
@@ -81,7 +81,8 @@ void logToSpdlog(
   // every fmt version DART supports (unlike fmt::runtime, which is fmt 8+ only)
   // and independent of spdlog's formatting backend.
   try {
-    logger->log(level, fmt::vformat(format_str, fmt::make_format_args(args...)));
+    logger->log(
+        level, fmt::vformat(format_str, fmt::make_format_args(args...)));
   } catch (const std::exception& e) {
     logger->log(
         level, fmt::format("[log format error: {}] {}", e.what(), format_str));

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.19.2</version>
+  <version>6.19.3</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.19.2"
+version = "6.19.3"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
Cuts the **DART 6.19.3** patch release on the DART 6 LTS line.

- `package.xml`: `6.19.2` -> `6.19.3`
- `pixi.toml`: `[workspace] version` `6.19.2` -> `6.19.3`
- `CHANGELOG.md`: dates the 6.19.3 section `(2026-06-26)`, adds the release summary, and links the contributing DART PRs (#3117, #3201)

Release contents (milestone [101](https://github.com/dartsim/dart/milestone/101?closed=1)):
- Harden contact handling against invalid geometry (#3117, gz-physics#1010)
- Stop fmt 12.2 deprecation warning leaking through DART logging headers (#3201, gz-physics#1018)

CI toolchain-drift fixes that unblocked this release (build-infra, not changelog-visible) landed in #3197.

After merge: tag `v6.19.3` on this commit to trigger the PyPI publish, create the GitHub Release, and close milestone 101.