### PR TITLE
Preserve protected CI runs under concurrency

### DIFF
--- a/.github/workflows/ci_altlinux.yml
+++ b/.github/workflows/ci_altlinux.yml
@@ -11,7 +11,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Scheduled coverage runs should not replace pending validation runs.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group for schedules while keeping manual runs cancellable.
+  group: >-
+    ${{ github.event_name == 'schedule'
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:

--- a/.github/workflows/ci_altlinux.yml
+++ b/.github/workflows/ci_altlinux.yml
@@ -11,14 +11,17 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Scheduled coverage runs should not replace pending validation runs.
+  # Protected release-branch and scheduled runs should not replace pending
+  # validation runs.
   # GitHub's default concurrency queue keeps only one pending run, so use a
-  # run-specific group for schedules while keeping manual runs cancellable.
+  # run-specific group for preserved refs while keeping manual runs cancellable.
   group: >-
-    ${{ github.event_name == 'schedule'
+    ${{ (github.event_name == 'schedule' || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   altlinux:

--- a/.github/workflows/ci_cuda.yml
+++ b/.github/workflows/ci_cuda.yml
@@ -33,7 +33,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch runs should not replace pending validation runs.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group on main while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ github.ref == 'refs/heads/main'
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:

--- a/.github/workflows/ci_cuda.yml
+++ b/.github/workflows/ci_cuda.yml
@@ -33,14 +33,16 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch runs should not replace pending validation runs.
+  # Protected main/release-branch runs should not replace pending validation runs.
   # GitHub's default concurrency queue keeps only one pending run, so use a
-  # run-specific group on main while keeping PR/topic refs cancellable.
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ github.ref == 'refs/heads/main'
+    ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -6,14 +6,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch and scheduled runs should not replace pending validation.
+  # Protected main/release-branch and scheduled runs should not replace pending
+  # validation.
   # GitHub's default concurrency queue keeps only one pending run, so use a
   # run-specific group for preserved refs while keeping manual runs cancellable.
   group: >-
-    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    ${{ (github.event_name == 'schedule'
+        || github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   freebsd:

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -6,20 +6,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main/release-branch and scheduled runs should not replace pending
-  # validation.
-  # GitHub's default concurrency queue keeps only one pending run, so use a
-  # run-specific group for preserved refs while keeping manual runs cancellable.
-  group: >-
-    ${{ (github.event_name == 'schedule'
-        || github.ref == 'refs/heads/main'
-        || startsWith(github.ref, 'refs/heads/release-'))
-        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
-        || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: >-
-    ${{ github.event_name != 'schedule'
-        && github.ref != 'refs/heads/main'
-        && !startsWith(github.ref, 'refs/heads/release-') }}
+  # The Docker-backed FreeBSD harness uses a fixed VM container name
+  # (`dart-freebsd-vm`), so all runs must serialize instead of running in
+  # independent run-specific groups.
+  group: ${{ github.workflow }}-vm-container
+  queue: max
+  cancel-in-progress: false
 
 jobs:
   freebsd:

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -6,7 +6,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch and scheduled runs should not replace pending validation.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group for preserved refs while keeping manual runs cancellable.
+  group: >-
+    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci_gz_dart6.yml
+++ b/.github/workflows/ci_gz_dart6.yml
@@ -24,13 +24,15 @@ permissions:
   contents: read
 
 concurrency:
-  # Scheduled DART 6 canaries should not replace pending scheduled runs.
-  # Manual dispatches keep the same group and continue to supersede each other.
+  # Scheduled DART 6 canaries and protected release-branch manual runs should
+  # not replace pending validation.
   group: >-
-    ${{ github.event_name == 'schedule'
+    ${{ (github.event_name == 'schedule' || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   gz-canary:

--- a/.github/workflows/ci_gz_dart6.yml
+++ b/.github/workflows/ci_gz_dart6.yml
@@ -24,7 +24,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Scheduled DART 6 canaries should not replace pending scheduled runs.
+  # Manual dispatches keep the same group and continue to supersede each other.
+  group: >-
+    ${{ github.event_name == 'schedule'
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:

--- a/.github/workflows/ci_gz_physics.yml
+++ b/.github/workflows/ci_gz_physics.yml
@@ -12,7 +12,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch and scheduled runs should not replace pending canaries.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci_gz_physics.yml
+++ b/.github/workflows/ci_gz_physics.yml
@@ -12,14 +12,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch and scheduled runs should not replace pending canaries.
+  # Protected main/release-branch and scheduled runs should not replace pending
+  # canaries.
   # GitHub's default concurrency queue keeps only one pending run, so use a
   # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    ${{ (github.event_name == 'schedule'
+        || github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   changes:

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -13,7 +13,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch runs should not replace pending lint/doc validations.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group on main while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ github.ref == 'refs/heads/main'
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -13,14 +13,17 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch runs should not replace pending lint/doc validations.
+  # Protected main/release-branch runs should not replace pending lint/doc
+  # validations.
   # GitHub's default concurrency queue keeps only one pending run, so use a
-  # run-specific group on main while keeping PR/topic refs cancellable.
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ github.ref == 'refs/heads/main'
+    ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   lint:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -17,7 +17,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch and scheduled runs should not replace pending validation.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -17,14 +17,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch and scheduled runs should not replace pending validation.
+  # Protected main/release-branch and scheduled runs should not replace pending
+  # validation.
   # GitHub's default concurrency queue keeps only one pending run, so use a
   # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    ${{ (github.event_name == 'schedule'
+        || github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   changes:

--- a/.github/workflows/ci_simd.yml
+++ b/.github/workflows/ci_simd.yml
@@ -23,14 +23,16 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch runs should not replace pending validation runs.
+  # Protected main/release-branch runs should not replace pending validation runs.
   # GitHub's default concurrency queue keeps only one pending run, so use a
-  # run-specific group on main while keeping PR/topic refs cancellable.
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ github.ref == 'refs/heads/main'
+    ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   simd-x86-levels:

--- a/.github/workflows/ci_simd.yml
+++ b/.github/workflows/ci_simd.yml
@@ -23,7 +23,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch runs should not replace pending validation runs.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group on main while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ github.ref == 'refs/heads/main'
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -14,14 +14,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch and scheduled runs should not replace pending validation.
+  # Protected main/release-branch and scheduled runs should not replace pending
+  # validation.
   # GitHub's default concurrency queue keeps only one pending run, so use a
   # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    ${{ (github.event_name == 'schedule'
+        || github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   changes:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -14,7 +14,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch and scheduled runs should not replace pending validation.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -17,7 +17,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch and scheduled runs should not replace pending validation.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -17,14 +17,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Protected main-branch and scheduled runs should not replace pending validation.
+  # Protected main/release-branch and scheduled runs should not replace pending
+  # validation.
   # GitHub's default concurrency queue keeps only one pending run, so use a
   # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    ${{ (github.event_name == 'schedule'
+        || github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   changes:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,13 @@ permissions:
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Protected main-branch and scheduled runs should not replace pending scans.
+  # GitHub's default concurrency queue keeps only one pending run, so use a
+  # run-specific group for preserved refs while keeping PR/topic refs cancellable.
+  group: >-
+    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,14 +37,20 @@ permissions:
   security-events: write
 
 concurrency:
-  # Protected main-branch and scheduled runs should not replace pending scans.
+  # Protected main/release-branch and scheduled runs should not replace pending
+  # scans.
   # GitHub's default concurrency queue keeps only one pending run, so use a
   # run-specific group for preserved refs while keeping PR/topic refs cancellable.
   group: >-
-    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    ${{ (github.event_name == 'schedule'
+        || github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
         || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   matrix_prep:

--- a/.github/workflows/performance_dashboard.yml
+++ b/.github/workflows/performance_dashboard.yml
@@ -33,6 +33,7 @@ permissions:
 
 concurrency:
   group: performance-dashboard
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -18,13 +18,18 @@ name: Publish dartpy
 concurrency:
   # Include the event name so a manual workflow_dispatch publish is not
   # cancelled by a push-triggered wheel build of the same ref.
-  # Protected main-branch and scheduled runs should not replace pending wheel
-  # runs, so include the run id only for refs that must be preserved.
+  # Protected main/release-branch and scheduled runs should not replace pending
+  # wheel runs, so include the run id only for refs that must be preserved.
   group: >-
-    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+    ${{ (github.event_name == 'schedule'
+        || github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release-'))
         && format('{0}-{1}-{2}-{3}', github.workflow, github.ref, github.event_name, github.run_id)
         || format('{0}-{1}-{2}', github.workflow, github.ref, github.event_name) }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
 jobs:
   changes:

--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -18,7 +18,12 @@ name: Publish dartpy
 concurrency:
   # Include the event name so a manual workflow_dispatch publish is not
   # cancelled by a push-triggered wheel build of the same ref.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  # Protected main-branch and scheduled runs should not replace pending wheel
+  # runs, so include the run id only for refs that must be preserved.
+  group: >-
+    ${{ (github.event_name == 'schedule' || github.ref == 'refs/heads/main')
+        && format('{0}-{1}-{2}-{3}', github.workflow, github.ref, github.event_name, github.run_id)
+        || format('{0}-{1}-{2}', github.workflow, github.ref, github.event_name) }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -13,6 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  queue: max
   cancel-in-progress: false
 
 jobs:
@@ -47,6 +48,7 @@ jobs:
     needs: discover-base-branches
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.base }}
+      queue: max
       cancel-in-progress: false
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,6 +325,9 @@ compatibility remains on the active DART 6 LTS branch._
   redundant branch-push core tier once a PR is open; branch protection now
   requires the stable aggregate `Wheels` check instead of stale per-leg wheel
   names.
+- Preserved protected `main` and scheduled CI validation runs under GitHub
+  Actions concurrency by giving protected refs run-specific groups and using
+  explicit multi-pending queues for serialized maintenance workflows.
 
 ## DART 6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,9 +325,9 @@ compatibility remains on the active DART 6 LTS branch._
   redundant branch-push core tier once a PR is open; branch protection now
   requires the stable aggregate `Wheels` check instead of stale per-leg wheel
   names.
-- Preserved protected `main` and scheduled CI validation runs under GitHub
-  Actions concurrency by giving protected refs run-specific groups and using
-  explicit multi-pending queues for serialized maintenance workflows.
+- Preserved protected `main`, `release-*`, and scheduled CI validation runs
+  under GitHub Actions concurrency by giving protected refs run-specific groups
+  and using explicit multi-pending queues for serialized maintenance workflows.
   ([#3235](https://github.com/dartsim/dart/pull/3235))
 
 ## DART 6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Preserved protected `main` and scheduled CI validation runs under GitHub
   Actions concurrency by giving protected refs run-specific groups and using
   explicit multi-pending queues for serialized maintenance workflows.
+  ([#3235](https://github.com/dartsim/dart/pull/3235))
 
 ## DART 6
 

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -384,7 +384,9 @@ concurrency:
         && !startsWith(github.ref, 'refs/heads/release-') }}
 
 # For workflows with matrix jobs that serialize writes to fixed branches
-# (e.g., update_lockfiles), keep a stable group and request the full queue.
+# (e.g., update_lockfiles) or jobs that use a fixed external resource
+# (e.g., the Docker-backed FreeBSD VM container), keep a stable group and
+# request the full queue.
 concurrency:
   group: ${{ github.workflow }}-${{ matrix.base }}
   queue: max

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -354,21 +354,41 @@ Guardrails:
 
 **Concurrency configuration:**
 
-All CI workflows use concurrency groups to cancel in-progress jobs when new commits are pushed to the same branch, with exceptions:
+CI workflows cancel superseded topic-branch and PR runs, but protected
+validation runs must finish:
 
-- **main branch**: Never cancelled (ensure full test coverage)
-- **scheduled jobs**: Never cancelled (ensure periodic validation completes)
+- **main and release branches**: preserve every post-merge validation run
+- **scheduled jobs**: preserve every periodic validation run
+
+GitHub's default concurrency queue keeps only one pending run per group. Setting
+`cancel-in-progress: false` prevents active-run cancellation, but a newer
+pending run can still replace an older pending run unless the workflow uses an
+explicit multi-pending queue or a run-specific group. Because `queue: max` cannot
+be combined with `cancel-in-progress: true`, shared workflows use run-specific
+groups only for protected refs and schedules while keeping a stable cancellable
+group for topic refs.
 
 ```yaml
-# Standard pattern for push/PR-triggered workflows
+# Standard pattern for workflows that should cancel topic refs but preserve
+# protected post-merge and scheduled validation.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'schedule' && github.ref != 'refs/heads/main' }}
+  group: >-
+    ${{ (github.event_name == 'schedule'
+         || github.ref == 'refs/heads/main'
+         || startsWith(github.ref, 'refs/heads/release-'))
+        && format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id)
+        || format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'schedule'
+        && github.ref != 'refs/heads/main'
+        && !startsWith(github.ref, 'refs/heads/release-') }}
 
-# For workflows with matrix that push to fixed branches (e.g., update_lockfiles)
+# For workflows with matrix jobs that serialize writes to fixed branches
+# (e.g., update_lockfiles), keep a stable group and request the full queue.
 concurrency:
   group: ${{ github.workflow }}-${{ matrix.base }}
-  cancel-in-progress: false  # Queue instead of cancel/race
+  queue: max
+  cancel-in-progress: false
 ```
 
 **Maintain full test coverage:**


### PR DESCRIPTION
## Summary

- Preserve protected `main` and scheduled CI validation runs under GitHub Actions concurrency.
- Add explicit multi-pending queues for serialized maintenance workflows.
- Document the concurrency rule so future workflow edits do not rely on GitHub Actions single-pending defaults.

## Motivation / Problem

- Follow-up investigation after #3222/#3223 showed that `cancel-in-progress: false` prevents active-run cancellation but does not preserve every pending protected run.
- GitHub Actions keeps only one pending run per concurrency group by default, so newer protected `main` or scheduled runs can replace older pending validation.
- `queue: max` cannot be combined with `cancel-in-progress: true`, so shared PR/protected workflows need different grouping for preserved refs versus cancellable topic refs.

## Changes / Key Changes

- Give protected `main` and scheduled runs run-specific concurrency groups while keeping topic and PR refs cancellable.
- Add `queue: max` to serialized maintenance workflows that always use `cancel-in-progress: false`.
- Update `docs/onboarding/ci-cd.md` with the correct protected-run and queue guidance.
- Add the DART 7 changelog entry.

## Testing

- `git diff --check`
- Parsed the changed workflow YAML files with `pixi run python` and `yaml.safe_load(...)`.
- `pixi run lint`
- `pixi run check-lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3222 and #3223.
- DART 6 LTS companion: #3233.

---

#### Checklist

- [x] Milestone set (`DART 7.0` for `main`)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Unit tests not applicable (workflow/docs-only change)
- [x] New API docs not applicable
- [x] Python bindings not applicable
