### PR TITLE
Scope publish_dartpy concurrency by event name (DART 6 LTS)

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -36,7 +36,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Include the event name so a manual workflow_dispatch (used to publish a
+  # release) is not cancelled by the push-triggered build of the same ref, and
+  # vice versa. Same-event runs on a ref still supersede each other.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 # This workflow will install Python dependencies, run tests and lint with a


### PR DESCRIPTION
The `publish_dartpy` concurrency group was `${{ github.workflow }}-${{ github.ref }}`, so a manual `workflow_dispatch` publish and the push-triggered build of the **same** `release-*` ref shared one group with `cancel-in-progress: true` and cancelled each other. During the v6.19.3 release this killed the dispatch publish mid-run (before `upload_pypi`), and left `cancelled` (red ✗) checks on the branch tip.

Add `-${{ github.event_name }}` to the group so `push` and `workflow_dispatch` on a ref no longer collide; same-event runs on a ref still supersede each other (`cancel-in-progress` unchanged).