### PR TITLE
Use pixi for dartpy format checks

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -61,24 +61,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.checkout_ref || github.event.inputs.ref || github.ref }}
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          python-version: 3.11
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install black -U
-          pip install isort -U
+          cache: true
 
       - name: Check format
         run: |
-          black --check --diff .
+          pixi run black --check --diff .
 
       - name: Check import
         run: |
-          isort --check --diff .
+          pixi run isort --check --diff .
 
   build_wheels:
     name: ${{ matrix.os }}-${{ matrix.build }}


### PR DESCRIPTION
## Summary

- Update `Publish dartpy` format checks to use the repository pixi toolchain instead of separately installing formatter packages with pip.

## Motivation / Problem

- The `release-6.20` push for #3267 failed in `Publish dartpy / Check format` because the workflow installed floating latest `black`, and `black 26.5.1` disagrees with the repository-locked `black 25.12.0` formatting.
- Keeping the workflow on the repo lockfile fixes the root cause and avoids future drift between local lint and this hosted check.

## Changes / Key Changes

- Replace the `setup-python` plus unpinned pip formatter install in `publish_dartpy.yml` with `prefix-dev/setup-pixi`.
- Run `pixi run black --check --diff .` and `pixi run isort --check --diff .` for the dartpy format job.

## Testing

- `pixi run black --check --diff .`
- `pixi run isort --check --diff .`
- `pixi run check-lint`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up for the `release-6.20` `Publish dartpy / Check format` failure after #3267.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable
