### PR TITLE
Schedule lockfile updates for Friday night

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -7,7 +7,9 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 5 * * SAT # Runs at 05:00 every Saturday
+    # Friday night Pacific time, so lockfile PRs are ready by Saturday morning.
+    - cron: "0 22 * * FRI"
+      timezone: "America/Los_Angeles"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Moves the scheduled lockfile update workflow to Friday night Pacific time so generated lockfile PRs are available by Saturday morning.

## Motivation / Problem

- The previous schedule ran at 05:00 UTC on Saturday, which made the intended local timing less explicit. The maintenance window should be Friday night for DART maintainers watching Saturday morning PRs.

## Changes / Key Changes

- Updates `.github/workflows/update_lockfiles.yml` to run at `22:00` every Friday.
- Adds `timezone: "America/Los_Angeles"` so the schedule tracks Pacific time directly.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Lockfile schedule | `0 5 * * SAT` with a UTC-oriented Saturday comment | `0 22 * * FRI` with `America/Los_Angeles` timezone |
| Maintainer workflow | Scheduled timing had to be inferred from UTC | Friday night intent is encoded in the workflow |

## Testing

- `pixi run lint`
- `pixi run check-lint-yaml`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/update_lockfiles.yml')); print('valid')"`
- `git diff --check HEAD`

## Breaking Changes

- [x] None
- N/A: schedule-only maintainer automation change.

## Related Issues / PRs (backports)

- None.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required — N/A: this only changes scheduled maintainer automation timing.
- [x] Add unit tests for new functionality — N/A: workflow schedule-only change.
- [x] Document new methods and classes — N/A: no API surface added.
- [x] Add Python bindings (dartpy) if applicable — N/A: no Python API change.
