### PR TITLE
Plan DART 6 native collision port

### DIFF
--- a/docs/dev_tasks/dart6_dependency_minimization/03-native-collision-port-scoping.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/03-native-collision-port-scoping.md
@@ -1,9 +1,11 @@
-# Scoping: Native collision detector port (DART 7 → DART 6.20)
+# Scoping: Native collision detector port (DART 7 -> DART 6.20)
 
-> **Status: SCOPING / PLANNING ONLY** — no code, no PR yet. This is the design
-> artifact for the maintainer's go/no-go on the native-collision initiative
-> recorded in `02-default-environment-split.md` (decision c). Sub-doc of the
-> `dart6_dependency_minimization` task.
+> **Status: PLANNING REFRESH / EXECUTION PLAN** - DART 6.20 has already landed a
+> substantial performance stack for issue #3056, but the DART 7 native collision
+> engine has **not** been ported to DART 6 and FCL is still the release-branch
+> default. This document is the go/no-go and sequencing artifact for the native
+> port/default-flip work recorded in `02-default-environment-split.md`
+> (decision c). Sub-doc of the `dart6_dependency_minimization` task.
 
 ## Why (the real dependency win)
 
@@ -11,35 +13,104 @@ DART 6.20 hard-requires **FCL** as the core collision dependency (default
 detector + linked into `dart` + in `DART_PKG_EXTERNAL_DEPS`), and ships Bullet/
 ODE as alternative backends. The only way to actually *remove* external collision
 dependencies (not just hide them) is to make a **native** detector the default
-and turn FCL/Bullet/ODE optional — exactly what DART 7 did (PLAN-035, PRs #2652
+and turn FCL/Bullet/ODE optional - exactly what DART 7 did (PLAN-035, PRs #2652
 /#2688/#2700). Goal for 6.20: native default that is **gz-compatible**, **feature-
 complete**, and **evidence-driven faster** than Bullet/ODE/FCL.
 
-## What DART 7 provides (the source) — `dart/collision/native/` (~80 files)
+## Current evidence refresh (2026-07-03)
+
+Refs checked:
+
+- `origin/release-6.20` and this planning branch: `849f22245b7ef11299fa73074c77d6c50b8dda01`.
+- `origin/main`: `c0419111df6e0260169867526dcbccce04353e09`.
+- Related remote heads: `feature/native-occupancy-grid`,
+  `task/native-collision-performance-exec`, `docs/dart6-performance-dashboard`,
+  `backport/2490-to-release-6.20`, `fix/gz-physics-joint-detach-6.20`.
+
+Live conclusion:
+
+- `release-6.20` still has no `dart/collision/native/` port. The DART 6
+  `dart` detector remains the old limited detector; the default path still
+  resolves through FCL.
+- DART 7 source/reference PRs remain #2652 (native default), #2688 (coverage and
+  performance superset), and #2700 (native CCD). Use these as reference only;
+  do not copy the EnTT/C++23 world plumbing directly into DART 6.
+- DART 6 performance work for #3056 landed through the release stack (#3123,
+  #3125, #3126, #3129, #3133, #3135, #3139, #3141, #3143, #3144, #3170, #3171,
+  #3172, #3183, #3188, #3191, #3192, #3194, #3199, #3203). That stack resolves
+  the headless-performance issue path, but it is **not** the native-engine port
+  and does not by itself make FCL optional.
+- Open release-6.20 work relevant to this plan:
+  - #3209 (`perf/contact-rich-benchmark-case`) adds the deterministic
+    contact-rich container benchmark needed as a default-flip gate.
+  - #3230 (`docs/dart6-performance-dashboard`) adds the DART 6 performance
+    dashboard workflow and benchmark-history plumbing.
+  - #3229 (`backport/2490-to-release-6.20`) backports the DART 7 SIMD
+    abstraction to C++17; useful for native hot paths, not a correctness
+    prerequisite.
+  - #3226 and #3227 are correctness/performance-adjacent release work and must
+    be watched before interpreting collision-result drift.
+- Issue #3056 is still open, but its latest maintainer evidence says the DART 6
+  performance task was completed by #3199/#3203. Its final benchmark comment is
+  still useful as a non-regression guardrail: DART-native was around RTF 65 on
+  the `3k_shapes.sdf` case with a stable hash, while ODE plane-shape parsing was
+  fixed from very low RTF to high RTF on the same large scene. Treat those rows
+  as historical guardrails, not proof that the full DART 7 native detector is
+  ported.
+
+Local A/B probe on this branch (freshly rebuilt `contact_benchmark`, compiler
+cache disabled because the stale build cache pointed to a removed Pixi
+`sccache`):
+
+```bash
+pixi run ./build/default/cpp/Release/bin/contact_benchmark \
+  --generate-objects 120 --steps 300 --warmup 0 --checkpoint 0 --quiet \
+  --collision <detector> --world-threads 1 --max-contacts 20000
+```
+
+| Detector | RTF | Avg step | Contacts | Resting | Hash | Notes |
+| --- | ---: | ---: | ---: | ---: | --- | --- |
+| `default` | 0.773604 | 1.29265 ms | 240 | 60/120 | `0xf69bb3c8f91330` | Matches FCL hash/outcome, slower in this short run. |
+| `dart` | 3.33242 | 0.300082 ms | 240 | 80/120 | `0x8d8b20bbb24e90ee` | Faster here, but old limited DART detector is not the DART 7 native port. |
+| `fcl` | 1.96733 | 0.508303 ms | 240 | 60/120 | `0xf69bb3c8f91330` | Current explicit incumbent default detector. |
+| `ode` | 12.8554 | 0.0777883 ms | 0 | 120/120 | `0x7ab7392133b33c99` | Fast but physically different; zero final contacts means not a speed-only win. |
+| `bullet` | 0.994733 | 1.00529 ms | 268 | 76/120 | `0x3abd10e684addd83` | Finite state, different contact/resting profile. |
+
+Immediate implication: a native-default decision cannot use RTF alone. Every
+performance row must be paired with final contacts, contact-cap status, resting
+count, finite-state status, final hash, and scene-dump diffs. Different
+detectors legitimately produce different hashes, but a new native detector must
+be internally stable and must stay within documented tolerance envelopes against
+the incumbent for each capability.
+
+## What DART 7 provides (the source) - `dart/collision/native/` (~80 files)
 
 - **Broadphase:** AABB-tree, brute-force, spatial-hash, sweep-and-prune (`broad_phase/`).
 - **Narrowphase:** GJK + MPR (`gjk.cpp`, `mpr.cpp`), box-box SAT + face-clip + contact-reduction (`narrow_phase/box_box/`), sphere/box/capsule/cylinder/plane/mesh pairs, convex-convex, `distance.cpp`, `raycast.cpp`, `ccd.cpp`/`primitive_ccd.cpp`.
 - **SDF:** dense / ESDF / TSDF fields (`sdf/`).
 - **Manifolds:** persistent 4-point contact manifolds with warm-starting (`persistent_manifold_cache.*`, `contact_manifold.*`).
-- **Default mechanism:** `DartCollisionDetector` registers under aliases (`"fcl"`/`"bullet"`/`"ode"`→native); FCL/ODE detectors became **header-only facades** (`collision/{fcl,ode}/compat/`) over native; no external collision deps.
+- **Default mechanism:** `DartCollisionDetector` registers under aliases
+  (`"fcl"`/`"bullet"`/`"ode"` -> native); FCL/ODE detectors became
+  **header-only facades** (`collision/{fcl,ode}/compat/`) over native; no
+  external collision deps.
 
-## The target (DART 6.20) — `dart/collision/`
+## The target (DART 6.20) - `dart/collision/`
 
 - Clean factory interface: `CollisionDetector` (virtuals: `collide×2`, `distance×2`, `raycast`, `createCollisionGroup`, `createCollisionObject`, `refreshCollisionObject`, `getType`, `cloneWithoutCollisionObjects`), `CollisionGroup`, `CollisionObject`, `CollisionResult`, `Contact`, `CollisionOption`.
-- Detectors: **`dart`** (basic, narrowphase-only, no broadphase/distance/raycast, limited shapes), **`fcl`** (full; **hardcoded default** created in *both* `ConstraintSolver` constructors via `FCLCollisionDetector::create()` — `dart/constraint/ConstraintSolver.cpp:322` & `:342`; core), `ode`, `bullet`.
-- FCL coupling to break: default detector · `VoxelGridShape`/octree (only FCL, via `fcl::OcTree`) · distance queries (**FCL-only** — Bullet/ODE/DART `distance()` are warn-and-return stubs).
-- Capability incumbents (verified in-tree, for parity targeting): **distance → FCL only** (`::fcl::distance`; others stub), **raycast → Bullet only** (only `BulletCollisionDetector` overrides `raycast()`; FCL/ODE/DART fall back to the base "not supported"), **VoxelGrid/octree → FCL only**.
+- Detectors: **`dart`** (basic, narrowphase-only, no broadphase/distance/raycast, limited shapes), **`fcl`** (full; **hardcoded default** created in *both* `ConstraintSolver` constructors via `FCLCollisionDetector::create()` - `dart/constraint/ConstraintSolver.cpp:322` & `:342`; core), `ode`, `bullet`.
+- FCL coupling to break: default detector, `VoxelGridShape`/octree (only FCL, via `fcl::OcTree`), distance queries (**FCL-only** - Bullet/ODE/DART `distance()` are warn-and-return stubs).
+- Capability incumbents (verified in-tree, for parity targeting): **distance -> FCL only** (`::fcl::distance`; others stub), **raycast -> Bullet only** (only `BulletCollisionDetector` overrides `raycast()`; FCL/ODE/DART fall back to the base "not supported"), **VoxelGrid/octree -> FCL only**.
 
-## ⚠️ The DART 6 ↔ DART 7 gap (dominant effort/risk)
+## The DART 6 vs DART 7 gap (dominant effort/risk)
 
 The port is **not a copy**:
-1. **EnTT (ECS):** DART 7's `native` (`collision_world`, `comps/`) is built on EnTT — a dependency DART 6.20 does not have. Pulling EnTT in would *add* a dependency (defeats the goal), so the ECS-backed parts must be **reworked to plain C++17** (object-oriented `CollisionGroup`/`CollisionObject`) — significant.
-2. **C++23 → C++17:** DART 7 native uses C++23 idioms; DART 6.20 is C++17 (Ubuntu-LTS policy). Must downgrade (`std::span`, concepts, ranges, etc.).
+1. **EnTT (ECS):** DART 7's `native` (`collision_world`, `comps/`) is built on EnTT - a dependency DART 6.20 does not have. Pulling EnTT in would *add* a dependency (defeats the goal), so the ECS-backed parts must be **reworked to plain C++17** (object-oriented `CollisionGroup`/`CollisionObject`) - significant.
+2. **C++23 -> C++17:** DART 7 native uses C++23 idioms; DART 6.20 is C++17 (Ubuntu-LTS policy). Must downgrade (`std::span`, concepts, ranges, etc.).
 3. **API adaptation:** DART 7's collision API differs from DART 6's `CollisionDetector`/`Group`/`Object`. The native algorithms (GJK/MPR/SAT/SDF — largely pure math on Eigen types) port relatively cleanly; the *world/group/object plumbing* needs rewriting against DART 6's interface.
 
 **Implication:** port the **algorithm core** (broadphase + narrowphase + distance/ccd/raycast/manifolds — Eigen-only math) and re-plumb it behind DART 6's `CollisionDetector`/`CollisionGroup` in C++17 without EnTT.
 
-## gz-physics / gz-sim compatibility matrix (hard constraint — `pixi run -e gazebo test-gz`)
+## gz-physics / gz-sim compatibility matrix (hard constraint - `pixi run -e gazebo test-gz`)
 
 | gz requirement | Evidence | Native-port obligation |
 | --- | --- | --- |
@@ -54,31 +125,116 @@ The port is **not a copy**:
 
 Shape pairs (box/sphere/capsule/cylinder/plane/mesh/convex), **distance queries** (incumbent: **FCL only**), **raycast** (incumbent: **Bullet only**), **CCD**, **persistent manifolds**, and **VoxelGrid/octree** (**FCL only**, via `fcl::OcTree`). Parity bar = **native determinism** (a stable `contact_benchmark` final-state hash with native held fixed) **plus tolerance-based scene-dump diffs** vs the incumbent detectors on the corpus — bit-exact match vs FCL/Bullet/ODE is *not* required (see Risks).
 
-## Evidence-driven performance plan (your bar: native ≥ Bullet/ODE/FCL)
+## Evidence-driven performance plan (native >= Bullet/ODE/FCL)
 
-- **Harness exists:** `examples/contact_benchmark` takes `--collision dart|fcl|bullet|ode` and emits **RTF + final-state hash + contact stats** → same scene, swap detector, compare.
-- **Macro:** parametrize `BM_INTEGRATION_boxes` (currently hardcodes Bullet, `boxes_scene.hpp:91`) across all four detectors; run `contact_benchmark` at 10/30/120 objects × {default, `--disable-deactivation`}.
-- **Micro:** port DART 7 #2688's comparative benchmarks (`bm_narrow_phase`, `bm_stacked_scenes`) for broadphase pairs/s + narrowphase contacts/s.
-- **Success** = perf: RTF(native) ≥ RTF(bullet/ode/fcl); **and** correctness: a stable native final-state hash + tolerance-based scene-dump diffs vs incumbents (per the parity bar — *not* bit-exact hash equality; see the DART 6.20 issue #3056 entries in `CHANGELOG.md`, the rerunnable `examples/contact_benchmark` harness, and Risks).
+Minimum evidence packet before implementation starts:
+
+- Merge #3209 or carry an equivalent local patch for the contact-rich container
+  benchmark.
+- Merge #3230 or carry an equivalent local JSON/HTML capture path so benchmark
+  rows are durable and comparable across commits.
+- Fix local build-cache state before running numbers:
+  `DART_DISABLE_COMPILER_CACHE=ON` or a valid `sccache`/`ccache` executable.
+- Record commit SHAs (`origin/release-6.20`, branch head, and any reference
+  `origin/main` SHA), compiler, CPU/governor, Pixi environment, exact command
+  lines, and whether optional detectors were built.
+
+Macro gates:
+
+- `contact_benchmark`: generated 120/900/3000 shape scenes, `3k_shapes.sdf`,
+  SDF PlaneShape mode, and contact-rich container once #3209 lands.
+- `BM_INTEGRATION_boxes` or successor: parameterized across native/FCL/Bullet/ODE
+  instead of hardcoding Bullet.
+- `BM_INTEGRATION_contact_container`: single-threaded and multi-threaded rows
+  with contacts/resting/mobile summaries.
+- Gazebo-visible scenes: `pixi run -e gazebo test-gz` plus a small
+  `fix/gz-physics-joint-detach-6.20` regression scene when #3227 lands.
+
+Micro gates:
+
+- Port or backport DART 7 #2688-style narrowphase and broadphase benchmarks:
+  pairs/s, contacts/s, manifold update cost, raycast cost, distance-query cost,
+  and mesh/SDF query cost.
+- Use #3229 SIMD only after the scalar implementation is correct and measured;
+  SIMD is an optimization packet, not a substitute for the C++17 port.
+- Profile before optimizing. Require a before/after table for every hot-path
+  change and reject changes that improve RTF by dropping contacts, breaking
+  sleeping, or changing finite-state behavior without an accepted tolerance
+  rationale.
+
+Success means **both**:
+
+- Performance: native RTF and microbenchmark throughput are >= the fastest
+  incumbent detector for each supported capability, or a maintainer-approved
+  exception is recorded before the default flip.
+- Correctness: native is internally deterministic; final state is finite; contact
+  cap, contact pairs, contacts, resting counts, and scene-dump diffs are within
+  documented tolerances against the capability incumbent (FCL for distance and
+  default contacts, Bullet for raycast, existing DART behavior where it is the
+  only incumbent).
 
 ## Phased plan (each phase = its own reviewable PR; gz gate every phase)
 
-0. **This scoping** + stand up the benchmark/parity harness (parametrize `BM_boxes`, port comparative benchmarks). No behavior change.
-1. **Land the native engine** adapted to DART 6 (C++17, **no EnTT**) as an internal library, exposed via the existing `dart` detector (broadphase + core narrowphase). FCL stays default. Unit tests per shape pair.
-2. **Feature parity**: distance, raycast, CCD, manifolds, all shape pairs; correctness = stable native hash + tolerance-based scene-dump diffs vs the **capability's incumbent** (distance vs **FCL**, raycast vs **Bullet**, contacts vs FCL/Bullet/ODE) — not bit-exact hash equality (see Risks).
-3. **Performance**: meet the evidence bar (macro + micro benchmarks); fix hot paths.
-4. **Flip the default** to native in *both* `ConstraintSolver` constructors (`ConstraintSolver.cpp:322` & `:342`) — not just one — and confirm the runtime `setCollisionDetector` path (`:578`) is unaffected; make FCL/Bullet/ODE **optional** (facade or optional components) while keeping gz's `collision-bullet`/`collision-ode` components subclassable + `test-gz` green.
-5. **Decouple FCL from core**: native VoxelGrid/octree path → drop `fcl` from the `dart` target and `DART_PKG_EXTERNAL_DEPS` → **the dependency win** (FCL/Bullet/ODE/ccd no longer required by a default build).
+0. **Evidence harness and queue cleanup.** Land or unblock #3209 and #3230, decide
+   whether #3229 is a prerequisite for native optimization, and capture a
+   baseline packet on current `release-6.20`. No behavior change.
+1. **Native core skeleton.** Port the pure math/native algorithm core to DART 6
+   as C++17 with no EnTT and no new dependency: AABB/broadphase scaffolding,
+   GJK/MPR/SAT primitives, contact data structures, and deterministic tests.
+   Keep it internal; FCL remains default.
+2. **DART 6 detector adapter.** Plumb the native core behind the existing
+   `CollisionDetector`/`CollisionGroup`/`CollisionObject` contracts, initially
+   behind the `dart` detector or a new internal factory alias. Cover primitive,
+   convex, mesh, plane, and SDF/voxel paths. FCL remains default.
+3. **Capability parity.** Add distance, raycast, CCD, persistent manifolds,
+   contact reduction, `CollisionOption.maxNumContactsPerPair`, and VoxelGrid/
+   octree replacement. Gate each capability against its incumbent: FCL for
+   distance/default contacts, Bullet for raycast, and current DART behavior where
+   no other incumbent exists.
+4. **Performance optimization.** Optimize only with measured evidence: data
+   layout, scratch caches, broadphase pair pruning, manifold reuse, scene-local
+   allocation control, optional SIMD from #3229, and thread-safe contact
+   aggregation. Every optimization PR carries parent-vs-PR and detector-vs-
+   detector tables.
+5. **Compatibility facade decision.** Decide whether Bullet/ODE/FCL components
+   stay real optional components or become facade-over-native compatibility
+   components. This phase must prove gz subclassing still works, not just
+   `find_package`.
+6. **Default flip.** Flip native in *both* `ConstraintSolver` constructors
+   (`ConstraintSolver.cpp:322` & `:342`) and confirm runtime
+   `setCollisionDetector` remains unaffected. Require the full A/B packet,
+   `pixi run test-all`, and `pixi run -e gazebo test-gz` before merge.
+7. **FCL decoupling.** Only after the default flip is green, drop FCL from the
+   `dart` target and `DART_PKG_EXTERNAL_DEPS`, move Bullet/ODE/FCL packages out
+   of the default build, and update package/export docs. This is the dependency
+   win.
 
 ## Risks / open questions (for maintainer)
 
 - **EnTT removal + C++23→C++17** is the bulk of the effort; confirm "no new deps" (EnTT must not be introduced).
 - **gz subclassing**: is facade-over-native acceptable for `Bullet/OdeCollisionDetector`, or must Bullet/ODE remain real for gz? (DART 7 used facades; verify gz's `Gz*CollisionDetector` still compiles/links against facades.)
 - **Bit-exact parity** with FCL/Bullet contacts is likely infeasible; agree the correctness bar is the `contact_benchmark` hash *for the native detector held fixed*, plus tolerance-based scene-dump diffs vs incumbents.
-- **LTS risk**: this is a large change on a release branch. Phasing keeps each PR reviewable + gz-gated; default-flip (phase 4) is the point of no return — gate it on the perf evidence + a full Gazebo run.
+- **LTS risk**: this is a large change on a release branch. Phasing keeps each PR reviewable + gz-gated; default-flip (phase 6) is the point of no return - gate it on the perf evidence + a full Gazebo run.
 - **#3114** (FCL null contact when contact generation is disabled — the island-deactivation regression) is **already merged** into `release-6.20` and present in this branch (`e3b76ddf`); no rebase needed, the native port builds on top of it.
 - **Scale**: DART 7 delivered this across PLAN-035 (#2652/#2688/#2700) over months; in 6.20 it's a multi-PR, multi-week initiative even reusing the algorithms.
 
+## Immediate work packet
+
+1. Refresh this dashboard and branch state whenever a release-6.20 PR lands.
+2. Unblock/merge #3209 and #3230, or locally carry their benchmark surfaces for
+   a baseline packet.
+3. Re-run the local A/B command above at larger scale (900 and 3000 generated
+   objects, `3k_shapes.sdf`, and the #3209 container workload) with scene dumps.
+4. Write the baseline packet before porting code. It should include command
+   lines, raw benchmark output, hashes, scene-dump tolerances, CPU metadata, and
+   an explicit "native default allowed/not allowed" verdict.
+5. Start Phase 1 only after the baseline packet is reviewed.
+
 ## Recommendation
 
-Feasible and the right end-state, but **XL**. Recommend starting at **Phase 0** (harness + this scoping) on maintainer go-ahead, then Phase 1 as a standalone PR, re-evaluating after parity (Phase 2) before committing to the default-flip (Phase 4). If 6.20 LTS appetite for a change this large is limited, an alternative is to keep FCL core in 6.20 and target the native default for a **6.21** minor.
+Feasible and the right end-state, but **XL**. The native detector port should
+not start as a default-flip branch. Start with Phase 0 evidence harness and a
+baseline packet, then land Phase 1/2 as internal non-default work. Re-evaluate
+after capability parity and performance optimization before committing to the
+default flip. If 6.20 LTS appetite for a change this large is limited, keep FCL
+core in 6.20 and target the native default for a later 6.x minor.

--- a/docs/dev_tasks/dart6_dependency_minimization/03-native-collision-port-scoping.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/03-native-collision-port-scoping.md
@@ -58,9 +58,9 @@ Live conclusion:
   as historical guardrails, not proof that the full DART 7 native detector is
   ported.
 
-Local A/B probe on this branch (freshly rebuilt `contact_benchmark`, compiler
-cache disabled because the stale build cache pointed to a removed Pixi
-`sccache`):
+Local A/B probe on this branch (freshly rebuilt `contact_benchmark`; stale
+CMake compiler launcher cache entries were cleared because the old build tree
+pointed to a removed Pixi `sccache`):
 
 ```bash
 pixi run ./build/default/cpp/Release/bin/contact_benchmark \
@@ -133,8 +133,10 @@ Minimum evidence packet before implementation starts:
   benchmark.
 - Merge #3230 or carry an equivalent local JSON/HTML capture path so benchmark
   rows are durable and comparable across commits.
-- Fix local build-cache state before running numbers:
-  `DART_DISABLE_COMPILER_CACHE=ON` or a valid `sccache`/`ccache` executable.
+- Fix local build-cache state before running numbers: either configure from a
+  clean build directory, provide a valid `sccache`/`ccache`, or explicitly clear
+  the launcher cache entries with
+  `-DCMAKE_C_COMPILER_LAUNCHER= -DCMAKE_CXX_COMPILER_LAUNCHER=`.
 - Record commit SHAs (`origin/release-6.20`, branch head, and any reference
   `origin/main` SHA), compiler, CPU/governor, Pixi environment, exact command
   lines, and whether optional detectors were built.

--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -12,7 +12,7 @@
 >   names (a project convention; see the naming note in
 >   `02-default-environment-split.md`).
 >
-> _Last updated: 2026-06-22._
+> _Last updated: 2026-07-03._
 
 ## Lanes & owners
 
@@ -20,8 +20,8 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | **In progress — first PR merged (#3123)**; WIP branches continue |
-| **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Merged (incl. #3118 profiling driver) |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | **Planning refresh / evidence gating**; DART 7 native engine not ported, #3123+ performance stack landed |
+| **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Release stack landed through #3199/#3203; use results as guardrails |
 
 ## PR tracker
 
@@ -63,30 +63,63 @@
   → `MERGED`). Dependency-free primitive plane contacts + finite-shape broadphase pruning —
   **first piece** of the native collision port (the FCL/Bullet/ODE-reduction lever); not yet
   the FCL-optional default-flip.
+- Follow-up #3056 release work has landed through #3199/#3203. This resolves the
+  measured headless-performance path, but it does **not** port DART 7
+  `dart/collision/native/` or make FCL optional.
 
 ### 🔄 Open — monitoring
-**No open dependency-minimization PRs** — the work queue is clear; all tracked dep-min PRs
-have merged (see the merged sections above). Next activity is expected from the
-native-collision-port lane's WIP branches (`feature/native-occupancy-grid`,
-`task/native-collision-performance-exec`).
+Open release-6.20 PRs relevant to native collision planning (checked
+2026-07-03):
+
+- **#3230** `docs/dart6-performance-dashboard` — DART 6 performance dashboard,
+  benchmark-history workflow, display/merge/preview scripts, and bounded
+  benchmark surfaces. Treat as a prerequisite or carry an equivalent local
+  artifact path before claiming durable A/B evidence.
+- **#3229** `backport/2490-to-release-6.20` — C++17 SIMD abstraction backport.
+  Useful for native hot-path optimization, not a correctness prerequisite.
+- **#3209** `perf/contact-rich-benchmark-case` — deterministic contact-rich
+  container workload for `contact_benchmark` and `BM_INTEGRATION_contact_container`.
+  This is a required default-flip gate because it catches contact-count/resting
+  drift that simple RTF rows can hide.
+- **#3227** `fix/gz-physics-joint-detach-6.20` and **#3226**
+  `fix/deactivation-final-quiet-gate` — correctness/performance-adjacent release
+  work. Watch them before interpreting gz-visible collision drift.
+
+Related remote heads still visible: `feature/native-occupancy-grid`,
+`task/native-collision-performance-exec`, `docs/dart6-performance-dashboard`,
+`backport/2490-to-release-6.20`, and `fix/gz-physics-joint-detach-6.20`.
 
 _(Note for automated reviewers: a just-merged PR can briefly still show "Open" on its page
 due to GitHub merge-state lag — confirm via `gh pr view <n> --json state` and `git log`
 before treating it as an open/active PR.)_
 
 ### 🛠️ Native-collision-port lane (the largest dependency lever — FCL/Bullet/ODE)
-- **#3123 merged** — first piece (primitive plane contacts + broadphase pruning).
-- WIP branches (no PR yet): `feature/native-occupancy-grid`, `task/native-collision-performance-exec` — expect follow-up PRs.
-- _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`), feature/contact parity, evidence-driven perf ≥ Bullet/ODE/FCL. The FCL-optional default-flip (the actual dependency drop) is still ahead._
+- **Current state:** DART 6.20 has performance/collision-enabling work, but no
+  DART 7 native engine port and no FCL-optional default. `release-6.20` still
+  uses FCL as the default detector.
+- **Local planning evidence:** on branch `plan/dart6-native-collision-port`
+  (`849f22245b7e`), `contact_benchmark --generate-objects 120 --steps 300`
+  produced finite rows for `default`, `dart`, `fcl`, `ode`, and `bullet`.
+  The results prove the harness is usable and also prove speed-only ranking is
+  unsafe: ODE was fastest but ended with zero contacts, while default/FCL shared
+  a hash and DART/Bullet had different contact/resting profiles.
+- **Next expected work:** land or locally carry #3209 and #3230; capture a
+  release-6.20 baseline packet; then start the non-default C++17/no-EnTT native
+  core port. Do not flip defaults until `03`'s full A/B packet and gz gate pass.
+- _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
+  feature/contact parity, evidence-driven perf ≥ Bullet/ODE/FCL, and
+  outcome/hash/scene-dump tolerances. The FCL-optional default-flip (the actual
+  dependency drop) is still ahead._
 
 ## Coordination flags / blockers
 
-1. **Base / conflict status** (base `9b0c68a5a82`+, advancing as PRs merge):
-   - **No real conflicts open.** (#3122's earlier `modify/delete` on the deleted
-     GLUT example was resolved by accepting the deletion, as diagnosed.)
-   - Open PRs routinely fall ~1 behind as the base advances; a maintainer merge-up
+1. **Base / conflict status**:
+   - Current planning baseline: `origin/release-6.20` =
+     `849f22245b7ef11299fa73074c77d6c50b8dda01`; `origin/main` =
+     `c0419111df6e0260169867526dcbccce04353e09`.
+   - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
-   - All owned by the maintainer.
+   - All remote mutations are owned by the maintainer.
 2. **Shared hot files:** `pixi.toml` / `pixi.lock` are touched by multiple lanes —
    **merge `origin/release-6.20` before pushing**, never rebase a published PR branch
    (per `AGENTS.md` / `02`).
@@ -101,10 +134,11 @@ before treating it as an open/active PR.)_
      this lane only flags it rather than acting. (Coverage logs also show benign
      `Cannot generate a safe runtime search path` RPATH warnings across
      pre-existing targets.)
-4. **Native-collision lane: first PR merged (#3123)** — "dependency-free primitive
-   plane contacts + finite-shape broadphase pruning". The largest dependency lever
-   has begun landing; hold each follow-up to `03`'s gz-compat / parity / perf bar.
-   WIP branches `feature/native-occupancy-grid` + `task/native-collision-performance-exec` continue.
+4. **Native-collision lane: plan before port.** The #3056 performance stack is
+   useful evidence, but the DART 7 native port/default-flip is still unstarted
+   on DART 6.20. Do not treat `feature/native-occupancy-grid` or
+   `task/native-collision-performance-exec` as release-branch PRs unless a live
+   PR exists and is based on `release-6.20`.
 
 ## Effort-level status
 
@@ -123,10 +157,11 @@ before treating it as an open/active PR.)_
 - **Just landed (2026-06-22):** legacy `dart/integration` dead-code removal (#3122);
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
-- **Open queue: empty** — all dep-min PRs merged; next from the native-collision WIP branches.
-- **Largest remaining win (started, #3123 merged):** native-collision port → makes
-  FCL/Bullet/ODE optional and eventually drops `fcl` from core. The default-flip
-  (the actual dependency drop) is still ahead, via the WIP branches' follow-up PRs.
+- **Open queue: active again** — #3209, #3229, #3230, #3226, and #3227 all affect
+  how native-collision evidence should be gathered or interpreted.
+- **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE
+  optional and eventually drops `fcl` from core. The DART 7 native engine is not
+  yet ported to DART 6.20; default-flip is still a late-phase decision.
 - **Confirmed non-removable standalone:** `boost` (OSG-coupled), core deps
   (Eigen/assimp/fmt/tinyxml2/urdfdom), `octomap` (exported-header contract).
 

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -7,6 +7,8 @@ This task is for the DART 6.20 support lane.
 - Implementation branch:
   `plan/dart6-dependency-minimization-6.20`, based on
   `origin/release-6.20`.
+- Native-collision planning refresh branch:
+  `plan/dart6-native-collision-port`, based on `origin/release-6.20`.
 - DART 7 reference: use `origin/main` directly, or create a local worktree from
   `origin/main` for comparisons. Do not rely on a developer-specific checkout
   path.
@@ -14,17 +16,20 @@ This task is for the DART 6.20 support lane.
   `origin/main` or remote refs (or your own separate `main` worktree) as
   comparison evidence only.
 
-Evidence was collected on 2026-06-19 after fetching `origin/main`,
-`origin/release-6.20`, and `origin/release-6.19`.
+Evidence was first collected on 2026-06-19 after fetching `origin/main`,
+`origin/release-6.20`, and `origin/release-6.19`. The native-collision port
+evidence in `03-native-collision-port-scoping.md` and the dashboard state in
+`04-orchestration-dashboard.md` were refreshed on 2026-07-03 after fetching
+`origin/main` and `origin/release-6.20`.
 
 ## Current Branch State
 
-- `origin/release-6.20` currently points at `b94cd16f6eb` (`Plan DART 6.20
-  dependency minimization (#3074)`).
-- `package.xml` and `pixi.toml` on `origin/release-6.20` still report version
-  `6.19.2`.
-- DART 6.20 is intentionally using the release lane before the package version
-  metadata bump lands.
+- `origin/release-6.20` currently points at
+  `849f22245b7ef11299fa73074c77d6c50b8dda01`.
+- `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x
+  package version (`6.19.3` in the current CMake configure output).
+- DART 6.20 intentionally uses the release lane while package version metadata
+  catches up to the branch/milestone naming.
 
 ## DART 6 Dependency Inventory
 

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -33,12 +33,14 @@ evidence in `03-native-collision-port-scoping.md` and the dashboard state in
 
 ## DART 6 Dependency Inventory
 
-`package.xml` on `release-6.20` lists these package dependencies:
+`package.xml` on `release-6.20` currently lists these package dependencies:
 
 - Required or exported build dependencies: `assimp`, `eigen`, `libfcl-dev`,
   `liburdfdom-dev`, and `tinyxml2`.
 - Optional or component-related package dependencies that are still advertised:
-  `bullet`, `glut`, `libxi-dev`, and `libxmu-dev`.
+  `bullet`.
+- Already removed from the package manifest on this baseline: `glut`,
+  `libxi-dev`, and `libxmu-dev`.
 
 `pixi.toml` on `release-6.20` keeps a broad default environment. The important
 project dependencies include:
@@ -47,20 +49,23 @@ project dependencies include:
   `urdfdom`, `tinyxml2`, and optional `spdlog`.
 - Collision and constraint ecosystem dependencies: `bullet-cpp`, `libode`,
   `octomap`, and `fcl`.
-- GUI dependencies: `openscenegraph`, `freeglut`, OpenGL/GLU packages, and
-  `imgui`.
-- Optimizer dependencies: `ipopt`, `nlopt`, and `pagmo-devel`.
+- GUI dependencies: `openscenegraph`, `imgui`, and the OSG/OpenGL stack pulled
+  through those packages.
+- Already removed from the default Pixi environment on this baseline:
+  `freeglut`, `ipopt`, `nlopt`, and `pagmo-devel`.
 - Test, build, and docs tools: CMake, Ninja, GoogleTest, Google Benchmark,
   Doxygen, Sphinx, pytest, and related Python tooling.
 
 CMake on `release-6.20` makes `fmt`, Eigen, FCL, and Assimp part of the core
-configure/build path. Bullet, ODE, GUI, optimizer backends, OctoMap, and ImGui
-are component or feature surfaces, but the default Pixi environment makes many
-of them available by default.
+configure/build path. Bullet, ODE, GUI, OctoMap, and ImGui are component or
+feature surfaces, but the default Pixi environment still makes many of them
+available by default.
 
 ## DART 6 `dart/external` Inventory
 
-`release-6.20` started with these vendored source trees:
+`release-6.20` started with these vendored source trees; the current baseline
+has retired the top-level `dart/external/` source directory, but the list is
+kept here as historical task context:
 
 - `dart/external/convhull_3d`
 - `dart/external/ikfast`
@@ -70,16 +75,16 @@ of them available by default.
 
 Usage summary:
 
-- `convhull_3d` was included by the math geometry implementation. The first
-  implementation slice replaces it with DART-owned native math detail code.
-- `ikfast` is included by DART's IKFast wrapper, generated WAM examples, and
-  integration tests.
-- `imgui` provides the DART 6 `external-imgui` compatibility component from
+- `convhull_3d` was included by the math geometry implementation and has been
+  replaced by DART-owned native math detail code.
+- `ikfast` moved to DART's dynamics path with a compatibility forwarding
+  header for the old installed include path.
+- `imgui` now provides the DART 6 `external-imgui` compatibility component from
   the system package by default, including headless package builds, and uses a
   DART-patched fetched copy when `DART_USE_SYSTEM_IMGUI` is disabled.
-- `lodepng` is used by the GLUT screenshot path.
-- `odelcpsolver` was included by core constraint, contact, boxed LCP, Dantzig,
-  PGS, and default `World` solver paths.
+- `lodepng` was removed with the GLUT screenshot path.
+- `odelcpsolver` was replaced in production by DART-owned LCP solver code, with
+  legacy ODE code retained only where needed as test baseline material.
 
 ## DART 7 Reference State
 
@@ -151,8 +156,9 @@ Default Pixi/package metadata for optional components
 - Plan: move optional packages out of the default path one at a time only after
   proving the default configure still succeeds and explicit feature/component
   environments keep their tests.
-- Candidates for feature-only treatment before code removal: Bullet, ODE, GUI
-  packages, optimizer packages, and OctoMap.
+- Remaining candidates for feature-only treatment before code removal: Bullet,
+  ODE, GUI packages, and OctoMap. Optimizer packages were already removed from
+  the default environment.
 - Validation: default configure/build, explicit feature configure/build for each
   moved surface, package-component smoke tests, and Gazebo when the change is
   visible to downstream package discovery.


### PR DESCRIPTION
## Summary

- Refresh the DART 6.20 native collision detector port plan with current branch, PR, issue, and remote-branch evidence.
- Record a small local detector A/B probe from `contact_benchmark` and use it to require correctness/outcome gates alongside performance gates.
- Update the dependency-minimization dashboard so the native-collision queue no longer appears empty and the next work is sequenced through benchmark/dashboard prerequisites before any default flip.

## Motivation / Problem

The previous planning docs were stale: they still described the native-collision work as early scoping with no live queue, even though DART 6.20 has since landed a substantial #3056 performance stack and now has open release-branch PRs that affect how native-collision evidence should be collected.

The important distinction for maintainers is that the #3056/#3123+ performance stack improves DART 6 collision-heavy scenarios, but it does not port DART 7 `dart/collision/native/` to DART 6 and does not make FCL optional. This PR makes that distinction explicit and sets evidence gates before native implementation, optimization, default flip, or FCL decoupling work.

## Changes / Key Changes

- Refresh `03-native-collision-port-scoping.md` with:
  - current `origin/release-6.20` and `origin/main` SHAs;
  - related remote branches and live PRs (#3209, #3229, #3230, #3226, #3227);
  - related issue/PR context for #3056, #3199, #3203, and DART 7 native references (#2652, #2688, #2700);
  - local A/B results for `default`, `dart`, `fcl`, `ode`, and `bullet` on the same generated workload;
  - phased gates for baseline evidence, C++17/no-EnTT porting, parity, optimization, gz compatibility, default flip, and FCL decoupling.
- Refresh `04-orchestration-dashboard.md` so the live status board tracks the active release-6.20 native-collision-adjacent queue and does not treat WIP branches as release PRs without a live PR.
- Refresh `README.md` branch-state metadata for the planning refresh branch and current release baseline.

## Testing

- `pixi run ./build/default/cpp/Release/bin/contact_benchmark --help`
- `pixi run ./build/default/cpp/Release/bin/contact_benchmark --generate-objects 120 --steps 300 --warmup 0 --checkpoint 0 --quiet --collision dart --world-threads 1 --max-contacts 20000`
- `pixi run ./build/default/cpp/Release/bin/contact_benchmark --generate-objects 120 --steps 300 --warmup 0 --checkpoint 0 --quiet --collision fcl --world-threads 1 --max-contacts 20000`
- `pixi run ./build/default/cpp/Release/bin/contact_benchmark --generate-objects 120 --steps 300 --warmup 0 --checkpoint 0 --quiet --collision ode --world-threads 1 --max-contacts 20000`
- `pixi run ./build/default/cpp/Release/bin/contact_benchmark --generate-objects 120 --steps 300 --warmup 0 --checkpoint 0 --quiet --collision bullet --world-threads 1 --max-contacts 20000`
- `pixi run ./build/default/cpp/Release/bin/contact_benchmark --generate-objects 120 --steps 300 --warmup 0 --checkpoint 0 --quiet --collision default --world-threads 1 --max-contacts 20000`
- `pixi run lint`
- `git diff --check`

Notes:

- The local Release CMake cache initially pointed at removed Pixi tools (`sccache` and `clang-format-22`). I repaired the local cache by clearing the stale compiler-launcher entries for the benchmark build and pointing CMake at the available Pixi `clang-format`; no tracked build/config files were changed.
- This is docs-only planning; no C++/Python behavior changed.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Related issue: #3056
- Related release PRs: #3123, #3199, #3203, #3209, #3226, #3227, #3229, #3230
- Related DART 7 reference PRs: #2652, #2688, #2700

---

#### Checklist

- [x] Milestone set: DART 6.20.0
- [x] CHANGELOG.md updated if required: N/A, docs-only planning update
- [x] Add unit tests for new functionality: N/A, no code behavior changed
- [x] Document new methods and classes: N/A, no new API
- [x] Add Python bindings (dartpy) if applicable: N/A, no bindings changed

