### PR TITLE
Add root-cause discipline to AI principles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,11 @@ compatibility remains on the active DART 6 LTS branch._
   method catalog — blind-spot review, throwaway spike, requirements interview,
   and reference map — each mapped to a public path, so agents resolve unknowns
   before large work instead of encoding guesses into a plan.
+- Added a root-cause discipline to the AI operating docs: `docs/ai/principles.md`
+  now carries an axiom that unexpected failures (failing tests, build errors,
+  regressions, numerical drift) are reproduced as the smallest failing case and
+  fixed at the cause with regression coverage, rather than silenced or patched
+  around, plus a matching principle-audit item.
 
 #### Tests, Benchmarks, and Quality Gates
 

--- a/docs/ai/orchestration.md
+++ b/docs/ai/orchestration.md
@@ -202,7 +202,8 @@ How any session — human or agent — finds work and avoids collisions:
 - Scope mismatch: the executor stops and returns the packet with what was
   found; the orchestrator re-cuts it.
 - Gate failure the packet cannot explain: treat as a finding, not a fixup —
-  report back rather than patching around it.
+  report back rather than patching around it (the packet-scoped case of the
+  root-cause axiom in `docs/ai/principles.md`).
 - Conflicting instructions between a packet and an owner doc: the owner doc
   wins; report the conflict so the packet (or the doc) is corrected.
 - Anything touching shared state beyond the local clone follows the safety

--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -53,6 +53,12 @@ the owner docs above.
    are allowed when the task calls for them. Pushes, PR updates, comments,
    review-thread changes, CI re-triggers, and merges require explicit
    maintainer/user approval.
+10. **Failures get root-caused, not patched around.** When something breaks
+    unexpectedly — a failing test, build error, regression, or numerical
+    drift — stop, reproduce the smallest failing case, and fix the cause with
+    regression coverage rather than silencing the symptom. If the cause is
+    outside the current scope, report it back per `docs/ai/orchestration.md`
+    instead of routing around it.
 
 ## Principle Audit
 
@@ -68,6 +74,8 @@ Before finalizing substantial AI-assisted work, check:
 - Source of truth: mutable state has one owner; other surfaces point to it.
 - Decision evidence: consequential choices are backed by a verification/debug
   method that addresses false-positive and false-negative risk.
+- Root cause: any unexpected failure was reproduced and fixed at the cause with
+  regression coverage, not silenced or patched around.
 - Public path: workflow guidance maps to tracked docs and `pixi run ...` gates.
 - Evidence: checks, review results, artifacts, or blockers are recorded.
 - Shared-state safety: any external mutation was explicitly approved.


### PR DESCRIPTION
## Summary

- Add a cross-cutting root-cause discipline (Axiom 10) to DART's AI operating
  principles: unexpected failures get reproduced and fixed at the cause with
  regression coverage, not patched around.

## Motivation / Problem

DART's AI-infra was strong on _proactive_ rigor (Axiom 2 "surface unknowns",
Axiom 7 "decisions need verification") but had no cross-cutting _reactive_
principle for what to do when something breaks. The "stop-the-line / root-cause
triage" idea is a staple of good agent operating guides (this one adapts it
from a widely-used generic `claude.md`), and it maps directly onto DART's
correctness-critical work (regressions, numerical drift, flaky gates). Before
this, root-cause/regression discipline appeared only inside the `dart-fix-*`
workflows, never as a principle.

## Changes / Key Changes

- `docs/ai/principles.md`: add Axiom 10, "Failures get root-caused, not patched
  around" — stop, reproduce the smallest failing case, fix the underlying
  cause, add regression coverage; do not silence the symptom or widen scope to
  route around it. Add a matching principle-audit item.
- `CHANGELOG.md`: entry under Build, Packaging, and Developer Tooling.

The fix _procedure_ stays in the `dart-fix-*` workflows; this is the
cross-cutting principle only, so no duplication of the workflow steps.

## Testing

- `pixi run check-lint-md`, `pixi run check-lint-spell`,
  `pixi run check-docs-policy`, `pixi run check-ai-commands` — all pass.
- Independent blind-spot review of the diff (a different session) checked for
  duplication against `docs/ai/orchestration.md`'s packet-scoped escalation rule
  and against Axioms 6/7; the axiom is a distinct cross-cutting principle.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- DART 6 LTS companion on `release-6.20`: a lane-appropriate bullet version —
  dartsim/dart#3260.

---

#### Checklist

- [x] Milestone set (DART 7.0)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` (AI-infra change
      that alters how agents fix/verify work)
- [ ] ~unit tests / docs / bindings~ — N/A, docs-only
