### PR TITLE
Add rigid IPC two-wall tunnel fixture-row coverage

### DIFF
--- a/docs/dev_tasks/rigid_ipc_solver/README.md
+++ b/docs/dev_tasks/rigid_ipc_solver/README.md
@@ -210,6 +210,18 @@
         through the opt-in runtime stage. A rotated cube with a large time-step
         velocity toward a fixed wall remains intersection-free, and the stage
         reports a conservative CCD line-search hit.
+  - [x] Add audited two-wall tunnel corridor fixture coverage through the
+        opt-in runtime stage. A unit cube flies down a tight (1 mm) fixed
+        floor/ceiling corridor at high speed, activates rigid IPC contact, stays
+        finite, keeps advancing along the tunnel axis, and stays within the
+        fixed wall clearances. The three-wall, four-wall, and 8K tunnel rows
+        remain planned: at their tighter 0.1 mm clearance the conservative
+        curved-CCD line search limits each step to about the separation
+        distance, so a fast cube is arrested (intersection-free but ~3 mm of
+        travel) rather than traversing the channel, and the dense 8K walls are
+        too slow for a unit test pending dense-contact performance work. These
+        are next gaps for the conservative-CCD/performance climb, not
+        test-authoring gaps.
   - [x] Add the first audited tessellated-plane fixture coverage through the
         opt-in runtime stage. A cube falls onto a fixed two-triangle mesh plane,
         activates contact, stays finite, and preserves nonnegative clearance.
@@ -470,6 +482,12 @@
   - [x] Mark the audited 3D tunneling unit-test fixture row
         (`fixtures/3D/unit-tests/tunneling.json`) as implemented after
         high-speed cube-vs-wall conservative line-search coverage landed.
+  - [x] Mark the audited 3D two-wall tunnel unit-test fixture row
+        (`fixtures/3D/unit-tests/tunnel/2-walls.json`) as implemented after
+        two-wall tunnel corridor runtime coverage landed. The three-wall,
+        four-wall, and 8K tunnel variants remain planned: the conservative
+        curved-CCD line search arrests a fast cube at their tighter 0.1 mm
+        clearance, and the 8K walls are too slow for a unit test.
   - [x] Mark the audited 3D two-triangle tessellated-plane unit-test fixture row
         (`fixtures/3D/unit-tests/tessellated-plane/two-triangles.json`) as
         implemented after cube-on-two-triangle-plane runtime coverage landed.

--- a/docs/dev_tasks/rigid_ipc_solver/RESUME.md
+++ b/docs/dev_tasks/rigid_ipc_solver/RESUME.md
@@ -13,6 +13,50 @@ kinematic obstacles, the performance climb, remaining corpus/parity coverage,
 and articulated-scene support without exposing solver registries, ECS storage,
 external project names, or backend resources in public API.
 
+## Session 2026-07-04: two-wall tunnel fixture row (+ 3/4-wall/8K deferral)
+
+Delivered a bounded Phase 3/6 runtime-manifest slice:
+
+- Added DART-owned runtime coverage for the audited two-wall tunnel unit-test
+  fixture row (`fixtures/3D/unit-tests/tunnel/2-walls.json`) in
+  `RigidIpcPaperExperiments.TwoWallTunnelCubeStaysBetweenWallsFixtureRow`: a unit
+  cube flies down a tight (1 mm) fixed floor/ceiling corridor at high speed,
+  activates rigid IPC contact, stays finite, keeps advancing along the tunnel
+  axis (asserted with a real `startX + 0.1` margin), and stays within the fixed
+  wall clearances (tracked from the cube corners so the invariant is not polluted
+  by native static wall-vs-wall overlaps from the support geometry).
+- Marked that one upstream 3D unit-test fixture row implemented in the generated
+  manifest (planned 339 -> 338, implemented 459 -> 460).
+- Deferred the three-wall, four-wall, and 8K tunnel rows with evidence. A pre-PR
+  adversarial review flagged that a bare `> startX` progress assertion could pass
+  a frozen cube; adding a `startX + 0.1` margin then EXPOSED that at the faithful
+  0.1 mm clearance of `3-walls.json`/`4-walls.json` the conservative curved-CCD
+  line search limits each step to about the separation distance, so the cube is
+  arrested (intersection-free but only ~3 mm / ~56 mm of travel) rather than
+  traversing. Loosening the gap would be an overclaim (their fixtures' defining
+  feature is the 0.1 mm tolerance), so those rows stay planned as a
+  conservative-CCD/performance gap. The 8K variant additionally holds active
+  contact against two 8192-triangle walls every step (~minutes/step), too slow
+  for a unit test -- tied to the dense-contact performance work in
+  `benchmarks.md`.
+
+Environment note (this checkout): plain `pixi run ninja ...` compiles but fails
+at link with `undefined reference to __libc_dlopen_mode@GLIBC_PRIVATE` because
+the conda `ld` shadows the CMake-configured system `/usr/bin/ld`. Build with
+`pixi run bash -c 'PATH=/usr/bin:$PATH ninja -C build/default/cpp/Release <target>'`.
+
+Validation in this slice:
+
+- `pixi run bash -c 'PATH=/usr/bin:$PATH ninja -C build/default/cpp/Release test_rigid_ipc_paper_experiments'`
+- `./build/default/cpp/Release/bin/test_rigid_ipc_paper_experiments --gtest_color=no --gtest_filter='RigidIpcPaperExperiments.TwoWallTunnelCubeStaysBetweenWallsFixtureRow'`
+- `pixi run python scripts/generate_rigid_ipc_fixture_manifest.py --upstream-dir /tmp/rigid-ipc`
+- `pixi run python scripts/check_rigid_ipc_fixture_manifest.py --upstream-dir /tmp/rigid-ipc`
+- `pixi run python scripts/check_rigid_ipc_fixture_manifest.py`
+- `pixi run pytest tests/test_rigid_ipc_fixture_manifest_tools.py`
+- `pixi run lint`
+
+No push or PR mutation has been made from this slice.
+
 ## Session 2026-06-01: generic hash-grid source row
 
 Delivered a bounded Phase 2/6 algorithm-manifest slice:

--- a/docs/plans/082-rigid-implicit-barrier-contact/rigid_ipc_fixture_manifest.json
+++ b/docs/plans/082-rigid-implicit-barrier-contact/rigid_ipc_fixture_manifest.json
@@ -8608,17 +8608,17 @@
       "topic": "rigid contact correctness regression",
       "priority": "P0",
       "dart_target_type": "test",
-      "expected_invariant": "DART focused test preserves nonnegative clearance, momentum/energy behavior where applicable, and expected restitution or friction outcome.",
+      "expected_invariant": "DART covers the audited 3D two-wall tunnel row: a unit cube flies down a tight (1 mm) fixed floor/ceiling corridor at high speed, stays finite, keeps advancing along the tunnel axis, and never tunnels out through either fixed wall.",
       "visual_evidence_requirement": "not-required",
       "benchmark_profile_artifact": "not-required",
-      "status": "planned",
-      "dart_artifact": "CTest label rigid_ipc_fixture::2_walls",
+      "status": "implemented",
+      "dart_artifact": "test_rigid_ipc_paper_experiments::RigidIpcPaperExperiments.TwoWallTunnelCubeStaysBetweenWallsFixtureRow",
       "required_assets_or_importer": [
         "meshes/cube.obj",
         "meshes/plane.obj"
       ],
-      "dart_command_or_ctest_or_benchmark": "ctest -L rigid_ipc_fixture::2_walls",
-      "notes_or_gap": "Classified from upstream rigid-ipc path; retire this planned row only after DART has matching code, tests, benchmarks, and evidence."
+      "dart_command_or_ctest_or_benchmark": "pixi run bash -lc 'build/default/cpp/Release/bin/test_rigid_ipc_paper_experiments --gtest_color=no --gtest_filter=RigidIpcPaperExperiments.TwoWallTunnelCubeStaysBetweenWallsFixtureRow'",
+      "notes_or_gap": "Covered by DART-owned two-wall tunnel runtime coverage for the 3D unit-test fixture mechanism. The three-wall, four-wall, and 8K tunnel rows remain planned: at their tighter 0.1 mm clearance the conservative curved-CCD line search limits each step to about the separation distance, so a fast cube is arrested rather than traversing, and the dense 8K walls are too slow for a unit test pending dense-contact performance work."
     },
     {
       "upstream_path": "fixtures/3D/unit-tests/tunnel/3-walls.json",

--- a/scripts/generate_rigid_ipc_fixture_manifest.py
+++ b/scripts/generate_rigid_ipc_fixture_manifest.py
@@ -222,6 +222,24 @@ IMPLEMENTED_FIXTURE_ROWS = {
             "runtime evidence."
         ),
     },
+    "fixtures/3D/unit-tests/tunnel/2-walls.json": {
+        "test": "TwoWallTunnelCubeStaysBetweenWallsFixtureRow",
+        "expected_invariant": (
+            "DART covers the audited 3D two-wall tunnel row: a unit cube flies "
+            "down a tight (1 mm) fixed floor/ceiling corridor at high speed, "
+            "stays finite, keeps advancing along the tunnel axis, and never "
+            "tunnels out through either fixed wall."
+        ),
+        "notes_or_gap": (
+            "Covered by DART-owned two-wall tunnel runtime coverage for the 3D "
+            "unit-test fixture mechanism. The three-wall, four-wall, and 8K "
+            "tunnel rows remain planned: at their tighter 0.1 mm clearance the "
+            "conservative curved-CCD line search limits each step to about the "
+            "separation distance, so a fast cube is arrested rather than "
+            "traversing, and the dense 8K walls are too slow for a unit test "
+            "pending dense-contact performance work."
+        ),
+    },
     "fixtures/3D/unit-tests/erleben/cliff-edges.json": {
         "test": "ErlebenCliffEdgesFixtureRowStaysSeparated",
         "expected_invariant": (

--- a/tests/unit/simulation/contact/test_rigid_ipc_paper_experiments.cpp
+++ b/tests/unit/simulation/contact/test_rigid_ipc_paper_experiments.cpp
@@ -1159,8 +1159,13 @@ TEST(RigidIpcPaperExperiments, TwoWallTunnelCubeStaysBetweenWallsFixtureRow)
   EXPECT_TRUE(cube.getTranslation().allFinite());
   EXPECT_TRUE(cube.getLinearVelocity().allFinite());
   EXPECT_GT(cube.getTranslation().x(), startX + 0.1);
-  EXPECT_GT(minBottomZ, -halfGap - 5e-3);
-  EXPECT_LT(maxTopZ, halfGap + 5e-3);
+  // Intersection-free: no cube corner may cross either fixed wall face
+  // (z = +/-halfGap). The penetration tolerance is kept well below the 1 mm
+  // wall gap so a regression that let the cube drift through a wall cannot
+  // pass; in practice the cube holds the full ~1 mm clearance (corners settle
+  // at z = +/-0.5, i.e. 1 mm inside each face).
+  EXPECT_GT(minBottomZ, -halfGap - 2e-4);
+  EXPECT_LT(maxTopZ, halfGap + 2e-4);
   EXPECT_TRUE(sawActiveContact);
 }
 

--- a/tests/unit/simulation/contact/test_rigid_ipc_paper_experiments.cpp
+++ b/tests/unit/simulation/contact/test_rigid_ipc_paper_experiments.cpp
@@ -1092,6 +1092,78 @@ TEST(RigidIpcPaperExperiments, HighSpeedCubeDoesNotTunnelThroughWall)
   EXPECT_GT(ipcStage.getLastStats().lineSearchHits, 0u);
 }
 
+TEST(RigidIpcPaperExperiments, TwoWallTunnelCubeStaysBetweenWallsFixtureRow)
+{
+  // fixtures/3D/unit-tests/tunnel/2-walls.json: a unit cube flies down a tight
+  // horizontal corridor (fixed floor and ceiling planes 1.002 apart, ~1 mm
+  // clearance above and below the cube) at high speed. The rigid IPC barrier
+  // must keep the cube intersection-free with both fixed planes while it
+  // advances along the tunnel axis without tunneling out through either wall.
+  sx::World world;
+  world.setGravity(Eigen::Vector3d::Zero());
+  world.setTimeStep(0.01);
+
+  constexpr double halfGap = 0.501; // fixed floor/ceiling offset from center
+  constexpr double planeHalfExtent = 5.0;
+
+  sx::RigidBodyOptions floorOptions;
+  floorOptions.isStatic = true;
+  floorOptions.position = Eigen::Vector3d(0.0, 0.0, -halfGap);
+  auto floor = world.addRigidBody("two_wall_tunnel_floor", floorOptions);
+  floor.setCollisionShape(makeTwoTrianglePlaneMesh(planeHalfExtent));
+
+  sx::RigidBodyOptions ceilingOptions;
+  ceilingOptions.isStatic = true;
+  ceilingOptions.position = Eigen::Vector3d(0.0, 0.0, halfGap);
+  auto ceiling = world.addRigidBody("two_wall_tunnel_ceiling", ceilingOptions);
+  ceiling.setCollisionShape(makeTwoTrianglePlaneMesh(planeHalfExtent));
+
+  constexpr double cubeHalfExtent = 0.5;
+  constexpr double startX = -4.0;
+  sx::RigidBodyOptions cubeOptions;
+  cubeOptions.mass = 1.0;
+  cubeOptions.position = Eigen::Vector3d(startX, 0.0, 0.0);
+  cubeOptions.linearVelocity = Eigen::Vector3d(25.0, 0.0, 0.0);
+  auto cube = world.addRigidBody("two_wall_tunnel_cube", cubeOptions);
+  cube.setCollisionShape(
+      sx::CollisionShape::makeBox(
+          {cubeHalfExtent, cubeHalfExtent, cubeHalfExtent}));
+
+  sx::compute::SequentialExecutor executor;
+  sx::compute::RigidIpcContactStage ipcStage;
+  sx::compute::WorldStepPipeline pipeline;
+  pipeline.addStage(ipcStage);
+
+  bool sawActiveContact = false;
+  double minBottomZ = std::numeric_limits<double>::infinity();
+  double maxTopZ = -std::numeric_limits<double>::infinity();
+  for (int s = 0; s < 15; ++s) {
+    world.step(executor, pipeline);
+    const auto& stats = ipcStage.getLastStats();
+    EXPECT_FALSE(stats.failed) << "step " << s;
+    sawActiveContact = sawActiveContact || stats.activeConstraints > 0u;
+
+    const Eigen::Matrix3d R = cube.getRotation();
+    for (double dx : {-cubeHalfExtent, cubeHalfExtent}) {
+      for (double dy : {-cubeHalfExtent, cubeHalfExtent}) {
+        for (double dz : {-cubeHalfExtent, cubeHalfExtent}) {
+          const Eigen::Vector3d v
+              = cube.getTranslation() + R * Eigen::Vector3d(dx, dy, dz);
+          minBottomZ = std::min(minBottomZ, v.z());
+          maxTopZ = std::max(maxTopZ, v.z());
+        }
+      }
+    }
+  }
+
+  EXPECT_TRUE(cube.getTranslation().allFinite());
+  EXPECT_TRUE(cube.getLinearVelocity().allFinite());
+  EXPECT_GT(cube.getTranslation().x(), startX + 0.1);
+  EXPECT_GT(minBottomZ, -halfGap - 5e-3);
+  EXPECT_LT(maxTopZ, halfGap + 5e-3);
+  EXPECT_TRUE(sawActiveContact);
+}
+
 TEST(RigidIpcPaperExperiments, CubeSettlesOnTwoTrianglePlaneFixtureRow)
 {
   sx::World world;


### PR DESCRIPTION
## Summary

- Add DART-owned runtime coverage for the audited upstream two-wall rigid IPC tunnel unit-test fixture and mark that PLAN-082 manifest row implemented. The three-wall, four-wall, and 8K tunnel rows are left planned with a recorded reason (see below).

## Motivation / Problem

- PLAN-082 (rigid implicit-barrier contact) is tracked against an upstream fixture manifest, and the tunnel unit-test fixtures exercise a core guarantee: a fast body confined in a tight fixed passage must stay intersection-free (anti-tunneling) while advancing along the tunnel axis. The two-wall row had no DART-owned coverage.

## Changes / Key Changes

- `tests/unit/simulation/contact/test_rigid_ipc_paper_experiments.cpp`: add `TwoWallTunnelCubeStaysBetweenWallsFixtureRow`, reconstructing `fixtures/3D/unit-tests/tunnel/2-walls.json`. A unit cube flies down a tight (1 mm) fixed floor/ceiling corridor via the opt-in `RigidIpcContactStage`; it asserts finite state, forward progress (`startX + 0.1` margin), active rigid IPC contact, and cube-corner clearance against the fixed inner wall faces (avoiding static wall-vs-wall `collide()` contamination).
- `scripts/generate_rigid_ipc_fixture_manifest.py` + regenerated `docs/plans/082-rigid-implicit-barrier-contact/rigid_ipc_fixture_manifest.json`: mark that row implemented (planned 339 → 338, implemented 459 → 460).
- `docs/dev_tasks/rigid_ipc_solver/README.md`, `RESUME.md`: progress-log updates, including the deferral rationale below.

## Why only the two-wall row

A pre-PR review flagged that a bare `> startX` progress check could pass a frozen cube. Adding a `startX + 0.1` margin then exposed that at the *faithful* 0.1 mm clearance of `3-walls.json` / `4-walls.json`, the conservative curved-CCD line search limits each step to about the separation distance, so a fast cube is arrested (intersection-free but only ~3 mm / ~56 mm of travel) rather than traversing. Loosening the gap would be an overclaim, since the tight tolerance is those fixtures' defining feature, so they stay planned as a conservative-CCD / performance gap. The two-wall fixture's 1 mm clearance is above that crawl threshold, so its cube genuinely traverses. The 8K variant additionally holds active contact against two 8192-triangle walls every step (~minutes/step), too slow for a unit test.

## Testing

Verified on the branch after bringing in the latest `main` (the intervening `main` commits are docs/plan-only and leave the simulation sources unchanged):

- `test_rigid_ipc_paper_experiments` full suite — 46/46 pass (including the new two-wall tunnel test)
- `pixi run python scripts/generate_rigid_ipc_fixture_manifest.py --upstream-dir <rigid-ipc@23b6ba6>` — regeneration is idempotent against the committed manifest
- `pixi run python scripts/check_rigid_ipc_fixture_manifest.py` (offline and `--upstream-dir`) — OK, 798 entries
- `pixi run pytest tests/test_rigid_ipc_fixture_manifest_tools.py` — 50/50
- `pixi run lint` — pass

Not run for this change: full `pixi run test-all` / `-e cuda test-all` — the change is isolated to one test binary plus the manifest data file, fully covered by the gates above.

## Breaking Changes

- [x] None
