### PR TITLE
Point stable docs guidance at release-6.20

### DIFF
--- a/docs/readthedocs/index.rst
+++ b/docs/readthedocs/index.rst
@@ -12,8 +12,8 @@ Welcome to DART documentation!
    This site documents **DART 7**, an in-progress redesign that is **not yet
    recommended for production use**. If you need a stable release, use
    **DART 6 LTS**: see the `DART 6 documentation
-   <https://dart.readthedocs.io/en/stable/>`_ and the `release-6.19 branch
-   <https://github.com/dartsim/dart/tree/release-6.19>`_. New to DART 7? Start
+   <https://dart.readthedocs.io/en/stable/>`_ and the `release-6.20 branch
+   <https://github.com/dartsim/dart/tree/release-6.20>`_. New to DART 7? Start
    with the :doc:`user_guide/index`.
 
 Introduction


### PR DESCRIPTION
## Summary

- Updates the DART documentation landing page to point stable users at the active `release-6.20` branch instead of the retired `release-6.19` branch.

## Motivation / Problem

- #3231 removed the retired `release-6.19` branch from the DART 6 Gazebo canary matrix, but the Read the Docs landing page still linked stable users to that deleted branch.

## Changes / Key Changes

- Changes the stable DART 6 branch reference in `docs/readthedocs/index.rst` from `release-6.19` to `release-6.20`.

## Testing

- `pixi run lint`
- `git diff --check`
- `rg -n "release-6\\.19 branch|github.com/dartsim/dart/tree/release-6\\.19|release-6\\.19" docs/readthedocs/index.rst .github/workflows/ci_gz_dart6.yml` (no matches)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3231.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required (N/A — stale docs-link cleanup after #3231)
- [x] Add unit tests for new functionality (N/A — docs-only link update)
- [x] Document new methods and classes (N/A — no API changes)
- [x] Add Python bindings (dartpy) if applicable (N/A — no bindings changes)
