### PR TITLE
Fix release SIMD trait on MSVC

### DIFF
--- a/dart/simd/fwd.hpp
+++ b/dart/simd/fwd.hpp
@@ -78,27 +78,47 @@ inline constexpr bool is_valid_width_v
 
 namespace detail {
 
+// Check whether width is static before evaluating its value. MSVC reports a
+// hard error for non-static V::width unless the value probe is staged.
+template <typename V, typename = void>
+struct HasStaticWidthMember : std::false_type
+{
+};
+
+template <typename V>
+struct HasStaticWidthMember<V, std::void_t<decltype(&V::width)>>
+  : std::bool_constant<!std::is_member_object_pointer_v<decltype(&V::width)>>
+{
+};
+
+template <typename V>
+using StaticWidthConstant
+    = std::integral_constant<std::size_t, static_cast<std::size_t>(V::width)>;
+
+template <typename V, typename = void, bool = HasStaticWidthMember<V>::value>
+struct HasValidStaticWidth : std::false_type
+{
+};
+
+template <typename V>
+struct HasValidStaticWidth<V, std::void_t<StaticWidthConstant<V>>, true>
+  : std::bool_constant<
+        std::is_convertible_v<
+            decltype(V::width),
+            std::size_t> && is_valid_width_v<StaticWidthConstant<V>::value>>
+{
+};
+
 template <typename V, typename = void>
 struct IsVecTrait : std::false_type
 {
 };
 
-// The integral_constant probe keeps V::width inside the SFINAE context: a
-// width member that is not a constant expression must yield false (as the
-// DART 7 concept does), not a hard error.
 template <typename V>
-struct IsVecTrait<
-    V,
-    std::void_t<
-        typename V::scalar_type,
-        decltype(V::width),
-        std::
-            integral_constant<std::size_t, static_cast<std::size_t>(V::width)>>>
+struct IsVecTrait<V, std::void_t<typename V::scalar_type>>
   : std::bool_constant<
-        std::is_convertible_v<
-            decltype(V::width),
-            std::
-                size_t> && is_scalar_type_v<typename V::scalar_type> && is_valid_width_v<static_cast<std::size_t>(V::width)>>
+        is_scalar_type_v<
+            typename V::scalar_type> && HasValidStaticWidth<V>::value>
 {
 };
 

--- a/dart/simd/fwd.hpp
+++ b/dart/simd/fwd.hpp
@@ -78,16 +78,17 @@ inline constexpr bool is_valid_width_v
 
 namespace detail {
 
-// Check whether width is static before evaluating its value. MSVC reports a
-// hard error for non-static V::width unless the value probe is staged.
+// Check for non-static width members before evaluating the value. MSVC reports
+// a hard error for non-static V::width unless the value probe is staged, while
+// enum width constants are valid but not addressable.
 template <typename V, typename = void>
-struct HasStaticWidthMember : std::false_type
+struct HasNonStaticWidthMember : std::false_type
 {
 };
 
 template <typename V>
-struct HasStaticWidthMember<V, std::void_t<decltype(&V::width)>>
-  : std::bool_constant<!std::is_member_object_pointer_v<decltype(&V::width)>>
+struct HasNonStaticWidthMember<V, std::void_t<decltype(&V::width)>>
+  : std::is_member_object_pointer<decltype(&V::width)>
 {
 };
 
@@ -95,13 +96,13 @@ template <typename V>
 using StaticWidthConstant
     = std::integral_constant<std::size_t, static_cast<std::size_t>(V::width)>;
 
-template <typename V, typename = void, bool = HasStaticWidthMember<V>::value>
+template <typename V, typename = void, bool = HasNonStaticWidthMember<V>::value>
 struct HasValidStaticWidth : std::false_type
 {
 };
 
 template <typename V>
-struct HasValidStaticWidth<V, std::void_t<StaticWidthConstant<V>>, true>
+struct HasValidStaticWidth<V, std::void_t<StaticWidthConstant<V>>, false>
   : std::bool_constant<
         std::is_convertible_v<
             decltype(V::width),

--- a/tests/unit/simd/test_config.cpp
+++ b/tests/unit/simd/test_config.cpp
@@ -52,6 +52,20 @@ struct NonConstantWidth
   std::size_t width;
 };
 
+struct RuntimeStaticWidth
+{
+  using scalar_type = float;
+  static std::size_t width;
+};
+
+std::size_t RuntimeStaticWidth::width = 4;
+
+struct InvalidWidth
+{
+  using scalar_type = float;
+  static constexpr std::size_t width = 3;
+};
+
 struct NonConstMask
 {
   using scalar_type = float;
@@ -85,6 +99,11 @@ static_assert(!is_vec_v<int>, "int must not satisfy is_vec_v");
 static_assert(
     !is_vec_v<NonConstantWidth>,
     "a non-constant width member must yield false, not a hard error");
+static_assert(
+    !is_vec_v<RuntimeStaticWidth>,
+    "a runtime static width member must yield false, not a hard error");
+static_assert(
+    !is_vec_v<InvalidWidth>, "invalid vector widths must be rejected");
 static_assert(is_vec_mask_v<VecMask4f>, "VecMask4f must satisfy is_vec_mask_v");
 static_assert(!is_vec_mask_v<int>, "int must not satisfy is_vec_mask_v");
 static_assert(

--- a/tests/unit/simd/test_config.cpp
+++ b/tests/unit/simd/test_config.cpp
@@ -66,6 +66,15 @@ struct InvalidWidth
   static constexpr std::size_t width = 3;
 };
 
+struct EnumWidth
+{
+  using scalar_type = float;
+  enum
+  {
+    width = 4
+  };
+};
+
 struct NonConstMask
 {
   using scalar_type = float;
@@ -104,6 +113,8 @@ static_assert(
     "a runtime static width member must yield false, not a hard error");
 static_assert(
     !is_vec_v<InvalidWidth>, "invalid vector widths must be rejected");
+static_assert(
+    is_vec_v<EnumWidth>, "enum width constants must remain supported");
 static_assert(is_vec_mask_v<VecMask4f>, "VecMask4f must satisfy is_vec_mask_v");
 static_assert(!is_vec_mask_v<int>, "int must not satisfy is_vec_mask_v");
 static_assert(


### PR DESCRIPTION
## Summary

- Fix the C++17 SIMD vector trait backport so MSVC treats non-static or runtime `width` members as a false trait result instead of instantiating an invalid cast.

## Motivation / Problem

- Post-merge release-branch CI for #3233 and the current `release-6.20` head fails in CI Windows while compiling `UNIT_simd_config`.
- The failure is `dart/simd/fwd.hpp(101): error C2440: 'static_cast': cannot convert from 'unknown' to 'size_t'` when evaluating `is_vec_v<NonConstantWidth>` under MSVC.

## Changes / Key Changes

- Split the C++17 `is_vec_v` implementation into staged helpers that first detect whether `width` is a static member, then evaluate the constexpr width value only in that static-member path.
- Add compile-time regression checks for non-static width, runtime static width, and invalid constexpr width cases.

## Testing

- `pixi run lint`
- `pixi run build-tests`
- `pixi run ./build/default/cpp/Release/tests/unit/simd/UNIT_simd_config`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to release-branch CI exposed after #3233 preserved release runs.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [ ] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable
