### PR TITLE
Isolate Pixi binary paths in CI

### DIFF
--- a/.github/workflows/api_doc.yml
+++ b/.github/workflows/api_doc.yml
@@ -71,6 +71,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install pixi environment
         run: pixi install --locked

--- a/.github/workflows/ci_gz_physics.yml
+++ b/.github/workflows/ci_gz_physics.yml
@@ -49,6 +49,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -52,6 +52,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Check Lint
         run: |

--- a/.github/workflows/ci_simd.yml
+++ b/.github/workflows/ci_simd.yml
@@ -67,6 +67,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0

--- a/.github/workflows/ci_toolchain.yml
+++ b/.github/workflows/ci_toolchain.yml
@@ -89,6 +89,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Configure, build tests, and run ctest
         env:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -50,6 +50,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
@@ -93,6 +94,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
@@ -136,6 +138,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
@@ -179,6 +182,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -53,6 +53,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi.exe
 
       - name: Check Lint
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,6 +76,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install system dependencies
         if: matrix.run_build

--- a/.github/workflows/performance_dashboard_dart6.yml
+++ b/.github/workflows/performance_dashboard_dart6.yml
@@ -123,6 +123,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Install system dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.3

--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -65,6 +65,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
 
       - name: Check format
         run: |
@@ -180,6 +181,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
           cache: true
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi.exe
 
       - name: Expose pixi dependencies (Windows)
         if: ${{ matrix.os == 'windows-latest' && (matrix.release_only == false || env.DARTPY_REF == 'refs/heads/main' || env.DARTPY_REF == 'main' || startsWith(env.DARTPY_REF, 'refs/heads/release-') || startsWith(env.DARTPY_REF, 'release-') || startsWith(env.DARTPY_REF, 'refs/tags/v') || startsWith(env.DARTPY_REF, 'v')) }}

--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
+          pixi-bin-path: ${{ runner.temp }}/pixi/bin/pixi
           run-install: false
       - name: Update lockfiles
         run: |


### PR DESCRIPTION
## Summary
- configure setup-pixi to install Pixi under the per-job runner temp directory
- apply the same pixi-bin-path across CI workflows so stale ~/.pixi/bin/pixi files cannot break setup

## Root cause
The release-6.20 push run failed in DART 6 Performance Dashboard and CI gz-physics before project code ran. Both jobs failed inside prefix-dev/setup-pixi because /home/runner/.pixi/bin/pixi already existed on the runner. Using runner.temp gives each job an isolated Pixi binary path while preserving setup-pixi caching for the project environment.

## Validation
- pixi run check-lint
- git diff --check
