### PR TITLE
Pin macOS wheel runners to macos-15 (DART 6 LTS)

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -106,14 +106,18 @@ jobs:
             experimental: false
             release_only: true
 
+          # Pin macOS to macos-15 (not macos-latest): Homebrew builds bottles for
+          # the runner OS, and macos-latest migrated to macOS 26, so its 26.0-min
+          # dylibs fail delocate against MACOSX_DEPLOYMENT_TARGET=15.0 below. A
+          # macos-15 runner yields 15.0-min bottles matching the macosx_15_0 wheel.
           - os: macos-latest
-            runner: macos-latest
+            runner: macos-15
             build: "cp313-macosx_arm64"
             experimental: false
             release_only: false
 
           - os: macos-latest
-            runner: macos-latest
+            runner: macos-15
             build: "cp312-macosx_arm64"
             experimental: false
             release_only: true


### PR DESCRIPTION
## Problem
The v6.19.3 macOS wheels (`cp312`/`cp313-macosx_arm64`) fail non-deterministically in `delocate-wheel`:

```
libfmt.12.2.0.dylib ... minimum target of 26.0
libosg.3.6.5.dylib  ... minimum target of 26.0
libBulletCollision  ... minimum target of 26.0
Set MACOSX_DEPLOYMENT_TARGET=26.0 to update minimum supported macOS for this wheel.
delocate-wheel ... dartpy-6.19.3-cp313-cp313-macosx_15_0_arm64.whl failed
```

## Root cause
The macOS rows use `runner: macos-latest`, which GitHub is mid-migrating to **macOS 26**. Homebrew builds bottles for the runner OS (min target 26.0), but the workflow declares `MACOSX_DEPLOYMENT_TARGET=15.0`, so the wheel is tagged `macosx_15_0`. `delocate` correctly refuses to bundle 26.0-min dylibs into a 15.0 wheel. Whether a job passes depends on whether it lands on a macOS-15 or macOS-26 runner — a coin flip, so re-running is not a fix.

## Fix
Pin both macOS wheel rows to `runner: macos-15` (the matrix already separates `runner` from the `os` label). Homebrew then builds 15.0-targeted bottles that match the declared `macosx_15_0` floor — deterministic, and it preserves the macOS-15 compatibility floor. Empirically, the jobs that landed on macOS-15 already produced valid `macosx_15_0` wheels.