### PR TITLE
Add root-cause discipline to DART 6 AI principles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@
     affected code, or an independent blind-spot review — instead of coding a
     guess and discovering them mid-change.
 
+  * Add a root-cause discipline to the release-branch AI principles
+    (`docs/ai/principles.md`): fix bugs at the root cause — reproduce the
+    smallest failing case, fix the underlying cause, and add regression
+    coverage — instead of silencing the symptom or widening scope to route
+    around it.
+
   * Replace the vendored `dart/external/convhull_3d` implementation with a
     DART-owned native `dart/math/detail/ConvexHull.hpp` implementation used by
     `math::computeConvexHull3D`, while keeping the legacy implementation only

--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -13,6 +13,9 @@ These principles apply to AI-assisted work on the DART 6.20 support branch.
   your plan is a map, not the territory of the real code. Convert consequential
   unknowns into knowns first — reproduce the bug, read the affected code, or get
   an independent blind-spot review — instead of discovering them mid-change.
+- Fix bugs at the root cause: reproduce the failure as the smallest case, fix
+  the underlying cause, and add regression coverage — do not silence the symptom
+  or widen scope to route around it.
 
 ## Compatibility First
 


### PR DESCRIPTION
## Summary

- Add a lane-appropriate root-cause discipline to the DART 6.20 support-branch
  AI principles: fix bugs at the root cause with regression coverage, not by
  patching around the symptom.

## Motivation / Problem

Companion to the DART 7 (`main`) root-cause axiom, adapting the
"stop-the-line / root-cause triage" idea from a widely-used agent operating
guide. `release-6.20` is primarily a bug-fix / compatibility lane, so this
discipline is especially relevant here; it slots into the existing Evidence
First section as one bullet rather than the DART 7 axiom structure (this branch
has no numbered-axiom taxonomy).

## Changes / Key Changes

- `docs/ai/principles.md`: add an Evidence First bullet — fix bugs at the root
  cause (reproduce the smallest failing case, fix the underlying cause, add
  regression coverage) instead of silencing the symptom or widening scope to
  route around it.
- `CHANGELOG.md`: entry under DART 6.20.0 → Build.

## Testing

- `pixi run check-lint-spell` and `pixi run check-ai-commands` (the release-6.20
  lint gates) pass. Cpp/cmake/py lint gates do not apply to a docs-only change.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- DART 7 companion on `main` (the Axiom 10 version) — dartsim/dart#3259.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` (AI-infra change
      that alters how agents fix/verify work)
- [ ] ~unit tests / docs / bindings~ — N/A, docs-only
