### PR TITLE
Compress AI-principles Axiom 2 to peer length

### DIFF
--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -26,11 +26,9 @@ the owner docs above.
 2. **Assumptions and unknowns must be surfaced.** Do not silently choose
    between materially different interpretations: state the assumption, ask when
    the decision is consequential, and record the evidence when the repo answers
-   it. Before large or ambiguous work, go further and hunt for the unknowns you
-   have not named yet — your prompts, context, and plan are a map, not the
-   territory of the real code and requirements. Surface consequential unknowns
-   up front rather than discovering them mid-implementation;
-   `docs/ai/orchestration.md` owns the method catalog.
+   it. Before large or ambiguous work, also hunt for the unknowns you have not
+   named yet and surface them up front rather than mid-implementation;
+   `docs/ai/orchestration.md` owns the methods for doing so.
 3. **Simplicity is a requirement.** Solve the current DART problem. Do not add
    speculative flexibility, hierarchy, abstraction, or configuration unless it
    removes real complexity or matches an established DART pattern.


### PR DESCRIPTION
## Summary

- Compress `docs/ai/principles.md` Axiom 2 back to the length of its peer
  axioms and keep the map-is-not-the-territory metaphor only in its owner doc.

## Motivation / Problem

Fast-follow to #3252. A post-merge multi-lens review flagged that Axiom 2 had
grown to ~2x the length of every other axiom, and that the
map-is-not-the-territory metaphor now appeared both inline in `principles.md`
and in `docs/ai/orchestration.md`, which already owns and develops it. That
strains this file's own rule (line 18: "Keep this file short. Move examples,
procedures, and compatibility detail to the owner docs above") and the
single-source-of-truth axiom.

## Changes / Key Changes

- `docs/ai/principles.md`: trim Axiom 2 to ~peer length by merging the
  discovery/timing sentences and dropping the inline metaphor. The guidance is
  unchanged — surface unknowns before large work — and the pointer to the owner
  doc is retained (`docs/ai/orchestration.md` owns the methods and the
  map/territory framing).

## Testing

- `pixi run check-lint-md`, `pixi run check-lint-spell`,
  `pixi run check-docs-policy`, `pixi run check-ai-commands` — all pass.
- Verified the metaphor now lives solely in `docs/ai/orchestration.md`
  (`principles.md` has zero "territory" mentions).

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to dartsim/dart#3252 (adds the discipline this PR compresses).

---

#### Checklist

- [x] Milestone set (DART 7.0)
- [x] CHANGELOG.md — no entry required: editorial compression of guidance that
      landed in #3252, with no change to how agents choose, run, verify, or
      review work (per `docs/onboarding/changelog.md`).
- [ ] ~unit tests / docs / bindings~ — N/A, docs-only
