### PR TITLE
Add a matrix-free-vs-sparse-CG contact-heavy crossover benchmark

### DIFF
--- a/tests/benchmark/simulation/bm_deformable_body.cpp
+++ b/tests/benchmark/simulation/bm_deformable_body.cpp
@@ -327,6 +327,76 @@ sx::DeformableBodyOptions makeFemCubeOptions(
 }
 
 //==============================================================================
+// A solid cellsPerSide^3 FEM cube, unpinned and started just above a static
+// ground barrier (top face at z == 0). Under gravity it drops and settles on
+// the barrier, so the projected-Newton solve is dominated by the near-singular
+// clamped-log barrier Hessian on the contacting bottom nodes -- the stiff,
+// ill-conditioned regime where the matrix-free block-Jacobi preconditioner and
+// the sparse incomplete-Cholesky preconditioner diverge in CG iterations and
+// per-step cost. This is the contact-heavy fixture behind the matrix-free vs
+// sparse-CG crossover benchmarks; the crossover it measures (per-step time, CG
+// iterations, and fallbacks-to-steepest-descent as the mesh scales) is the
+// evidence a future automatic large-mesh matrix-free selection policy needs.
+sx::DeformableBodyOptions makeFemContactCubeOptions(
+    int cellsPerSide, bool useIterativeSolver, bool useMatrixFreeSolver = false)
+{
+  const int cells = std::max(cellsPerSide, 1);
+  const int n = cells + 1;
+  constexpr double h = 0.04;
+  // Bottom face starts one small gap above the barrier top (z == 0) so the
+  // first steps drive it into the activation band.
+  constexpr double kGroundGap = 0.02;
+
+  sx::DeformableBodyOptions options;
+  options.material.density = 1.0e3;
+  options.material.youngsModulus = 1.5e5;
+  options.material.poissonRatio = 0.3;
+  options.material.useFiniteElementElasticity = true;
+  options.material.useIterativeLinearSolver = useIterativeSolver;
+  options.material.useMatrixFreeLinearSolver = useMatrixFreeSolver;
+
+  for (int k = 0; k < n; ++k) {
+    for (int j = 0; j < n; ++j) {
+      for (int i = 0; i < n; ++i) {
+        options.positions.push_back(
+            Eigen::Vector3d(i * h, j * h, kGroundGap + k * h));
+      }
+    }
+  }
+
+  const auto nodeIndex = [&](int i, int j, int k) {
+    return static_cast<std::size_t>(i + n * (j + n * k));
+  };
+  static constexpr int kCubeTets[6][4]
+      = {{0, 1, 3, 7},
+         {0, 3, 2, 7},
+         {0, 2, 6, 7},
+         {0, 6, 4, 7},
+         {0, 4, 5, 7},
+         {0, 5, 1, 7}};
+  for (int ck = 0; ck < cells; ++ck) {
+    for (int cj = 0; cj < cells; ++cj) {
+      for (int ci = 0; ci < cells; ++ci) {
+        std::array<std::size_t, 8> corner{};
+        for (int b = 0; b < 8; ++b) {
+          corner[static_cast<std::size_t>(b)] = nodeIndex(
+              ci + (b & 1), cj + ((b >> 1) & 1), ck + ((b >> 2) & 1));
+        }
+        for (const auto& tet : kCubeTets) {
+          options.tetrahedra.push_back(
+              {corner[static_cast<std::size_t>(tet[0])],
+               corner[static_cast<std::size_t>(tet[1])],
+               corner[static_cast<std::size_t>(tet[2])],
+               corner[static_cast<std::size_t>(tet[3])]});
+        }
+      }
+    }
+  }
+  // No fixed nodes: the cube is free to fall and rest on the ground barrier.
+  return options;
+}
+
+//==============================================================================
 struct DeformableGridWorld
 {
   DeformableGridWorld(int columns, int rows, bool withGround)
@@ -1271,6 +1341,43 @@ struct DeformableFemCubeWorld
 };
 
 //==============================================================================
+struct DeformableFemContactCubeWorld
+{
+  DeformableFemContactCubeWorld(
+      int cellsPerSide,
+      bool useIterativeSolver,
+      bool useMatrixFreeSolver = false)
+  {
+    sx::RigidBodyOptions groundOptions;
+    groundOptions.isStatic = true;
+    groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+    auto ground = world.addRigidBody("ground", groundOptions);
+    ground.setCollisionShape(
+        sx::CollisionShape::makeBox(Eigen::Vector3d(5.0, 5.0, 0.5)));
+    setGroundBarrierPolicy(ground); // top face at z = 0
+
+    body = world.addDeformableBody(
+        "contact_cube",
+        makeFemContactCubeOptions(
+            cellsPerSide, useIterativeSolver, useMatrixFreeSolver));
+    nodeCount = body.getNodeCount();
+    tetrahedronCount = body.getTetrahedronCount();
+    for (std::size_t i = 0; i < nodeCount; ++i) {
+      totalMass += body.getMass(i);
+    }
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(0.004);
+    world.enterSimulationMode();
+  }
+
+  sx::World world;
+  sx::DeformableBody body;
+  std::size_t nodeCount = 0;
+  std::size_t tetrahedronCount = 0;
+  double totalMass = 0.0;
+};
+
+//==============================================================================
 // Steps a chunky cellsPerSide^3 FEM cube and records the per-step cost and
 // Newton-iteration count. The cube is run with both the sparse Cholesky direct
 // solve (BM_DeformableCube3dDirectStep) and the incomplete-Cholesky
@@ -1346,6 +1453,80 @@ void BM_DeformableCube3dCgStep(benchmark::State& state)
 void BM_DeformableCube3dMatrixFreeCgStep(benchmark::State& state)
 {
   BM_DeformableCube3dStep(
+      state, /*useIterativeSolver=*/false, /*useMatrixFreeSolver=*/true);
+}
+
+//==============================================================================
+// Contact-heavy matrix-free-vs-sparse-CG crossover: an unpinned FEM cube
+// settles on a static ground barrier, so the projected-Newton solve is
+// dominated by the stiff clamped-log barrier Hessian. Running the same scene
+// under sparse incomplete-Cholesky CG and matrix-free block-Jacobi CG at
+// increasing cube resolutions makes their per-step time, CG iterations, and
+// fallbacks-to-steepest-descent directly comparable on contact -- the evidence
+// a future automatic large-mesh matrix-free selection policy needs. Neither
+// path is the default (both are opt-in), so this measures without changing any
+// production selection.
+void BM_DeformableContactCubeStep(
+    benchmark::State& state, bool useIterativeSolver, bool useMatrixFreeSolver)
+{
+  const auto cellsPerSide = static_cast<int>(state.range(0));
+  DeformableFemContactCubeWorld fixture(
+      cellsPerSide, useIterativeSolver, useMatrixFreeSolver);
+
+  double totalNewtonIterations = 0.0;
+  double totalCgIterations = 0.0;
+  double totalMatrixFreeSolves = 0.0;
+  double totalFallbacks = 0.0;
+  double maxCgError = 0.0;
+  std::size_t maxHessianNonZeros = 0;
+  std::size_t maxHessianStorageBytes = 0;
+  for (auto _ : state) {
+    fixture.world.step();
+    const auto& diagnostics
+        = fixture.world.getLastDeformableSolverDiagnostics();
+    totalNewtonIterations += static_cast<double>(diagnostics.solverIterations);
+    totalCgIterations
+        += static_cast<double>(diagnostics.projectedNewtonIterativeIterations);
+    totalMatrixFreeSolves
+        += static_cast<double>(diagnostics.projectedNewtonMatrixFreeSolves);
+    totalFallbacks += static_cast<double>(diagnostics.projectedNewtonFallbacks);
+    maxCgError
+        = std::max(maxCgError, diagnostics.projectedNewtonIterativeMaxError);
+    maxHessianNonZeros = std::max(
+        maxHessianNonZeros, diagnostics.projectedNewtonHessianNonZeros);
+    maxHessianStorageBytes = std::max(
+        maxHessianStorageBytes, diagnostics.projectedNewtonHessianStorageBytes);
+    benchmark::DoNotOptimize(
+        fixture.body.getPosition(fixture.nodeCount - 1u).z());
+  }
+
+  const auto steps = static_cast<double>(state.iterations());
+  state.counters["nodes"] = static_cast<double>(fixture.nodeCount);
+  state.counters["tetrahedra"] = static_cast<double>(fixture.tetrahedronCount);
+  state.counters["total_mass"] = fixture.totalMass;
+  state.counters["newton_iters_per_step"] = totalNewtonIterations / steps;
+  state.counters["cg_iters_per_step"] = totalCgIterations / steps;
+  state.counters["matrix_free_solves_per_step"] = totalMatrixFreeSolves / steps;
+  // Steepest-descent fallbacks per step: the key convergence-regression signal
+  // when a preconditioner cannot carry the stiff-contact solve within the cap.
+  state.counters["fallbacks_per_step"] = totalFallbacks / steps;
+  state.counters["cg_max_error"] = maxCgError;
+  state.counters["hessian_nonzeros"] = static_cast<double>(maxHessianNonZeros);
+  state.counters["hessian_storage_bytes"]
+      = static_cast<double>(maxHessianStorageBytes);
+  state.SetItemsProcessed(
+      static_cast<int64_t>(state.iterations() * fixture.nodeCount));
+}
+
+void BM_DeformableContactCubeCgStep(benchmark::State& state)
+{
+  BM_DeformableContactCubeStep(
+      state, /*useIterativeSolver=*/true, /*useMatrixFreeSolver=*/false);
+}
+
+void BM_DeformableContactCubeMatrixFreeCgStep(benchmark::State& state)
+{
+  BM_DeformableContactCubeStep(
       state, /*useIterativeSolver=*/false, /*useMatrixFreeSolver=*/true);
 }
 
@@ -1847,6 +2028,14 @@ BENCHMARK(BM_DeformableMatrixFreeCgBarStep)->Arg(2)->Arg(8)->Arg(24);
 BENCHMARK(BM_DeformableCube3dDirectStep)->Arg(4)->Arg(6)->Arg(8)->Arg(10);
 BENCHMARK(BM_DeformableCube3dCgStep)->Arg(4)->Arg(6)->Arg(8)->Arg(10);
 BENCHMARK(BM_DeformableCube3dMatrixFreeCgStep)->Arg(4)->Arg(6)->Arg(8);
+// Contact-heavy crossover: same ground-contact cube under sparse IC-CG and
+// matrix-free block-Jacobi CG at increasing resolutions (27/64/125/216 nodes).
+BENCHMARK(BM_DeformableContactCubeCgStep)->Arg(2)->Arg(3)->Arg(4)->Arg(5);
+BENCHMARK(BM_DeformableContactCubeMatrixFreeCgStep)
+    ->Arg(2)
+    ->Arg(3)
+    ->Arg(4)
+    ->Arg(5);
 
 // The 32x16 (512-node) and 48x24 (1152-node) grids exceed the former 256-node
 // dense-solve cap, so they exercise the sparse projected-Newton path; compare

--- a/tests/benchmark/simulation/bm_deformable_body.cpp
+++ b/tests/benchmark/simulation/bm_deformable_body.cpp
@@ -331,8 +331,8 @@ sx::DeformableBodyOptions makeFemCubeOptions(
 // ground barrier (top face at z == 0). Under gravity it drops and settles on
 // the barrier, so the projected-Newton solve is dominated by the near-singular
 // clamped-log barrier Hessian on the contacting bottom nodes -- the stiff,
-// ill-conditioned regime where the matrix-free block-Jacobi preconditioner and
-// the sparse incomplete-Cholesky preconditioner diverge in CG iterations and
+// ill-conditioned regime where the matrix-free block-Jacobi CG path and the
+// assembled sparse Jacobi-preconditioned CG path diverge in iterations and
 // per-step cost. This is the contact-heavy fixture behind the matrix-free vs
 // sparse-CG crossover benchmarks; the crossover it measures (per-step time, CG
 // iterations, and fallbacks-to-steepest-descent as the mesh scales) is the
@@ -1380,8 +1380,8 @@ struct DeformableFemContactCubeWorld
 //==============================================================================
 // Steps a chunky cellsPerSide^3 FEM cube and records the per-step cost and
 // Newton-iteration count. The cube is run with both the sparse Cholesky direct
-// solve (BM_DeformableCube3dDirectStep) and the incomplete-Cholesky
-// preconditioned conjugate-gradient iterative solve (BM_DeformableCube3dCgStep)
+// solve (BM_DeformableCube3dDirectStep) and the Jacobi-preconditioned sparse
+// conjugate-gradient iterative solve (BM_DeformableCube3dCgStep)
 // at matching cell counts, so the direct-vs-iterative crossover is measurable:
 // the direct solve's 3D fill-in makes its per-step time climb super-linearly
 // with the element count, while the iterative solve stays near O(nnz) and
@@ -1460,7 +1460,7 @@ void BM_DeformableCube3dMatrixFreeCgStep(benchmark::State& state)
 // Contact-heavy matrix-free-vs-sparse-CG crossover: an unpinned FEM cube
 // settles on a static ground barrier, so the projected-Newton solve is
 // dominated by the stiff clamped-log barrier Hessian. Running the same scene
-// under sparse incomplete-Cholesky CG and matrix-free block-Jacobi CG at
+// under sparse Jacobi-preconditioned CG and matrix-free block-Jacobi CG at
 // increasing cube resolutions makes their per-step time, CG iterations, and
 // fallbacks-to-steepest-descent directly comparable on contact -- the evidence
 // a future automatic large-mesh matrix-free selection policy needs. Neither
@@ -2023,12 +2023,12 @@ BENCHMARK(BM_DeformableCgBarStep)->Arg(2)->Arg(8)->Arg(24)->Arg(48);
 BENCHMARK(BM_DeformableMatrixFreeCgBarStep)->Arg(2)->Arg(8)->Arg(24);
 // Chunky 3D cube, direct vs iterative at matching cell counts: the direct
 // solve's per-step time climbs super-linearly with the 3D fill-in while the
-// sparse IC-CG and explicit matrix-free CG rows expose the solve-effort and
+// sparse Jacobi-CG and explicit matrix-free CG rows expose the solve-effort and
 // sparse-Hessian footprint tradeoff.
 BENCHMARK(BM_DeformableCube3dDirectStep)->Arg(4)->Arg(6)->Arg(8)->Arg(10);
 BENCHMARK(BM_DeformableCube3dCgStep)->Arg(4)->Arg(6)->Arg(8)->Arg(10);
 BENCHMARK(BM_DeformableCube3dMatrixFreeCgStep)->Arg(4)->Arg(6)->Arg(8);
-// Contact-heavy crossover: same ground-contact cube under sparse IC-CG and
+// Contact-heavy crossover: same ground-contact cube under sparse Jacobi-CG and
 // matrix-free block-Jacobi CG at increasing resolutions (27/64/125/216 nodes).
 BENCHMARK(BM_DeformableContactCubeCgStep)->Arg(2)->Arg(3)->Arg(4)->Arg(5);
 BENCHMARK(BM_DeformableContactCubeMatrixFreeCgStep)

--- a/tests/unit/simulation/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/world/test_deformable_body.cpp
@@ -4432,7 +4432,7 @@ TEST(DeformableBody, MatrixFreeLinearSolverMatchesSolversOnGroundContact)
 // Scaled contact parity: a mid-size FEM cube (64 nodes = 192 DoF, above the
 // dense-direct DoF cap, so the built-in solve never takes the direct path)
 // settling on a ground barrier reaches the same equilibrium under sparse
-// incomplete-Cholesky CG and matrix-free block-Jacobi CG. This is the scaled
+// Jacobi-preconditioned CG and matrix-free block-Jacobi CG. This is the scaled
 // evidence behind a future automatic matrix-free selection: as the contact mesh
 // grows past where a dense direct solve is viable, the matrix-free path must
 // still match the sparse-CG reference and keep zero assembled-Hessian

--- a/tests/unit/simulation/world/test_deformable_body.cpp
+++ b/tests/unit/simulation/world/test_deformable_body.cpp
@@ -1220,6 +1220,66 @@ sx::DeformableBodyOptions makeFemCubeBody(
 }
 
 //==============================================================================
+// A solid cellsPerSide^3 FEM cube, unpinned and started just above the ground
+// barrier top (z == 0). Above cellsPerSide == 2 it exceeds the dense-direct DoF
+// cap, so the built-in solve uses the iterative path -- the scaled contact
+// fixture behind the matrix-free-vs-sparse-CG parity regression.
+sx::DeformableBodyOptions makeFemContactCubeGridBody(
+    int cellsPerSide, double youngsModulus)
+{
+  const int cells = std::max(cellsPerSide, 1);
+  const int n = cells + 1;
+  constexpr double h = 0.04;
+  constexpr double kGroundGap = 0.02;
+  const auto nodeIndex = [&](int i, int j, int k) {
+    return static_cast<std::size_t>(i + n * (j + n * k));
+  };
+
+  sx::DeformableBodyOptions options;
+  options.material.density = 1.0e3;
+  options.material.youngsModulus = youngsModulus;
+  options.material.poissonRatio = 0.3;
+  options.material.useFiniteElementElasticity = true;
+
+  for (int k = 0; k < n; ++k) {
+    for (int j = 0; j < n; ++j) {
+      for (int i = 0; i < n; ++i) {
+        options.positions.push_back(
+            Eigen::Vector3d(i * h, j * h, kGroundGap + k * h));
+      }
+    }
+  }
+
+  static constexpr int kCubeTets[6][4]
+      = {{0, 1, 3, 7},
+         {0, 3, 2, 7},
+         {0, 2, 6, 7},
+         {0, 6, 4, 7},
+         {0, 4, 5, 7},
+         {0, 5, 1, 7}};
+  for (int ck = 0; ck < cells; ++ck) {
+    for (int cj = 0; cj < cells; ++cj) {
+      for (int ci = 0; ci < cells; ++ci) {
+        std::array<std::size_t, 8> corner{};
+        for (int b = 0; b < 8; ++b) {
+          corner[static_cast<std::size_t>(b)] = nodeIndex(
+              ci + (b & 1), cj + ((b >> 1) & 1), ck + ((b >> 2) & 1));
+        }
+        for (const auto& tet : kCubeTets) {
+          options.tetrahedra.push_back(
+              sx::DeformableTetrahedron{
+                  corner[static_cast<std::size_t>(tet[0])],
+                  corner[static_cast<std::size_t>(tet[1])],
+                  corner[static_cast<std::size_t>(tet[2])],
+                  corner[static_cast<std::size_t>(tet[3])]});
+        }
+      }
+    }
+  }
+  return options;
+}
+
+//==============================================================================
 // A volumetric FEM cube dropped onto a static ground barrier settles on the
 // barrier surface intersection-free: gravity pulls it down, the IPC clamped-log
 // ground barrier catches it (no node crosses the ground top), and the stable
@@ -4365,6 +4425,116 @@ TEST(DeformableBody, MatrixFreeLinearSolverMatchesSolversOnGroundContact)
     ASSERT_TRUE(matrixFree.positions[i].allFinite());
     expectVectorNear(sparseCg.positions[i], direct.positions[i], 1e-4);
     expectVectorNear(matrixFree.positions[i], direct.positions[i], 1e-4);
+  }
+}
+
+//==============================================================================
+// Scaled contact parity: a mid-size FEM cube (64 nodes = 192 DoF, above the
+// dense-direct DoF cap, so the built-in solve never takes the direct path)
+// settling on a ground barrier reaches the same equilibrium under sparse
+// incomplete-Cholesky CG and matrix-free block-Jacobi CG. This is the scaled
+// evidence behind a future automatic matrix-free selection: as the contact mesh
+// grows past where a dense direct solve is viable, the matrix-free path must
+// still match the sparse-CG reference and keep zero assembled-Hessian
+// footprint.
+TEST(DeformableBody, MatrixFreeLinearSolverMatchesSparseCgOnScaledGroundContact)
+{
+  struct CubeRun
+  {
+    std::vector<Eigen::Vector3d> positions;
+    std::size_t cgSolves = 0;
+    std::size_t matrixFreeSolves = 0;
+    std::size_t numericFactorizations = 0;
+    std::size_t hessianNonZeros = 0;
+    std::size_t hessianStorageBytes = 0;
+    double minZ = std::numeric_limits<double>::infinity();
+  };
+
+  const auto runCube = [](bool matrixFree) {
+    sx::World world;
+    world.setGravity(Eigen::Vector3d(0.0, 0.0, -9.81));
+    world.setTimeStep(0.004);
+
+    sx::RigidBodyOptions groundOptions;
+    groundOptions.isStatic = true;
+    groundOptions.position = Eigen::Vector3d(0.0, 0.0, -0.5);
+    auto ground = world.addRigidBody("ground", groundOptions);
+    ground.setCollisionShape(
+        sx::CollisionShape::makeBox(Eigen::Vector3d(5.0, 5.0, 0.5)));
+    setGroundBarrierPolicy(ground); // top face at z = 0
+
+    // cellsPerSide == 3 -> 64 nodes = 192 DoF, above the 128-DoF dense-direct
+    // cap, so both runs take the sparse iterative path (no direct fallback).
+    auto options = makeFemContactCubeGridBody(3, 1.5e5);
+    options.material.useIterativeLinearSolver = !matrixFree;
+    options.material.useMatrixFreeLinearSolver = matrixFree;
+    auto body = world.addDeformableBody("contact_cube", options);
+
+    compute::SequentialExecutor executor;
+    compute::DeformableDynamicsStage stage;
+    compute::WorldStepPipeline pipeline;
+    pipeline.addStage(stage);
+
+    CubeRun run;
+    // 80 steps is enough to drop the cube, engage the stiff ground barrier, and
+    // settle; the barrier holds every step, so the intersection-free and parity
+    // assertions do not need a longer, slower run.
+    for (int i = 0; i < 80; ++i) {
+      world.step(executor, pipeline);
+      const auto& stats = stage.getLastStats();
+      run.cgSolves += stats.projectedNewtonIterativeSolves;
+      run.matrixFreeSolves += stats.projectedNewtonMatrixFreeSolves;
+      run.numericFactorizations += stats.projectedNewtonNumericFactorizations;
+      run.hessianNonZeros
+          = std::max(run.hessianNonZeros, stats.projectedNewtonHessianNonZeros);
+      run.hessianStorageBytes = std::max(
+          run.hessianStorageBytes, stats.projectedNewtonHessianStorageBytes);
+    }
+    for (std::size_t i = 0; i < body.getNodeCount(); ++i) {
+      run.positions.push_back(body.getPosition(i));
+      run.minZ = std::min(run.minZ, body.getPosition(i).z());
+    }
+    return run;
+  };
+
+  const CubeRun sparseCg = runCube(/*matrixFree=*/false);
+  const CubeRun matrixFree = runCube(/*matrixFree=*/true);
+
+  // Both take the sparse iterative path (mesh is above the dense-direct cap):
+  // neither factorizes; sparse CG assembles a Hessian while matrix-free does
+  // not.
+  EXPECT_GT(sparseCg.cgSolves, 0u);
+  EXPECT_EQ(sparseCg.numericFactorizations, 0u);
+  EXPECT_GT(sparseCg.hessianNonZeros, 0u);
+  EXPECT_GT(sparseCg.hessianStorageBytes, 0u);
+
+  EXPECT_GT(matrixFree.cgSolves, 0u);
+  EXPECT_EQ(matrixFree.cgSolves, matrixFree.matrixFreeSolves);
+  EXPECT_EQ(matrixFree.numericFactorizations, 0u);
+  EXPECT_EQ(matrixFree.hessianNonZeros, 0u);
+  EXPECT_EQ(matrixFree.hessianStorageBytes, 0u);
+
+  // Both settle intersection-free on the barrier (no node crosses z = 0).
+  EXPECT_GE(sparseCg.minZ, -1e-3);
+  EXPECT_GE(matrixFree.minZ, -1e-3);
+  // ...and both genuinely descend into the barrier activation band (the cube
+  // engages contact rather than free-floating above it), so this is a real
+  // contact-heavy solve, not an elasticity-only one. The cube starts with its
+  // bottom face at z = 0.02 (kGroundGap); settling well below that confirms it
+  // dropped onto and pressed into the barrier.
+  EXPECT_LT(sparseCg.minZ, 0.015);
+  EXPECT_LT(matrixFree.minZ, 0.015);
+
+  // The two preconditioners reach the same settled configuration. Both solve
+  // the same linear system to the same CG residual tolerance each Newton
+  // iteration, so they agree to near machine precision (observed max delta
+  // ~2e-10 over the run); 1e-5 stays comfortably non-flaky while still catching
+  // any genuine matrix-free-vs-sparse-CG divergence (which would be mm-scale).
+  ASSERT_EQ(sparseCg.positions.size(), matrixFree.positions.size());
+  for (std::size_t i = 0; i < sparseCg.positions.size(); ++i) {
+    ASSERT_TRUE(sparseCg.positions[i].allFinite());
+    ASSERT_TRUE(matrixFree.positions[i].allFinite());
+    expectVectorNear(matrixFree.positions[i], sparseCg.positions[i], 1e-5);
   }
 }
 


### PR DESCRIPTION
## Summary

PLAN-081 M7 measurement slice. Produces the evidence a future **automatic
large-mesh matrix-free selection** policy needs, without changing any default
path (both the matrix-free and iterative solvers stay opt-in).

**Benchmark** `BM_DeformableContactCube{Cg,MatrixFreeCg}Step`: an unpinned FEM
cube settles on a static ground barrier, so the projected-Newton solve is
dominated by the stiff clamped-log barrier Hessian — the ill-conditioned regime
where matrix-free block-Jacobi CG and sparse Jacobi-preconditioned CG diverge. The
same scene runs under both solvers at increasing resolutions (27/64/125/216
nodes), emitting per-step **CG iterations**, **matrix-free solves**,
**steepest-descent fallbacks** (the key convergence-regression signal), and
**assembled-Hessian footprint**. Measured sample: sparse-CG footprint grows
2k→12k nnz while matrix-free stays 0.

**Regression** `MatrixFreeLinearSolverMatchesSparseCgOnScaledGroundContact`: a
mid-size 64-node cube (192 DoF, above the 128-DoF dense-direct cap, so the direct
path is never used) settling on a ground barrier reaches the same equilibrium
under sparse CG and matrix-free CG, with matrix-free keeping zero assembled-Hessian
footprint — proving parity holds as the contact mesh scales past where a dense
direct solve is viable.

## Scope

Test/benchmark only — no library or default-solver-path change.

## Verification

- `pixi run test-all` — all 6 categories PASSED (the new regression runs in the
  Simulation Tests suite).
- Benchmark smoke confirms both paths run and emit the crossover counters.
- The regression's position-parity tolerance is `1e-5` — the two preconditioners
  agree to ~2e-10 over the run (both solve the same system to the same CG
  tolerance), so `1e-5` is non-flaky yet tight enough to catch a genuine
  (mm-scale) divergence. It also asserts the cube actually descends into the
  barrier band (a real contact-heavy solve, not free-fall).

## Changelog

**No entry.** Internal benchmark/test evidence tooling; no user-facing change.
