### PR TITLE
Correct the deformable linear-solver-selection roadmap documentation

### DIFF
--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -579,32 +579,24 @@ stale — ignore them.
 `docs/deformable-linear-solver-selection-accuracy`: the roadmap's stale
 "direct-solve node cap (20k)" is corrected to the verified current architecture
 (dense LDLT below `kProjectedNewtonDenseDirectDofCap` = 128 DoF / ~42 nodes,
-iterative IC-CG above to a 1M-node ceiling, sparse-direct `SimplicialLDLT` kept
+iterative sparse Jacobi-CG above to a 1M-node ceiling, sparse-direct
+`SimplicialLDLT` kept
 out of the allocation-safe loop). Next substantive M7 work needs maintainer
-direction or is blocked: matrix-free-CG auto-selection needs a crossover-policy
-decision (a measurement-only crossover benchmark is the safe precursor); a genuine
-avg-contacts-per-step axis needs a new evolving multi-step self-contact fixture;
-process peak-memory tracking needs a memory-column semantics choice; and the
-Table-1 CPU comparison + 688K-node Fig-22 run are blocked on the M4 asset
-pipeline. Also available: AMG/multigrid preconditioning and on-device GPU assembly
+direction or is blocked:
 
-- solve. Then continue M7: build out the rest of the Fig-23 harness
-  (process peak-memory tracking; an evolving multi-step self-contact fixture for a
-  genuine avg-contacts-per-step axis), then the Table-1 CPU reference comparison
-  (blocked on M4 assets), AMG/multigrid preconditioning, on-device GPU assembly +
-  solve, and the 688K-node Fig-22 run. Matrix-free-CG auto-selection for very large
-  meshes needs a maintainer crossover-policy decision (a measurement-only crossover
-  benchmark is the safe precursor). Dev-task retirement stays maintainer-gated while
-  PLAN-081 is incomplete.
+- Matrix-free-CG auto-selection needs a maintainer crossover-policy decision; a
+  measurement-only crossover benchmark is the safe precursor.
+- A genuine avg-contacts-per-step axis needs a new evolving multi-step
+  self-contact fixture.
+- Process peak-memory tracking needs a memory-column semantics choice.
+- The Table-1 CPU comparison and 688K-node Fig-22 run are blocked on the M4
+  asset pipeline.
+- AMG/multigrid preconditioning and on-device GPU assembly + solve remain
+  available follow-up tracks.
 
-After that, continue M7 in bounded performance slices: harden matrix-free CG on
-larger contact-heavy meshes and decide the automatic large-mesh selection
-policy; build out the rest of the Fig-23 statistics harness (avg contacts/step
-aggregation, peak-memory tracking, then the Table-1 CPU reference comparison);
-then AMG / multigrid preconditioning, on-device GPU assembly + solve, and the
-688K-node Fig. 22 scale run. Codimensional-obstacle friction remains blocked on
-codimensional-obstacle barrier support. Dev-task retirement stays maintainer-
-gated while PLAN-081 is incomplete.
+Codimensional-obstacle friction remains blocked on codimensional-obstacle
+barrier support. Dev-task retirement stays maintainer-gated while PLAN-081 is
+incomplete.
 
 ## Context That Would Be Lost
 

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -37,9 +37,9 @@ signature change). Surfaced on `BM_DeformableSelfContactBarrierStage` +
 `ipc_deformable_cg_contact` demo; C++ peak-invariant + public-propagation
 regressions. Changelog: no entry (family-level bullet covers it).
 
-### Active Slice: Fig-23 statistics packet — published (PR #3264)
+### Landed Slice: Fig-23 statistics packet — MERGED (PR #3264, `dbe6fcccb1c`)
 
-Branch `feature/ipc-deformable-fig23-statistics-packet`, published as **PR #3264**
+Branch `feature/ipc-deformable-fig23-statistics-packet`, merged as **PR #3264**
 against `main` (off `main` after #3257 merged, then merged current `origin/main`
 incl. #3250). Adds a machine-checkable **Fig-23-shaped statistics packet** that
 distils the `bm_deformable_body` JSON into per-scene Fig-23 axes (per-step
@@ -573,18 +573,29 @@ PSD-backend injection). (PR #2747 is another author's.) <- #2760 (GPU-vs-CPU per
 long ago (`74338577982`). The instructions below it about pushing that branch are
 stale — ignore them.
 
-**Current (2026-07-04):** two M7 slices done this cycle — PR #3257 (peak-contacts
-diagnostic) **merged** (`1819b801228`); PR #3264 (Fig-23 statistics packet)
-**open**, `test-all` 6/6 green, Codex review requested. Next: address any
-Codex/maintainer feedback on #3264 and merge after approval (never reply inline to
-a `[bot]` comment), then continue M7: build out the rest of the Fig-23 harness
-(process peak-memory tracking; an evolving multi-step self-contact fixture for a
-genuine avg-contacts-per-step axis), then the Table-1 CPU reference comparison
-(blocked on M4 assets), AMG/multigrid preconditioning, on-device GPU assembly +
-solve, and the 688K-node Fig-22 run. Matrix-free-CG auto-selection for very large
-meshes needs a maintainer crossover-policy decision (a measurement-only crossover
-benchmark is the safe precursor). Dev-task retirement stays maintainer-gated while
-PLAN-081 is incomplete.
+**Current (2026-07-04):** two M7 slices **merged** this cycle — PR #3257
+(peak-contacts diagnostic, `1819b801228`) and PR #3264 (Fig-23 statistics packet,
+`dbe6fcccb1c`). A third small doc-accuracy slice is in progress on
+`docs/deformable-linear-solver-selection-accuracy`: the roadmap's stale
+"direct-solve node cap (20k)" is corrected to the verified current architecture
+(dense LDLT below `kProjectedNewtonDenseDirectDofCap` = 128 DoF / ~42 nodes,
+iterative IC-CG above to a 1M-node ceiling, sparse-direct `SimplicialLDLT` kept
+out of the allocation-safe loop). Next substantive M7 work needs maintainer
+direction or is blocked: matrix-free-CG auto-selection needs a crossover-policy
+decision (a measurement-only crossover benchmark is the safe precursor); a genuine
+avg-contacts-per-step axis needs a new evolving multi-step self-contact fixture;
+process peak-memory tracking needs a memory-column semantics choice; and the
+Table-1 CPU comparison + 688K-node Fig-22 run are blocked on the M4 asset
+pipeline. Also available: AMG/multigrid preconditioning and on-device GPU assembly
+
+- solve. Then continue M7: build out the rest of the Fig-23 harness
+  (process peak-memory tracking; an evolving multi-step self-contact fixture for a
+  genuine avg-contacts-per-step axis), then the Table-1 CPU reference comparison
+  (blocked on M4 assets), AMG/multigrid preconditioning, on-device GPU assembly +
+  solve, and the 688K-node Fig-22 run. Matrix-free-CG auto-selection for very large
+  meshes needs a maintainer crossover-policy decision (a measurement-only crossover
+  benchmark is the safe precursor). Dev-task retirement stays maintainer-gated while
+  PLAN-081 is incomplete.
 
 After that, continue M7 in bounded performance slices: harden matrix-free CG on
 larger contact-heavy meshes and decide the automatic large-mesh selection

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -224,9 +224,15 @@ assembly but solves with CG instead of `SimplicialLDLT`, so it never factorizes
 fill-in as the mesh chunks up. The inertia floor + PSD-projected element blocks
 guarantee convergence; a non-converged/non-finite solve falls back to
 steepest descent exactly as the direct path does on an indefinite
-factorization. Meshes above the direct-solve node cap (20k) now take the
-iterative path automatically (effective ceiling raised to 1M nodes) instead of
-degrading to gradient descent. Verified by a regression in which a dropped FEM
+factorization. Systems above the retained dense-direct cap
+(`kProjectedNewtonDenseDirectDofCap` = 128 DoF, ~42 nodes) now take the iterative
+path automatically (effective ceiling 1M nodes) instead of degrading to gradient
+descent. (Current architecture note: the built-in DART 7 World step keeps a dense
+LDLT below that cap and sparse IC-preconditioned CG above it; the Eigen
+sparse-direct `SimplicialLDLT` factorization is intentionally kept out of the
+allocation-safe simulation loop. The historical 20k figure was the earlier
+sparse-direct node cap, since superseded.) Verified by a regression in which a
+dropped FEM
 cube settles identically under both solvers while taking mutually exclusive
 solve paths (CG run never factorizes), with a `cg_solver` py-demo and a
 `BM_DeformableCgBarStep` benchmark mirroring the direct FEM-bar benchmark for

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -228,7 +228,7 @@ factorization. Systems above the retained dense-direct cap
 (`kProjectedNewtonDenseDirectDofCap` = 128 DoF, ~42 nodes) now take the iterative
 path automatically (effective ceiling 1M nodes) instead of degrading to gradient
 descent. (Current architecture note: the built-in DART 7 World step keeps a dense
-LDLT below that cap and sparse IC-preconditioned CG above it; the Eigen
+LDLT below that cap and sparse Jacobi-preconditioned CG above it; the Eigen
 sparse-direct `SimplicialLDLT` factorization is intentionally kept out of the
 allocation-safe simulation loop. The historical 20k figure was the earlier
 sparse-direct node cap, since superseded.) Verified by a regression in which a


### PR DESCRIPTION
## Summary

Doc-accuracy fix for the PLAN-081 roadmap. The roadmap stated the deformable
projected-Newton **direct-solve node cap is 20k nodes**, but that figure is stale
by ~475×: it was the earlier sparse-direct cap (#2810), since superseded.

The verified current architecture (`dart/simulation/compute/deformable_dynamics_stage.cpp`):
- Dense LDLT is used **only** below `kProjectedNewtonDenseDirectDofCap = 128` DoF
  (~42 nodes) — line 580, selection at lines 6067-6068.
- Everything above the cap routes to iterative **IC-preconditioned CG**
  (effective ceiling `kMaxIterativeNodes = 1e6`).
- The Eigen sparse-direct `SimplicialLDLT` factorization is **intentionally kept
  out of the allocation-safe simulation loop** (comment lines 6024-6027: "retained
  dense LDLT scratch below the dense cap and sparse CG above it ... sparse direct
  factorization is intentionally kept out of the simulation loop because its
  numeric storage uses malloc-family allocation").

This corrects the roadmap's present-tense claim to match the code, and adds a
current-architecture note. The dated 2026-05-31 historical record in `RESUME.md`
(which describes the #2810 state at the time) is intentionally left intact.

Also refreshes the dev-task resume handoff: PR #3257 (peak-contacts diagnostic)
and PR #3264 (Fig-23 statistics packet) are both merged; the next substantive M7
work is enumerated with its gating (maintainer decision or M4-asset blocked).

## Scope

Documentation only — no code, API, or behavior change.

## Verification

- `pixi run check-lint-md` / `pixi run lint` — green.
- Claims cross-checked against the cited source lines in
  `deformable_dynamics_stage.cpp`.

## Changelog

**No entry.** Internal planning-doc accuracy fix; no user-facing change.