### PR TITLE
Tighten the surface-unknowns bullet in DART 6 AI principles

### DIFF
--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -9,11 +9,10 @@ These principles apply to AI-assisted work on the DART 6.20 support branch.
 - Treat live GitHub state and current command output as authoritative.
 - Do not rely on stale branch notes when a current checkout or PR can be
   inspected.
-- Before a non-trivial fix, surface your unknowns instead of coding a guess:
-  your plan and notes are a map, not the territory of the real code. Convert
-  consequential unknowns into knowns first — a reproduction, a focused read of
-  the affected code, or an independent blind-spot review — rather than
-  discovering them mid-change.
+- Before a non-trivial fix, surface your unknowns rather than coding a guess:
+  your plan is a map, not the territory of the real code. Convert consequential
+  unknowns into knowns first — reproduce the bug, read the affected code, or get
+  an independent blind-spot review — instead of discovering them mid-change.
 
 ## Compatibility First
 


### PR DESCRIPTION
## Summary

- Tighten the Evidence First "surface your unknowns" bullet added in #3253 to
  the terse cadence of its peers, keeping the framing and the methods.

## Motivation / Problem

The DART 6 companion (#3253) added a five-line Evidence First bullet — the
longest in that section, where its peers are one to two lines. This is the
release-6.20 analogue of the DART 7 compactness tidy in #3255, but it is a
_different_ edit: the release-6.20 principles doc has no `orchestration.md`
owner and no numbered-axiom taxonomy, so the map-is-not-the-territory framing
has no other home and is kept here (it is single-sourced on this branch). Only
the prose is tightened.

## Changes / Key Changes

- `docs/ai/principles.md`: trim the bullet from five lines to four with more
  active verbs (`reproduce the bug, read the affected code, or get an
  independent blind-spot review`). The guidance is unchanged: surface unknowns
  before a non-trivial fix and convert them into knowns first.

## Testing

- `pixi run check-lint-spell` and `pixi run check-ai-commands` (the release-6.20
  lint gates) pass. `check-lint-cpp` / `check-lint-cmake` / `check-lint-py` do
  not apply to a docs-only change. (release-6.20 has no markdown/prettier gate.)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Tightens the bullet added in dartsim/dart#3253. DART 7 compactness analogue:
  dartsim/dart#3255 (not a direct backport — see Motivation).

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md — no entry required: editorial tightening of guidance that
      landed in #3253, with no change to how agents choose, run, verify, or
      review work (per `docs/onboarding/changelog.md`).
- [ ] ~unit tests / docs / bindings~ — N/A, docs-only
