### PR TITLE
Run DART 6 release-line CI on push only for release branches (release-6.19)

### DIFF
--- a/.github/workflows/api_doc.yml
+++ b/.github/workflows/api_doc.yml
@@ -4,8 +4,10 @@ name: API Documentation
 
 on:
   push:
+    # Feature-branch validation happens via pull_request; run on push only for
+    # the release lines so PR branches are not built twice per push.
     branches:
-      - "**"
+      - "release-*"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
@@ -22,7 +24,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   build:

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -17,8 +17,10 @@ name: CI FreeBSD (VM)
 
 on:
   push:
+    # Feature-branch validation happens via pull_request; run on push only for
+    # the release lines so PR branches are not built twice per push.
     branches:
-      - "**"
+      - "release-*"
   pull_request:
     branches:
       - "**"
@@ -32,7 +34,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   freebsd:

--- a/.github/workflows/ci_gz_physics.yml
+++ b/.github/workflows/ci_gz_physics.yml
@@ -4,8 +4,10 @@ name: CI gz-physics
 
 on:
   push:
+    # Feature-branch validation happens via pull_request; run on push only for
+    # the release lines so PR branches are not built twice per push.
     branches:
-      - "**"
+      - "release-*"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
@@ -25,7 +27,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   test_gazebo:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -4,8 +4,10 @@ name: CI macOS
 
 on:
   push:
+    # Feature-branch validation happens via pull_request; run on push only for
+    # the release lines so PR branches are not built twice per push.
     branches:
-      - "**"
+      - "release-*"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
@@ -25,7 +27,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   build:

--- a/.github/workflows/ci_toolchain.yml
+++ b/.github/workflows/ci_toolchain.yml
@@ -16,8 +16,10 @@ name: CI Toolchain (Linux)
 
 on:
   push:
+    # Feature-branch validation happens via pull_request; run on push only for
+    # the release lines so PR branches are not built twice per push.
     branches:
-      - "**"
+      - "release-*"
   pull_request:
     branches:
       - "**"
@@ -31,7 +33,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   toolchain:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -4,8 +4,10 @@ name: CI Linux
 
 on:
   push:
+    # Feature-branch validation happens via pull_request; run on push only for
+    # the release lines so PR branches are not built twice per push.
     branches:
-      - "**"
+      - "release-*"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
@@ -25,7 +27,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   coverage:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -4,8 +4,10 @@ name: CI Windows
 
 on:
   push:
+    # Feature-branch validation happens via pull_request; run on push only for
+    # the release lines so PR branches are not built twice per push.
     branches:
-      - "**"
+      - "release-*"
     paths-ignore:
       - ".github/workflows/cache_*.yml"
       - "docker/dev/**"
@@ -25,7 +27,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Stops the DART 6 lane from running its seven heavy workflows twice per push once a PR is open, and from running the full matrix on every pre-PR feature-branch push; pull_request events keep providing every required check unchanged.

## Motivation / Problem

- On this release line the heavy workflows (`ci_ubuntu`, `ci_macos`, `ci_windows`, `ci_gz_physics`, `ci_freebsd`, `api_doc`, `ci_toolchain`) trigger on `push: "**"` and `pull_request: "**"`. A push to a PR branch therefore runs everything twice (push + pull_request events use separate concurrency groups), and feature branches burn the full matrix (including the 30-120 min gz-physics + gz-sim build and the FreeBSD VM) before any PR exists. Measured recent examples: 114-201 min CI Linux plus 28-123 min gz workflow per push.

## Changes / Key Changes

- Restrict the seven workflows' `push` trigger to `release-*` refs. PRs keep full required coverage (including the gz-physics + gz-sim compatibility gate); pushes to the release lines keep full post-merge coverage.
- `cancel-in-progress` now excludes `release-*` refs (in addition to schedules), so post-merge continuous validation always completes — matching main's policy of never cancelling protected-ref runs.
- Note: `schedule:` triggers on non-default branches never fire (GitHub runs crons from the default branch only); continuous revalidation of this line between merges is provided by the new weekly `ci_gz_dart6.yml` canary on `main`, which checks out this branch and runs its `test-gz`.

## Testing

- YAML validated (`yaml.safe_load`) for all seven workflows; diff is trigger/concurrency-only, no job or step changes.

## Breaking Changes

- [x] None (CI triggers only; released artifacts and required PR checks unchanged)

## Related Issues / PRs (backports)

- Same change on the sibling release branch; main PR restructures the DART 7 CI tiers and adds the `ci_gz_dart6.yml` canary.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x patch
      milestone for the active DART 6 LTS branch)
- [ ] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
      (skipped: CI-trigger-only change with no user-visible behavior in
      released artifacts, per the "do not add entries" guidance)
- [ ] Add unit tests for new functionality (n/a — CI configuration)
- [ ] Document new methods and classes (n/a)
- [ ] Add Python bindings (dartpy) if applicable (n/a)
