### PR TITLE
Drop retired release-6.19 from the DART 6 Gazebo canary matrix

### DIFF
--- a/.github/workflows/ci_gz_dart6.yml
+++ b/.github/workflows/ci_gz_dart6.yml
@@ -38,7 +38,6 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - release-6.19
           - release-6.20
     env:
       DART_PARALLEL_JOBS: 8


### PR DESCRIPTION
## Summary

- Removes the `release-6.19` leg from `ci_gz_dart6.yml`: DART 6.19 is end-of-life and the branch has been deleted, so the weekly canary would fail checking it out. `release-6.20` is the active DART 6 LTS lane.

## Motivation / Problem

- The canary was added listing both release branches; 6.19 was retired immediately afterwards (fully contained in release-6.20 and main, history reachable via the `v6.19.*` tags).

## Testing

- `yaml.safe_load` on the workflow. The canary will be re-dispatched after this merges.

## Breaking Changes

- [x] None

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [ ] CHANGELOG.md updated (n/a — CI matrix follow-up to the branch retirement)
- [ ] Add unit tests (n/a)
- [ ] Document new methods and classes (n/a)
- [ ] Add Python bindings (n/a)