### PR TITLE
Define dart-changelog decision output contract

### DIFF
--- a/.claude/commands/dart-changelog.md
+++ b/.claude/commands/dart-changelog.md
@@ -39,6 +39,29 @@ Interpret `$ARGUMENTS` as one of these modes when present:
 
 If no mode is given, infer the smallest mode that satisfies the caller's need.
 
+## Output Contract
+
+Every run must leave the caller with a concise, pasteable decision note. Use
+this shape in the response, PR body draft, or handoff text:
+
+```markdown
+Changelog decision:
+
+- Mode: decide | draft | finalize | audit | release-audit
+- Base evidence: <base ref or PR/release inspected>
+- Scope evidence: <diff, PR, issue, or release section inspected>
+- Decision: entry required | no entry required | entry deferred | audit only
+- Target section: <release/category, or N/A>
+- Entry text: <final or draft bullet, or N/A>
+- PR-body note: <exact no-entry reason or follow-up, or N/A>
+- Follow-up: <PR link, maintainer approval, release audit, or none>
+```
+
+For `no entry required`, the PR-body note must name the evidence-backed reason
+rather than just saying "not needed." For `entry deferred`, say exactly what is
+missing, usually the PR number or release target. For `finalize`, confirm the
+entry still matches nearby `CHANGELOG.md` style after adding the PR link.
+
 ## Workflow
 
 1. Inspect the change and target:
@@ -76,20 +99,23 @@ If no mode is given, infer the smallest mode that satisfies the caller's need.
      entry;
    - typo-only, formatting-only, generated-only, and tiny internal refactors
      usually do not.
-4. When writing, start with the reader-visible outcome, not the implementation
+4. Record the decision with the Output Contract before modifying
+   `CHANGELOG.md` or telling a caller to skip it. The decision must cite the
+   diff, PR, issue, release section, or target branch that was inspected.
+5. When writing, start with the reader-visible outcome, not the implementation
    chore. Use one concise bullet, merge closely related changes, avoid author
    credits, and avoid one-bullet-per-PR diary style.
-5. Place the entry under the target branch's release section and nearest
+6. Place the entry under the target branch's release section and nearest
    existing category. Do not create a new category for one PR unless the release
    shape genuinely needs it.
-6. Add the best evidence link:
+7. Add the best evidence link:
    - if a PR number exists, use `([#1234](https://github.com/dartsim/dart/pull/1234))`;
    - if no PR number exists yet, draft without the link and leave the follow-up
      local until explicit approval permits another push or PR update.
-7. For release audits, consolidate noisy implementation ledgers, confirm
+8. For release audits, consolidate noisy implementation ledgers, confirm
    breaking/removal/deprecation bullets name a migration or support lane, and
    preserve human-readable release notes over exhaustive history.
-8. Validate with the gate appropriate to the caller. For changelog-only edits,
+9. Validate with the gate appropriate to the caller. For changelog-only edits,
    run the docs-only checks from `docs/ai/verification.md`; before any commit,
    run `pixi run lint`.
 
@@ -98,4 +124,6 @@ If no mode is given, infer the smallest mode that satisfies the caller's need.
 Other workflows should call this routine whenever they touch behavior or docs
 that may need release notes. The caller keeps ownership of the overall task,
 validation, PR body, and approval boundary; `dart-changelog` owns the changelog
-decision, wording, placement, and evidence-link hygiene.
+decision, wording, placement, evidence-link hygiene, and the pasteable decision
+note that lets Claude, Codex, OpenCode, and manual contributors record the same
+outcome.

--- a/.codex/skills/dart-changelog/SKILL.md
+++ b/.codex/skills/dart-changelog/SKILL.md
@@ -60,6 +60,29 @@ Interpret `$ARGUMENTS` as one of these modes when present:
 
 If no mode is given, infer the smallest mode that satisfies the caller's need.
 
+## Output Contract
+
+Every run must leave the caller with a concise, pasteable decision note. Use
+this shape in the response, PR body draft, or handoff text:
+
+```markdown
+Changelog decision:
+
+- Mode: decide | draft | finalize | audit | release-audit
+- Base evidence: <base ref or PR/release inspected>
+- Scope evidence: <diff, PR, issue, or release section inspected>
+- Decision: entry required | no entry required | entry deferred | audit only
+- Target section: <release/category, or N/A>
+- Entry text: <final or draft bullet, or N/A>
+- PR-body note: <exact no-entry reason or follow-up, or N/A>
+- Follow-up: <PR link, maintainer approval, release audit, or none>
+```
+
+For `no entry required`, the PR-body note must name the evidence-backed reason
+rather than just saying "not needed." For `entry deferred`, say exactly what is
+missing, usually the PR number or release target. For `finalize`, confirm the
+entry still matches nearby `CHANGELOG.md` style after adding the PR link.
+
 ## Workflow
 
 1. Inspect the change and target:
@@ -97,20 +120,23 @@ If no mode is given, infer the smallest mode that satisfies the caller's need.
      entry;
    - typo-only, formatting-only, generated-only, and tiny internal refactors
      usually do not.
-4. When writing, start with the reader-visible outcome, not the implementation
+4. Record the decision with the Output Contract before modifying
+   `CHANGELOG.md` or telling a caller to skip it. The decision must cite the
+   diff, PR, issue, release section, or target branch that was inspected.
+5. When writing, start with the reader-visible outcome, not the implementation
    chore. Use one concise bullet, merge closely related changes, avoid author
    credits, and avoid one-bullet-per-PR diary style.
-5. Place the entry under the target branch's release section and nearest
+6. Place the entry under the target branch's release section and nearest
    existing category. Do not create a new category for one PR unless the release
    shape genuinely needs it.
-6. Add the best evidence link:
+7. Add the best evidence link:
    - if a PR number exists, use `([#1234](https://github.com/dartsim/dart/pull/1234))`;
    - if no PR number exists yet, draft without the link and leave the follow-up
      local until explicit approval permits another push or PR update.
-7. For release audits, consolidate noisy implementation ledgers, confirm
+8. For release audits, consolidate noisy implementation ledgers, confirm
    breaking/removal/deprecation bullets name a migration or support lane, and
    preserve human-readable release notes over exhaustive history.
-8. Validate with the gate appropriate to the caller. For changelog-only edits,
+9. Validate with the gate appropriate to the caller. For changelog-only edits,
    run the docs-only checks from `docs/ai/verification.md`; before any commit,
    run `pixi run lint`.
 
@@ -119,4 +145,6 @@ If no mode is given, infer the smallest mode that satisfies the caller's need.
 Other workflows should call this routine whenever they touch behavior or docs
 that may need release notes. The caller keeps ownership of the overall task,
 validation, PR body, and approval boundary; `dart-changelog` owns the changelog
-decision, wording, placement, and evidence-link hygiene.
+decision, wording, placement, evidence-link hygiene, and the pasteable decision
+note that lets Claude, Codex, OpenCode, and manual contributors record the same
+outcome.

--- a/.opencode/command/dart-changelog.md
+++ b/.opencode/command/dart-changelog.md
@@ -43,6 +43,29 @@ Interpret `$ARGUMENTS` as one of these modes when present:
 
 If no mode is given, infer the smallest mode that satisfies the caller's need.
 
+## Output Contract
+
+Every run must leave the caller with a concise, pasteable decision note. Use
+this shape in the response, PR body draft, or handoff text:
+
+```markdown
+Changelog decision:
+
+- Mode: decide | draft | finalize | audit | release-audit
+- Base evidence: <base ref or PR/release inspected>
+- Scope evidence: <diff, PR, issue, or release section inspected>
+- Decision: entry required | no entry required | entry deferred | audit only
+- Target section: <release/category, or N/A>
+- Entry text: <final or draft bullet, or N/A>
+- PR-body note: <exact no-entry reason or follow-up, or N/A>
+- Follow-up: <PR link, maintainer approval, release audit, or none>
+```
+
+For `no entry required`, the PR-body note must name the evidence-backed reason
+rather than just saying "not needed." For `entry deferred`, say exactly what is
+missing, usually the PR number or release target. For `finalize`, confirm the
+entry still matches nearby `CHANGELOG.md` style after adding the PR link.
+
 ## Workflow
 
 1. Inspect the change and target:
@@ -80,20 +103,23 @@ If no mode is given, infer the smallest mode that satisfies the caller's need.
      entry;
    - typo-only, formatting-only, generated-only, and tiny internal refactors
      usually do not.
-4. When writing, start with the reader-visible outcome, not the implementation
+4. Record the decision with the Output Contract before modifying
+   `CHANGELOG.md` or telling a caller to skip it. The decision must cite the
+   diff, PR, issue, release section, or target branch that was inspected.
+5. When writing, start with the reader-visible outcome, not the implementation
    chore. Use one concise bullet, merge closely related changes, avoid author
    credits, and avoid one-bullet-per-PR diary style.
-5. Place the entry under the target branch's release section and nearest
+6. Place the entry under the target branch's release section and nearest
    existing category. Do not create a new category for one PR unless the release
    shape genuinely needs it.
-6. Add the best evidence link:
+7. Add the best evidence link:
    - if a PR number exists, use `([#1234](https://github.com/dartsim/dart/pull/1234))`;
    - if no PR number exists yet, draft without the link and leave the follow-up
      local until explicit approval permits another push or PR update.
-7. For release audits, consolidate noisy implementation ledgers, confirm
+8. For release audits, consolidate noisy implementation ledgers, confirm
    breaking/removal/deprecation bullets name a migration or support lane, and
    preserve human-readable release notes over exhaustive history.
-8. Validate with the gate appropriate to the caller. For changelog-only edits,
+9. Validate with the gate appropriate to the caller. For changelog-only edits,
    run the docs-only checks from `docs/ai/verification.md`; before any commit,
    run `pixi run lint`.
 
@@ -102,4 +128,6 @@ If no mode is given, infer the smallest mode that satisfies the caller's need.
 Other workflows should call this routine whenever they touch behavior or docs
 that may need release notes. The caller keeps ownership of the overall task,
 validation, PR body, and approval boundary; `dart-changelog` owns the changelog
-decision, wording, placement, and evidence-link hygiene.
+decision, wording, placement, evidence-link hygiene, and the pasteable decision
+note that lets Claude, Codex, OpenCode, and manual contributors record the same
+outcome.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Added a structured `dart-changelog` decision note so Claude, Codex, OpenCode,
   and manual PR authors can record the inspected evidence, target release
   section, entry text, no-entry reason, and PR-link follow-up consistently.
+  ([#3224](https://github.com/dartsim/dart/pull/3224))
 - Clarified DART 6 LTS release routing so remaining `6.19.x` fixes target the
   active `release-6.20` branch and `DART 6.20.0` milestone instead of opening a
   `DART 6.19.4` patch lane.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,9 @@ compatibility remains on the active DART 6 LTS branch._
 - Made DART AI workflows more completion- and changelog-aware by default, with
   verification-first `$dart-resume` task management and a reusable
   `$dart-changelog` routine for consistent release-note decisions and entries.
+- Added a structured `dart-changelog` decision note so Claude, Codex, OpenCode,
+  and manual PR authors can record the inspected evidence, target release
+  section, entry text, no-entry reason, and PR-link follow-up consistently.
 - Clarified DART 6 LTS release routing so remaining `6.19.x` fixes target the
   active `release-6.20` branch and `DART 6.20.0` milestone instead of opening a
   `DART 6.19.4` patch lane.

--- a/docs/onboarding/changelog.md
+++ b/docs/onboarding/changelog.md
@@ -114,12 +114,16 @@ shared decision/writing path for PR, docs, issue-fix, resume, and release
 workflows.
 
 1. Decide whether an entry is required using this guide.
-2. If no entry is required, record the reason in the PR description or checklist.
-3. If an entry is required before the PR number exists, draft the entry without
+2. Record the reusable `Changelog decision` note from `dart-changelog`,
+   including the inspected base/diff evidence, target release section, entry
+   text or exact no-entry reason, and any PR-link follow-up.
+3. If no entry is required, record the evidence-backed reason in the PR
+   description or checklist.
+4. If an entry is required before the PR number exists, draft the entry without
    a PR link or leave it for the PR-number follow-up.
-4. After the PR exists, add the PR link in the same entry. Keep this follow-up
+5. After the PR exists, add the PR link in the same entry. Keep this follow-up
    local until explicit maintainer/user approval allows another push.
-5. For AI-generated draft entries, curate aggressively: summarize the outcome,
+6. For AI-generated draft entries, curate aggressively: summarize the outcome,
    remove implementation noise, merge related bullets, and link to the owner
    doc for details.
 


### PR DESCRIPTION
## Summary

- Adds a structured `Changelog decision` output contract to `dart-changelog` so Claude, Codex, OpenCode, and manual contributors record the same changelog outcome fields.
- Updates the changelog guide to require evidence-backed no-entry reasons, target section capture, and PR-link follow-up tracking.
- Adds the corresponding DART 7 changelog entry linked to this PR.

## Motivation / Problem

`dart-changelog` is normally invoked by other workflows, not directly by users. Without a concrete output shape, each caller can summarize the decision differently, making PR bodies, handoffs, and follow-up changelog commits inconsistent across Claude, Codex, OpenCode, and manual runs.

## Changes / Key Changes

- Added an `Output Contract` section to the editable Claude workflow source and synced the generated Codex/OpenCode adapters.
- Required each run to report mode, base/scope evidence, decision, target section, entry text, PR-body note, and follow-up.
- Updated `docs/onboarding/changelog.md` so contributors preserve that reusable decision note.

## Testing

- `pixi run sync-ai-commands`
- `pixi run lint-md`
- `pixi run check-lint-md`
- `pixi run check-ai-commands`
- `pixi run check-docs-policy` (passed with existing `docs/ai/north-star.md` freshness advisories)
- `pixi run check-lint-spell`
- `git diff --check`
- `pixi run lint`

## Breaking Changes

- [x] None
- Documentation/workflow guidance only.

## Related Issues / PRs (backports)

- Follows #3220.
- Backports: N/A; main-branch AI workflow documentation.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality (N/A: docs/workflow-only change)
- [x] Document new methods and classes (N/A: no API methods/classes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no bindings)
