### PR TITLE
Add discover-unknowns discipline to AI principles and orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,12 @@ compatibility remains on the active DART 6 LTS branch._
   material rather than an installed workflow, keeping agent plans, packets,
   dev-task acceptance evidence, and gates in DART-owned docs.
   ([#3054](https://github.com/dartsim/dart/pull/3054))
+- Added a "discover your unknowns before committing" discipline to the AI
+  operating docs: `docs/ai/principles.md` Axiom 2 now covers surfacing unknowns
+  (the map-is-not-the-territory framing) and `docs/ai/orchestration.md` owns a
+  method catalog — blind-spot review, throwaway spike, requirements interview,
+  and reference map — each mapped to a public path, so agents resolve unknowns
+  before large work instead of encoding guesses into a plan.
 
 #### Tests, Benchmarks, and Quality Gates
 

--- a/docs/ai/orchestration.md
+++ b/docs/ai/orchestration.md
@@ -85,11 +85,47 @@ For small direct changes, it may be implicit in the issue, prompt, and final
 verification evidence.
 
 If an orchestrator or executor cannot name the acceptance evidence before
-editing, the next step is a planning, clarification, or spike packet, not a
-best-effort implementation. If a choice would materially change public API,
+editing, the next step is a planning, clarification, or spike packet (see
+"Discovering unknowns before committing" below), not a best-effort
+implementation. If a choice would materially change public API,
 release compatibility, numerical correctness, benchmark claims, or roadmap
 scope, record an owner-local `Decision needed` block instead of silently
 choosing.
+
+## Discovering unknowns before committing
+
+Specification intake only works when the map matches the territory. Your plan,
+context, and prompts are the map; the real code, tests, and requirements are
+the territory, and the gap between them is the work's unknowns. Before authoring
+or claiming a substantial packet, spend effort converting consequential unknowns
+into knowns instead of encoding guesses into a plan. A packet built on
+unexplored territory is not ready, however precise its wording looks.
+
+Four DART-native methods, each usable without a specific AI tool:
+
+- **Blind-spot review** — an independent pass, in a different session than the
+  one drafting the work, that answers "what is missing, wrong, or unstated
+  here?" against the plan and the code it touches. This is the authoring/review
+  separation above applied before implementation; route it through
+  `dart-analyze` or a read-only reviewer.
+- **Throwaway spike** — a time-boxed prototype on a scratch branch whose output
+  is knowledge, not merged code. Use it to make the territory visible (does the
+  API allow this, where does the real scope land) before the plan hardens, then
+  fold the findings back into the packet and discard the spike.
+- **Requirements interview** — let the agent interview the maintainer to pull
+  out intent, constraints, and non-goals that were never written down, answering
+  the intake questions above from the human rather than from a guess. Reserve it
+  for consequential ambiguity; short instructions in a well-prepared repo need
+  no interview.
+- **Reference map** — ground the work in authoritative references (the
+  `docs/readthedocs/papers.md` catalog via `dart-references`, design docs, or an
+  existing baseline in the code) instead of reconstructing behavior from memory.
+
+Blind-spot review and reference map route through `dart-analyze` and
+`dart-references`; the throwaway spike and the requirements interview are
+intentionally manual (a scratch branch, a conversation) with no dedicated
+workflow. Prefer the lightest method that resolves the unknown, and record what
+it resolved as the packet's assumptions-and-open-decisions evidence.
 
 ## Sizing rules
 

--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -23,9 +23,14 @@ the owner docs above.
 1. **Mission before motion.** Read enough context to understand the DART north
    star, current owner docs, and verification bar before substantial work. If a
    request conflicts with those rules, surface the tradeoff before editing.
-2. **Assumptions must be visible.** Do not silently choose between materially
-   different interpretations. State the assumption, ask when the decision is
-   consequential, and record the evidence when the repo answers it.
+2. **Assumptions and unknowns must be surfaced.** Do not silently choose
+   between materially different interpretations: state the assumption, ask when
+   the decision is consequential, and record the evidence when the repo answers
+   it. Before large or ambiguous work, go further and hunt for the unknowns you
+   have not named yet — your prompts, context, and plan are a map, not the
+   territory of the real code and requirements. Surface consequential unknowns
+   up front rather than discovering them mid-implementation;
+   `docs/ai/orchestration.md` owns the method catalog.
 3. **Simplicity is a requirement.** Solve the current DART problem. Do not add
    speculative flexibility, hierarchy, abstraction, or configuration unless it
    removes real complexity or matches an established DART pattern.
@@ -58,6 +63,8 @@ Before finalizing substantial AI-assisted work, check:
 - Objective: deliverables and non-goals are clear.
 - Assumptions: consequential ambiguity was asked about or resolved from
   evidence.
+- Unknowns: material unknowns were surfaced before large work (see
+  `docs/ai/orchestration.md`), not discovered mid-implementation.
 - Simplicity: the change is no larger than the current problem requires.
 - Scope: touched files are necessary and unrelated edits are preserved.
 - Source of truth: mutable state has one owner; other surfaces point to it.


### PR DESCRIPTION
## Summary

- Add a "discover your unknowns before committing" discipline to DART's AI
  operating docs, so agents convert consequential unknowns into knowns before
  large work instead of encoding guesses into a plan.

## Motivation / Problem

DART's AI-infra was already strong on evidence and verification (principles
Axioms 6–7, `docs/ai/verification.md`) and on _declaring_ assumptions
(Axiom 2), but it had no tool-agnostic discipline for the step _before_
declaring assumptions: actively discovering the unknowns you have not named
yet. That is the central lesson of Thariq's (Anthropic) "A Field Guide to
Fable: Finding Your Unknowns" — the map (your prompts, context, plan) is not
the territory (the real code and requirements), and the highest-leverage habit
with a capable model is surfacing your own unknowns so you can prompt it
better.

## Changes / Key Changes

- `docs/ai/principles.md`: broaden Axiom 2 from "Assumptions must be visible"
  to "Assumptions and unknowns must be surfaced", adding the
  map-is-not-the-territory framing and a pointer (not a copy) to the method
  catalog; add a matching audit-checklist line. The file stays compact.
- `docs/ai/orchestration.md`: add a "Discovering unknowns before committing"
  subsection that solely owns the four methods — blind-spot review, throwaway
  spike, requirements interview, reference map — each mapped to a DART public
  path (`dart-analyze`, a scratch branch, the intake questions,
  `dart-references` / `docs/readthedocs/papers.md`); cross-link the
  specification-intake spike-packet step to it.
- `CHANGELOG.md`: entry under Build, Packaging, and Developer Tooling.

No new AI surface is added; the change consolidates into existing owner docs
per `docs/ai/components.md`.

## Testing

- `pixi run check-lint-md`, `pixi run check-lint-spell`,
  `pixi run check-docs-policy`, `pixi run check-ai-commands` — all pass.
- Independent blind-spot review (a different session) of the diff caught a
  self-inflicted single-source-of-truth violation — the four-method list was
  copied into the must-stay-compact `principles.md` right after delegating it
  to `orchestration.md`; the copies were converted to pointers before
  finalizing.
- Principle audit in `docs/ai/principles.md` run and recorded as passing.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- DART 6 LTS companion on `release-6.20`: a lean, lane-appropriate version of
  the same discipline (added to the release-branch AI principles) —
  dartsim/dart#3253.

---

#### Checklist

- [x] Milestone set (DART 7.0)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` (AI-infra change
      that alters how agents choose/run/verify work)
- [ ] ~Add unit tests for new functionality~ — N/A, docs-only
- [ ] ~Document new methods and classes~ — N/A, docs-only
- [ ] ~Add Python bindings (dartpy) if applicable~ — N/A
