### PR TITLE
Fix clang-format violation in Logging-impl.hpp (Check Lint)

### DIFF
--- a/dart/common/detail/Logging-impl.hpp
+++ b/dart/common/detail/Logging-impl.hpp
@@ -81,7 +81,8 @@ void logToSpdlog(
   // every fmt version DART supports (unlike fmt::runtime, which is fmt 8+ only)
   // and independent of spdlog's formatting backend.
   try {
-    logger->log(level, fmt::vformat(format_str, fmt::make_format_args(args...)));
+    logger->log(
+        level, fmt::vformat(format_str, fmt::make_format_args(args...)));
   } catch (const std::exception& e) {
     logger->log(
         level, fmt::format("[log format error: {}] {}", e.what(), format_str));


### PR DESCRIPTION
## Summary

`#3202` landed a line in `dart/common/detail/Logging-impl.hpp` that is not clang-format-14 compliant, turning the **Check Lint** job red on `release-6.20` — and on every open PR, since PR CI runs the branch merged with the base.

```
dart/common/detail/Logging-impl.hpp:84:17: error: code should be clang-formatted [-Wclang-format-violations]
```

This reformats the file with the pinned clang-format-14 (wrapping the long `logger->log(...)` call to match the surrounding style). One-line change.

## Verification
- `pixi run check-lint` passes locally (clang-format + codespell + cmake + py): *"Every file seems to comply with our code convention."*
- Full clang-format-14 sweep of the CI file list is clean.

Unblocks Debug/Release Check-Lint for all open PRs. (A separate gz-physics `JointDetach` regression on the base is being investigated independently.)