### PR TITLE
Surface unknowns before non-trivial fixes in DART 6 AI principles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@
     the `dart-changelog` routine is available for backport changelog
     decisions.
 
+  * Add a "surface your unknowns" discipline to the release-branch AI
+    principles (`docs/ai/principles.md`): before a non-trivial fix, convert
+    consequential unknowns into knowns — a reproduction, a focused read of the
+    affected code, or an independent blind-spot review — instead of coding a
+    guess and discovering them mid-change.
+
   * Replace the vendored `dart/external/convhull_3d` implementation with a
     DART-owned native `dart/math/detail/ConvexHull.hpp` implementation used by
     `math::computeConvexHull3D`, while keeping the legacy implementation only

--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -9,6 +9,11 @@ These principles apply to AI-assisted work on the DART 6.20 support branch.
 - Treat live GitHub state and current command output as authoritative.
 - Do not rely on stale branch notes when a current checkout or PR can be
   inspected.
+- Before a non-trivial fix, surface your unknowns instead of coding a guess:
+  your plan and notes are a map, not the territory of the real code. Convert
+  consequential unknowns into knowns first — a reproduction, a focused read of
+  the affected code, or an independent blind-spot review — rather than
+  discovering them mid-change.
 
 ## Compatibility First
 


### PR DESCRIPTION
## Summary

- Add a lane-appropriate "surface your unknowns" discipline to the DART 6.20
  support-branch AI principles, so agents resolve consequential unknowns before
  a non-trivial fix instead of coding a guess.

## Motivation / Problem

Companion to the DART 7 (`main`) change that encodes the
map-is-not-the-territory lesson from Thariq's (Anthropic) "A Field Guide to
Fable: Finding Your Unknowns". The DART 6.20 branch is a lean compatibility
support lane with no orchestrator/packet model, so it gets only the
transferable kernel — surface your unknowns before a non-trivial fix — sized
for bug-fix and compatibility work, not the full method catalog that lives on
`main`.

## Changes / Key Changes

- `docs/ai/principles.md`: add one Evidence First bullet — before a non-trivial
  fix, convert consequential unknowns into knowns (a reproduction, a focused
  read of the affected code, or an independent blind-spot review) rather than
  coding a guess and discovering them mid-change.
- `CHANGELOG.md`: entry under DART 6.20.0 → Build.

## Testing

- `pixi run check-lint-spell` and `pixi run check-ai-commands` (the release-6.20
  lint gates) pass. `check-lint-cpp` / `check-lint-cmake` / `check-lint-py` do
  not apply to a docs-only change. (release-6.20 has no markdown/prettier gate.)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- DART 7 companion on `main` (full "discover unknowns" discipline + method
  catalog) — dartsim/dart#3252.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` (AI-infra change
      that alters how agents choose/run/verify work)
- [ ] ~Add unit tests for new functionality~ — N/A, docs-only
- [ ] ~Document new methods and classes~ — N/A, docs-only
- [ ] ~Add Python bindings (dartpy) if applicable~ — N/A
