### PR TITLE
Cut PR CI critical path: split ASAN, tier CodeQL/Alt Linux, parallelize coverage capture

### DIFF
--- a/.github/filters/ci-code.yml
+++ b/.github/filters/ci-code.yml
@@ -1,6 +1,5 @@
 code:
   - "**"
-  - "!.github/workflows/cache_*.yml"
   - "!.github/workflows/update_lockfiles.yml"
   - "!docker/dev/**"
   - "!docs/**"

--- a/.github/workflows/ci_altlinux.yml
+++ b/.github/workflows/ci_altlinux.yml
@@ -1,46 +1,21 @@
 name: CI Alt Linux (Docker)
 
+# Distro-reproducibility coverage. This runs on the weekly schedule and via
+# manual dispatch only: the Alt Linux Docker bootstrap is slow (Sisyphus
+# mirror fetches can consume most of the runner window) and distro repro
+# breakage is effectively never PR-local, so it fits the scheduled/manual
+# tier of the CI tiering policy rather than the PR tier.
 on:
-  pull_request:
-    branches:
-      - "**"
   schedule:
     - cron: "0 5 * * 1"
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - name: Clean stale Linux workspace
-        if: runner.os == 'Linux'
-        run: |
-          if [ -n "${GITHUB_WORKSPACE:-}" ] && [ "${GITHUB_WORKSPACE}" != "/" ] && [ -d "${GITHUB_WORKSPACE}" ]; then
-            find "${GITHUB_WORKSPACE}" -mindepth 1 -maxdepth 1 -exec rm -rf {} + || {
-              if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-                docker run --rm -v "${GITHUB_WORKSPACE}:/workspace" alpine:3.20 sh -c \
-                  'find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +'
-              else
-                echo "::warning::Unable to clean stale workspace entries before checkout."
-              fi
-            }
-          fi
-
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: .github/filters/ci-code.yml
-
   altlinux:
-    needs: changes
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.code == 'true'
     name: Alt Linux repro (Docker)
     runs-on: ubuntu-latest
     timeout-minutes: 300

--- a/.github/workflows/ci_gz_dart6.yml
+++ b/.github/workflows/ci_gz_dart6.yml
@@ -1,0 +1,67 @@
+# Scheduled Gazebo compatibility canary for the DART 6 LTS lane.
+#
+# GitHub only runs `schedule:` triggers from the default branch, so the cron
+# entries inside the release-6.* workflows never fire. This workflow lives on
+# main and checks out each active DART 6 release branch, then runs that
+# branch's own `test-gz` task (gz-physics + gz-sim built from source against
+# the branch's DART build). It revalidates downstream Gazebo compatibility
+# between release-line merges — e.g. after upstream gz movement or dependency
+# drift — without adding anything to PR CI.
+#
+# The per-PR gz gate on the release branches themselves is unchanged; this is
+# the continuous/scheduled tier for the same coverage.
+
+name: CI DART 6 Gazebo Canary
+
+on:
+  schedule:
+    # Weekly, offset from the other Monday crons (FreeBSD 04:00, Alt Linux
+    # 05:00, CodeQL 06:00) to avoid stampeding the runner pool.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
+jobs:
+  gz-canary:
+    name: gz-physics + gz-sim (${{ matrix.branch }})
+    runs-on: ubuntu-latest
+    # DART build + gz-physics + gz-sim from source; observed 30-130 min on the
+    # release-line PR gate depending on runner load.
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - release-6.19
+          - release-6.20
+    env:
+      DART_PARALLEL_JOBS: 8
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.branch }}
+
+      # The release branches predate the setup-pixi-ci composite action, and
+      # this job runs their checkout, so use setup-pixi directly like the
+      # release-line workflows do.
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          cache: true
+          environments: gazebo
+
+      - name: Install apt packages
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+        with:
+          packages: libgl1-mesa-dev libglu1-mesa-dev
+          version: 1.0
+
+      - name: Test gz-physics and gz-sim against ${{ matrix.branch }}
+        run: pixi run -e gazebo test-gz

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -7,13 +7,9 @@ on:
     branches:
       - "main"
       - "release-*"
-    paths-ignore:
-      - ".github/workflows/cache_*.yml"
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - ".github/workflows/cache_*.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -25,6 +25,7 @@ jobs:
       core_branch_push: ${{ steps.scope.outputs.core_branch_push }}
       code: ${{ steps.filter.outputs.code }}
       full_ci: ${{ steps.scope.outputs.full_ci }}
+      open_pr: ${{ steps.open_pr.outputs.open_pr }}
     steps:
       - name: Clean stale Linux workspace
         if: runner.os == 'Linux'
@@ -49,6 +50,38 @@ jobs:
         id: filter
         with:
           filters: .github/filters/ci-code.yml
+      - name: Check for an open PR from this branch
+        id: open_pr
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The branch-push core tier exists for pre-PR feedback. Once a PR is
+          # open, the pull_request event already runs the full tier for every
+          # push, so the push-tier core build would be redundant work. (Fork
+          # pushes query the fork's own PR list and keep their fork-side push
+          # CI, which runs on the fork's Actions quota.)
+          #
+          # Fail open: if gh is unavailable (e.g. a self-hosted parity runner)
+          # or the query fails, fall back to running the core tier as before.
+          # The headRepositoryOwner filter matters: --head matches by ref name
+          # only, and a fork PR whose head branch shares this branch's name
+          # must not suppress the upstream branch's core tier.
+          count=0
+          if command -v gh >/dev/null 2>&1; then
+            count=$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$GITHUB_REF_NAME" \
+              --state open \
+              --json headRepositoryOwner \
+              --jq "[.[] | select(.headRepositoryOwner.login == \"${GITHUB_REPOSITORY_OWNER}\")] | length" \
+              2>/dev/null || echo 0)
+          fi
+          if [ "${count}" -gt 0 ] 2>/dev/null; then
+            echo "open_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "open_pr=false" >> "$GITHUB_OUTPUT"
+          fi
 
   coverage:
     needs: changes
@@ -135,7 +168,10 @@ jobs:
 
   build-core:
     needs: changes
-    if: needs.changes.outputs.core_branch_push == 'true' && needs.changes.outputs.code == 'true'
+    if: >-
+      needs.changes.outputs.core_branch_push == 'true' &&
+      needs.changes.outputs.code == 'true' &&
+      needs.changes.outputs.open_pr != 'true'
     name: Core Tests (Linux)
     runs-on: ubuntu-latest
     # Cap runaway/hung jobs well below the ~6h GitHub default.
@@ -211,10 +247,12 @@ jobs:
       needs.changes.outputs.code == 'true')
     name: Release Tests
     runs-on: ubuntu-latest
-    # This job is build-bound (Release build + dartpy + examples + install +
-    # a full ASAN build/test) and runs ~150-180min; cap above that but well
-    # below the ~6h default so a genuine hang still fails fast.
-    timeout-minutes: 210
+    # This job is build-bound (Release build + dartpy + examples + install)
+    # and runs ~60-70min warm, ~120-140min with fully cold caches; cap above
+    # the cold case but well below the ~6h default so a genuine hang still
+    # fails fast. The AddressSanitizer phase that used to run here serially
+    # now lives in the separate ASAN Tests job below.
+    timeout-minutes: 150
     env:
       DART_PARALLEL_JOBS: 8
       # Parallelize the ctest phase (see Core Tests). ctest honors this natively.
@@ -237,9 +275,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      # The Release job builds a normal tree, dartpy, examples, and then a
-      # separate ASAN tree in the same workspace. Reclaim unused hosted-runner
-      # toolchains up front so the ASAN object files do not exhaust disk.
+      # The Release tree plus dartpy and examples runs close to the hosted
+      # runner's free space. Reclaim unused preinstalled toolchains up front
+      # so the build does not exhaust disk.
       - name: Free up disk space
         run: |
           set -x
@@ -288,19 +326,78 @@ jobs:
           BUILD_TYPE=Release \
           pixi run install
 
-      - name: Free Release build before ASAN
+  build-asan:
+    needs: changes
+    # The ASAN suite is compile-dominated: ~2h to build the instrumented tree
+    # for ~2min of ctest. That cost gates no PR-local signal worth 2h per
+    # push, so it runs as continuous coverage on protected branch pushes, the
+    # scheduled runs, and manual dispatch. Need ASAN evidence on a branch
+    # before merge? Trigger this workflow via workflow_dispatch on the branch.
+    if: >-
+      needs.changes.outputs.full_ci == 'true' &&
+      github.event_name != 'pull_request' &&
+      (github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true')
+    name: ASAN Tests
+    runs-on: ubuntu-latest
+    # Sized above the observed ~2h cold build so a genuine hang still fails
+    # well before the ~6h default kill.
+    timeout-minutes: 210
+    env:
+      # ASAN builds use materially more memory than a normal Release build;
+      # keep parallelism lower to avoid hosted-runner OOM kills.
+      DART_PARALLEL_JOBS: 4
+      # Parallelize the ctest phase (see Core Tests). ctest honors this natively.
+      CTEST_PARALLEL_LEVEL: 4
+    steps:
+      - name: Clean stale Linux workspace
+        if: runner.os == 'Linux'
+        run: |
+          if [ -n "${GITHUB_WORKSPACE:-}" ] && [ "${GITHUB_WORKSPACE}" != "/" ] && [ -d "${GITHUB_WORKSPACE}" ]; then
+            find "${GITHUB_WORKSPACE}" -mindepth 1 -maxdepth 1 -exec rm -rf {} + || {
+              if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+                docker run --rm -v "${GITHUB_WORKSPACE}:/workspace" alpine:3.20 sh -c \
+                  'find /workspace -mindepth 1 -maxdepth 1 -exec rm -rf {} +'
+              else
+                echo "::warning::Unable to clean stale workspace entries before checkout."
+              fi
+            }
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # The instrumented ASAN tree keeps sanitizer metadata and debug info for
+      # every test target; reclaim unused preinstalled toolchains so the build
+      # does not exhaust the hosted runner's disk.
+      - name: Free up disk space
         run: |
           set -x
           df -h /
-          rm -rf build/default/cpp/Release
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune --all --force || true
           df -h /
 
-      - name: Test with AddressSanitizer
+      - name: Setup pixi (CI)
+        uses: ./.github/actions/setup-pixi-ci
+        with:
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
+
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+        with:
+          packages: libgl1-mesa-dev libglu1-mesa-dev xvfb
+          version: 3
+
+      - name: Configure environment for compiler cache
+        uses: ./.github/actions/configure-compiler-cache
+
+      - name: Build and test with AddressSanitizer
         run: |
-          # ASAN builds use materially more memory than the normal Release
-          # build; keep parallelism lower to avoid hosted-runner OOM kills.
           DART_VERBOSE=ON \
-          DART_PARALLEL_JOBS=4 \
           pixi run test-asan
 
   native-collision-no-legacy:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,8 +41,49 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:
+  matrix_prep:
+    name: Security | CodeQL matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - id: matrix
+        run: |
+          # The C++ analysis needs a manual Debug build plus CodeQL database
+          # extraction (~100 min), which is too heavy to repeat on every PR
+          # push. It runs on main pushes, the weekly schedule, and manual
+          # dispatch; scanning main right after merge keeps alert coverage
+          # without gating PR feedback. The Python analysis (build-mode:
+          # none) is cheap and stays on PRs.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            cat >> "$GITHUB_OUTPUT" <<'EOF'
+          matrix<<JSON
+          {
+            "include": [
+              {"language": "python", "build_mode": "none", "run_build": false,
+               "dartpy": "ON", "gui": "ON", "cmake_build_type": "Release"}
+            ]
+          }
+          JSON
+          EOF
+          else
+            cat >> "$GITHUB_OUTPUT" <<'EOF'
+          matrix<<JSON
+          {
+            "include": [
+              {"language": "cpp", "build_mode": "manual", "run_build": true,
+               "dartpy": "OFF", "gui": "OFF", "cmake_build_type": "Debug"},
+              {"language": "python", "build_mode": "none", "run_build": false,
+               "dartpy": "ON", "gui": "ON", "cmake_build_type": "Release"}
+            ]
+          }
+          JSON
+          EOF
+          fi
+
   analyze:
     name: Security | CodeQL (${{ matrix.language }})
+    needs: matrix_prep
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -50,20 +91,7 @@ jobs:
       DART_VERBOSE: ON
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - language: cpp
-            build_mode: manual
-            run_build: true
-            dartpy: "OFF"
-            gui: "OFF"
-            cmake_build_type: Debug
-          - language: python
-            build_mode: none
-            run_build: false
-            dartpy: "ON"
-            gui: "ON"
-            cmake_build_type: Release
+      matrix: ${{ fromJSON(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Clean stale Linux workspace
         if: runner.os == 'Linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,12 @@ compatibility remains on the active DART 6 LTS branch._
   ([#3053](https://github.com/dartsim/dart/pull/3053))
 - Added optional CUDA smoke and benchmark packet paths while keeping default
   Pixi environments and dartpy wheels free of GPU runtime dependencies.
+- Cut the PR CI critical path roughly in half by moving the compile-dominated
+  ASAN suite, CodeQL C++ analysis, and Alt Linux repro to continuous/scheduled
+  coverage, parallelizing the Coverage (Debug) lcov capture, and skipping the
+  redundant branch-push core tier once a PR is open; branch protection now
+  requires the stable aggregate `Wheels` check instead of stale per-leg wheel
+  names.
 
 ## DART 6
 

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -12,9 +12,10 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
   - PR template checklist: [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
   - Asserts-enabled CI build (no `-DNDEBUG`): see [Asserts-Enabled CI Build](#asserts-enabled-ci-build-no--dndebug)
   - Eigen over-alignment CI build: see [Eigen Over-Alignment CI Build](#eigen-over-alignment-ci-build)
-  - ASAN testing (memory errors): `pixi run test-asan`; the Linux
-    `Release Tests` CI job runs it after the Release C++ tests, Python tests,
-    and examples.
+  - ASAN testing (memory errors): `pixi run test-asan`; the Linux `ASAN Tests`
+    CI job runs it on protected branch pushes, scheduled runs, and manual
+    dispatch. Trigger `CI Linux` via workflow_dispatch on a branch when a PR
+    needs ASAN evidence before merge.
   - CI monitoring commands: see [CI Monitoring (CLI)](#ci-monitoring-cli) and [CI Monitoring (API)](#ci-monitoring-api)
   - Common CI failure fixes: see [Common CI Failure Modes](#common-ci-failure-modes)
 - Fast CI fail-fast loop:
@@ -28,9 +29,10 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
   - `gh run view --job <JOB_ID> --log-failed` only works after the job completes; use the REST logs endpoint (or wait) when a run is still in progress.
   - If a PR is not mergeable due to conflicts, CI checks may be blocked or fail early (including AppVeyor); resolve conflicts locally and push before re-running CI.
   - FreeBSD VM tests can take over 1 hour to complete; this is expected, not a sign of failure.
-  - Linux `Release Tests` can be the last PR blocker because its
-    AddressSanitizer phase is long-running. Check the job step state and recent
-    successful `main` run durations before treating it as stuck.
+  - The Linux `ASAN Tests` job is compile-dominated (~2h of instrumented build
+    for ~2min of ctest) and runs on protected branch pushes, schedules, and
+    manual dispatch rather than on PRs. Check recent successful `main` run
+    durations before treating it as stuck.
   - FreeBSD VM startup can timeout (~5 min); this is transient—re-run the job.
   - `dynamic_cast` can fail silently on FreeBSD across shared library boundaries; use type enums + `static_cast`.
   - macOS ARM64 sporadic SEGFAULT from `alloca`/VLA alignment; use `std::vector<T>` instead.
@@ -92,12 +94,10 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
 ## Common CI Failure Modes
 
 - Formatting checks fail: run the C++ formatting task and re-run CI. Suggested (Unverified): `pixi run lint-cpp`.
-- Linux `Release Tests` ASAN compile fails with `No space left on device`:
-  treat this as hosted-runner disk exhaustion, not a failing DART test. The job
-  builds a normal Release tree, dartpy, examples, and then a separate ASAN tree
-  in the same workspace; keep disk cleanup at the start of that job and free
-  the already-installed Release build tree before the ASAN phase, then rerun the
-  failed check.
+- Linux `ASAN Tests` compile fails with `No space left on device`: treat this
+  as hosted-runner disk exhaustion, not a failing DART test. The instrumented
+  ASAN tree is large; keep the disk cleanup step at the start of the job, then
+  rerun the failed check.
 - Codecov patch failures: add targeted coverage for new lines or branches.
 - Example builds fail because sample code references removed formats or enums; update the example to match the current API (e.g., `dart::io::ModelFormat`).
 - Example or test links fail with `cannot find -ldart-<component>`: inspect the
@@ -271,9 +271,10 @@ DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run test-eigen-overalignment
 | `ci_macos.yml`       | Build, test           | macOS          | PR, main/release push, schedule       | Yes           |
 | `ci_windows.yml`     | Build, test           | Windows        | PR, main/release push, schedule       | Yes           |
 | `ci_freebsd.yml`     | Build, test (VM)      | FreeBSD        | Schedule, manual                      | N/A           |
-| `ci_altlinux.yml`    | Build, test (Docker)  | Alt Linux      | PR, schedule, manual                  | N/A           |
+| `ci_altlinux.yml`    | Build, test (Docker)  | Alt Linux      | Schedule, manual                      | N/A           |
 | `ci_cuda.yml`        | CUDA compile + smoke  | Ubuntu/GPU     | Path-scoped PR; trusted GPU runtime   | N/A           |
 | `ci_gz_physics.yml`  | Gazebo integration    | Ubuntu         | Release-branch push/PR; manual canary | Yes           |
+| `ci_gz_dart6.yml`    | DART 6 Gazebo canary  | Ubuntu         | Weekly schedule + manual (on main)    | N/A           |
 | `ci_simd.yml`        | SIMD multi-arch       | Ubuntu         | Branch/PR path-scoped, manual         | N/A           |
 | `publish_dartpy.yml` | Python wheels         | Multi-platform | PR, main/release/tag push, schedule   | Yes           |
 
@@ -282,25 +283,36 @@ DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run test-eigen-overalignment
 Use CI tiers to reduce PR feedback cost without removing coverage from the
 project's continuous validation surface.
 
-| Tier                      | Required before merge | Examples                                                                                           |
-| ------------------------- | --------------------- | -------------------------------------------------------------------------------------------------- |
-| Core branch push          | No                    | Lint, Ubuntu core release tests, path-scoped SIMD                                                  |
-| Required PR               | Yes                   | Lint/docs, core Linux, macOS, Windows, baseline dartpy wheels                                      |
-| Conditional PR            | When affected         | SIMD-only CI, CUDA compile CI, path-filtered platform jobs for code changes                        |
-| Release support PR        | Yes on release lines  | gz-physics compatibility on active DART 6 LTS PRs                                                  |
-| Main/release continuous   | After merge           | Full platform coverage on protected branches; full wheels on `main` and release tags               |
-| Scheduled/manual coverage | No                    | FreeBSD VM, CUDA packet benchmarks, gz-physics migration canaries, repeated full matrix, lockfiles |
+| Tier                      | Required before merge | Examples                                                                                                                        |
+| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Core branch push          | No                    | Lint, Ubuntu core release tests (skipped once the branch has an open PR), path-scoped SIMD                                      |
+| Required PR               | Yes                   | Lint/docs, core Linux, macOS, Windows, baseline dartpy wheels                                                                   |
+| Conditional PR            | When affected         | SIMD-only CI, CUDA compile CI, path-filtered platform jobs for code changes                                                     |
+| Release support PR        | Yes on release lines  | gz-physics compatibility on active DART 6 LTS PRs                                                                               |
+| Main/release continuous   | After merge           | Full platform coverage on protected branches; full wheels on `main` and release tags; ASAN suite; CodeQL C++ analysis           |
+| Scheduled/manual coverage | No                    | FreeBSD VM, Alt Linux repro, ASAN suite, CUDA packet benchmarks, gz-physics migration canaries, repeated full matrix, lockfiles |
 
 Guardrails:
 
 - Keep gz-physics compatibility required for release-line PRs that maintain the
   DART 6 support lane. On `main`/DART 7, use `ci_gz_physics.yml` as a manual
   migration canary when downstream compatibility evidence is needed.
+- GitHub only fires `schedule:` triggers from the default branch, so cron
+  entries inside `release-6.*` workflows never run. `ci_gz_dart6.yml` on main
+  fills that gap: it checks out each active DART 6 release branch weekly and
+  runs the branch's own `test-gz` (gz-physics + gz-sim from source) so
+  downstream drift is caught between release-line merges.
 - Treat core branch-push CI as early feedback only. It should be useful enough
   before a PR exists, but it is not a substitute for the required PR tier.
 - Do not move a job from required PR coverage to continuous-only coverage
   without evidence that it is expensive, redundant for most PRs, or better
   suited to scheduled validation.
+- The ASAN suite, CodeQL C++ analysis, and Alt Linux repro moved off the PR
+  tier in July 2026 with that evidence recorded: ASAN spends ~2h of
+  instrumented compile for ~2min of ctest, CodeQL C++ repeats a ~100min manual
+  build per PR push, and distro-repro breakage is effectively never PR-local.
+  All three keep running on `main` pushes and/or schedules; use
+  workflow_dispatch on a branch when a PR needs that evidence before merge.
 - Keep at least one dartpy wheel per supported OS in PR CI. Expanded Python
   version coverage can run on `main`, release tags, schedules, and manual
   dispatch.
@@ -539,7 +551,9 @@ so platform test jobs do not each rebuild docs.
   changes. The documentation build runs on PRs, protected branch pushes, and
   manual dispatch, but is skipped for ordinary feature branch pushes to keep
   the pre-PR tier small.
-- FreeBSD CI (`ci_freebsd.yml`) runs on schedule/manual only to reduce maintenance burden; Alt Linux also runs on PRs for distro repro coverage
+- FreeBSD CI (`ci_freebsd.yml`) and Alt Linux CI (`ci_altlinux.yml`) run on
+  schedule/manual only to keep PR feedback fast; distro-repro breakage is
+  effectively never PR-local
 - Lint is removed from platform-specific workflows since it's covered by the dedicated job
 
 **Shared code-change filter:** platform and integration workflows that use
@@ -593,16 +607,18 @@ maintenance-workflow-only changes
 
 - Lint
 - Ubuntu core release path: Release C++ tests, Release Python tests, examples,
-  and install
+  and install. Skipped once the branch has an open PR, because the
+  pull_request event already runs the full tier for every push.
 - SIMD multi-arch tests when SIMD paths change
 
 **Release branch pushes and PRs:**
 
 - Gazebo integration: gz-physics compatibility tests for the DART 6 support lane
 
-**Scheduled runs:**
+**Main/release pushes and scheduled runs:**
 
 - Repeat the PR validation on a fixed cadence
+- Run the ASAN suite (`ASAN Tests`), CodeQL C++ analysis, and Alt Linux repro
 - Ensure periodic full validation
 - Run expanded dartpy wheel Python-version coverage
 
@@ -618,6 +634,15 @@ does not repeat local-only validation in every platform job:
   coverage slice
 - Release jobs build examples and install where that platform covers the path
 
+The Coverage (Debug) job's `coverage-report` task parallelizes the lcov
+capture: object directories holding `.gcda` data are pruned so no listed
+directory has a listed ancestor (geninfo scans each `--directory`
+recursively), distributed round-robin across one capture process per job
+slot, and the partial tracefiles are merged with `lcov -a`. Each `.gcda` is
+captured exactly once, so the merged tracefile matches a serial capture. Set
+`DART_PARALLEL_JOBS=1` to fall back to a single capture process when
+debugging capture issues.
+
 Use `pixi run test-all` for local pre-PR validation; avoid adding it to CI jobs
 unless the duplicated lint/docs/build work is intentional.
 On Linux hosts with a visible NVIDIA CUDA runtime, also run
@@ -631,19 +656,23 @@ runtime checks do not depend on PTX JIT compatibility with the installed driver.
 
 ### Expected CI Times
 
-**Without caching (first run):**
+**Typical PR, warm cache (measured July 2026):**
 
-- Ubuntu: 45-60 min
-- macOS: 30-45 min
-- Windows: 25-35 min
-- Total: ~100-150 min
+- Ubuntu Release Tests: ~60-70 min (ASAN now runs as continuous coverage)
+- Ubuntu Coverage (Debug): ~95-105 min (build ~50, ctest ~38, parallel capture)
+- Ubuntu Debug Tests: ~55 min
+- macOS: ~35-50 min
+- Windows: ~75-100 min
+- Wall-clock to all-green: ~100 min (previously ~180 min when the ASAN phase
+  ran inside Release Tests)
 
-**With caching (subsequent runs):**
+**Continuous additions on main/release pushes:**
 
-- Ubuntu: 20-30 min
-- macOS: 15-25 min
-- Windows: 15-20 min
-- Total: ~30-60 min (50-70% reduction)
+- ASAN Tests: ~2h (compile-dominated)
+- CodeQL C++: ~100 min
+
+Cold caches roughly double the build-bound jobs; sccache typically recovers a
+50-70% reduction on subsequent runs.
 
 ### Cache Health
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1448,21 +1448,49 @@ CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE python scripts/cmak
 ], env = { BUILD_TYPE = "Debug" } }
 
 # Note: --rc flag is needed for lcov compatibility with gcc 13+
-coverage-report = { cmd = ["bash", "-lc", """
+coverage-report = { cmd = [
+  "bash",
+  "-lc",
+  """
 set -euo pipefail
+BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE
+PARALLEL_JOBS=${DART_PARALLEL_JOBS:-$(python scripts/parallel_jobs.py)}
 # Keep test objects during capture so library headers and templates exercised
 # from tests are counted. The lcov removal pass below filters test source files
 # out of the final report.
-find build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \
+find "$BUILD_DIR" \
     '(' -path '*/examples/*' -o -path '*/tutorials/*' ')' \
     '(' -name '*.gcda' -o -name '*.gcno' ')' -delete
+# lcov 1.x capture is single-threaded and takes ~35 minutes over the fully
+# instrumented tree in CI. Distribute the object directories that hold
+# coverage data round-robin across one capture process per job slot, then
+# merge the partial tracefiles. geninfo scans each --directory recursively,
+# so the awk filter prunes directories whose ancestor is already listed;
+# each .gcda is then captured exactly once and the merged tracefile matches
+# a serial capture (lcov -a would otherwise sum nested dirs' counts twice).
+rm -f coverage.chunk.* coverage.gcda_dirs.txt
+find "$BUILD_DIR" -name '*.gcda' -print0 | xargs -0 -r -n 64 dirname | sort -u | awk 'prev == "" || substr($0, 1, length(prev) + 1) != prev "/" { print; prev = $0 }' > coverage.gcda_dirs.txt
+test -s coverage.gcda_dirs.txt
+split -d -n r/${PARALLEL_JOBS} coverage.gcda_dirs.txt coverage.chunk.
+pids=()
+traces=()
+for chunk in coverage.chunk.*; do
+  test -s "$chunk" || continue
+  dirargs=()
+  while IFS= read -r d; do dirargs+=(--directory "$d"); done < "$chunk"
+  out="$chunk.info"
+  lcov --quiet --capture "${dirargs[@]}" --output-file "$out" --rc geninfo_unexecuted_blocks=1 --rc 'lcov_excl_line=LCOV_EXCL_LINE' &
+  pids+=($!)
+  traces+=("$out")
+done
+status=0
+for p in "${pids[@]}"; do wait "$p" || status=1; done
+test "$status" -eq 0
+addargs=()
+for t in "${traces[@]}"; do addargs+=(-a "$t"); done
+lcov "${addargs[@]}" --output-file coverage.info
+rm -f coverage.chunk.* coverage.gcda_dirs.txt
 lcov \
-    --capture \
-    --directory build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \
-    --output-file coverage.info \
-    --rc geninfo_unexecuted_blocks=1 \
-    --rc 'lcov_excl_line=LCOV_EXCL_LINE' \
-&& lcov \
     --remove coverage.info \
     '/usr/*' \
     '*/.pixi/*' \
@@ -1473,7 +1501,10 @@ lcov \
     '*/dart/gui/*' \
     --output-file coverage.info \
 && lcov --list coverage.info
-"""], depends-on = ["build-coverage"], env = { BUILD_TYPE = "Debug" } }
+""",
+], depends-on = [
+  "build-coverage",
+], env = { BUILD_TYPE = "Debug" } }
 
 coverage-report-dartsim = { cmd = ["bash", "-lc", """
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Cuts the PR CI critical path roughly in half (~180 min → ~100 min wall-clock to all-green) while keeping every validation surface: the heavy jobs move to continuous/scheduled tiers instead of being removed, and a new weekly canary adds DART 6 Gazebo coverage that previously never ran on a schedule.

## Motivation / Problem

- Measured on recent runs, the required Linux jobs dominated PR latency: `Release Tests` ran 179 min because a ~118 min AddressSanitizer build (for ~2 min of ctest) was bolted serially onto ~60 min of Release work, and `Coverage (Debug)` spent ~35 of its 124 min in a single-threaded lcov 1.16 capture.
- CodeQL C++ repeated a ~100 min manual build on every PR push, and the Alt Linux Docker repro ran on every PR despite distro-repro breakage never being PR-local.
- Every push to a branch with an open PR ran the ~60 min branch-push core tier in addition to the full PR tier (separate concurrency groups).
- `schedule:` triggers only fire from the default branch, so the cron entries in the `release-6.*` workflows never run — the DART 6 lane had no continuous Gazebo validation between merges.

## Changes / Key Changes

- `ci_ubuntu.yml`: split the AddressSanitizer phase out of `Release Tests` into a standalone `ASAN Tests` job that runs on protected branch pushes, schedules, and manual dispatch (workflow_dispatch on a branch is the escape hatch when a PR needs ASAN evidence pre-merge). `Release Tests` drops to ~60-70 min (timeout 210 → 150).
- `ci_ubuntu.yml`: the `changes` job now detects an open same-repo PR for the pushed branch (fail-open if `gh` is unavailable, filtered by head repository owner so fork PRs with colliding branch names don't suppress it) and skips the redundant `Core Tests (Linux)` push tier.
- `pixi.toml`: `coverage-report` parallelizes the lcov capture — gcda directories are pruned so no listed directory has a listed ancestor (geninfo scans recursively), split round-robin across one capture process per job slot, and merged with `lcov -a`; each `.gcda` is captured exactly once so the merged tracefile matches a serial capture. Validated locally against a full coverage tree (serial vs parallel per-file equivalence).
- `codeql.yml`: the C++ analysis (manual build) now runs on main pushes, the weekly schedule, and dispatch; the cheap Python analysis stays on PRs. Implemented via a matrix-prep job so the job definition stays single-sourced.
- `ci_altlinux.yml`: schedule + dispatch only, per the tiering policy's scheduled/manual tier.
- New `ci_gz_dart6.yml`: weekly + dispatch canary on main that checks out each active `release-6.*` branch and runs its own `test-gz` (gz-physics + gz-sim built from source against that branch's DART), filling the dead-cron gap on release lines.
- `ci_lint.yml`, `.github/filters/ci-code.yml`: dropped stale `cache_*.yml` references (that workflow only exists on release branches).
- `docs/onboarding/ci-cd.md`, `CHANGELOG.md`: tier tables, expected times, ASAN/coverage/canary documentation updated to match.

Branch protection was updated alongside this work: the stale `Wheels | * Py312` required contexts (no longer produced by any workflow) were replaced with the aggregate `Wheels` check, per the existing guardrail in `docs/onboarding/ci-cd.md`.

## Testing

- `pixi run lint` (clean), YAML `yaml.safe_load` on all changed workflows, `tomllib` parse + `bash -n` on the embedded coverage script.
- Local end-to-end coverage validation: `pixi run build-coverage` (full Debug+coverage build, 298 ctest tests), then serial vs chunked-parallel capture comparison on the resulting tree (per-file DA line sets and hit counts).
- Adversarial multi-agent review of the full diff (GitHub Actions semantics, bash/TOML, coverage-preservation event matrix, docs consistency); the three confirmed findings (nested-gcda double counting, fork-PR head-name collision, timeout headroom) are fixed in this diff.

## Breaking Changes

- [x] None (CI/infrastructure only; no library, API, or packaging behavior changes)

## Related Issues / PRs (backports)

- Companion release-lane PRs: push-trigger dedupe on `release-6.20` and `release-6.19` (same-titled PRs).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [ ] Add unit tests for new functionality (n/a — CI configuration)
- [ ] Document new methods and classes (n/a)
- [ ] Add Python bindings (dartpy) if applicable (n/a)
