### PR TITLE
Note the matrix-free contact crossover benchmark in the roadmap and handoff

### DIFF
--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -615,11 +615,27 @@ incomplete.
 
 ## How To Resume
 
-Current slice (2026-07-04) — Fig-23 statistics packet gates (Python-only, no C++ rebuild):
+Current checkpoint (2026-07-04) — maintainer-directed next slice:
 
 ```bash
-git checkout feature/ipc-deformable-fig23-statistics-packet
+git fetch origin main
+git checkout main
+git merge --ff-only origin/main
 git status && git log -3 --oneline
+sed -n '560,610p' docs/dev_tasks/ipc_deformable_solver/RESUME.md
+sed -n '270,295p' docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+```
+
+Do not resume a merged feature branch. Open a new branch only after maintainer
+direction chooses one of the currently blocked or policy-gated M7 follow-ups:
+matrix-free-CG auto-selection, avg-contacts-per-step fixture design,
+process-memory column semantics, M4 asset pipeline work, AMG/multigrid
+preconditioning, or on-device GPU assembly + solve.
+
+Prior merged slice (#3264) — Fig-23 statistics packet gates (archived):
+
+```bash
+# git checkout feature/ipc-deformable-fig23-statistics-packet   # merged as dbe6fcccb1c
 pixi run python -m pytest python/tests/unit/test_write_plan081_deformable_fig23_packet.py -q
 pixi run check-lint-py
 # End-to-end against a real benchmark run (proves the manifest matches real counters):

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -588,7 +588,8 @@ is blocked:
 - Matrix-free-CG auto-selection: the contact-heavy crossover benchmark + mid-size
   scaled parity regression landed (#3274) as the evidence base; choosing the
   automatic very-large-mesh selection policy itself is a maintainer decision
-  (both solvers stay opt-in until then).
+  (sparse Jacobi-CG remains the automatic path above the dense-direct cap, while
+  matrix-free stays opt-in until then).
 - A genuine avg-contacts-per-step axis needs a new evolving multi-step
   self-contact fixture.
 - Process peak-memory tracking needs a memory-column semantics choice.

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -573,19 +573,21 @@ PSD-backend injection). (PR #2747 is another author's.) <- #2760 (GPU-vs-CPU per
 long ago (`74338577982`). The instructions below it about pushing that branch are
 stale — ignore them.
 
-**Current (2026-07-04):** two M7 slices **merged** this cycle — PR #3257
-(peak-contacts diagnostic, `1819b801228`) and PR #3264 (Fig-23 statistics packet,
-`dbe6fcccb1c`). A third small doc-accuracy slice is in progress on
-`docs/deformable-linear-solver-selection-accuracy`: the roadmap's stale
-"direct-solve node cap (20k)" is corrected to the verified current architecture
-(dense LDLT below `kProjectedNewtonDenseDirectDofCap` = 128 DoF / ~42 nodes,
-iterative sparse Jacobi-CG above to a 1M-node ceiling, sparse-direct
-`SimplicialLDLT` kept
-out of the allocation-safe loop). Next substantive M7 work needs maintainer
-direction or is blocked:
+**Current (2026-07-04):** three M7 code slices **merged** this cycle — PR #3257
+(peak-contacts diagnostic, `1819b801228`), PR #3264 (Fig-23 statistics packet,
+`dbe6fcccb1c`), and PR #3274 (matrix-free-vs-sparse-CG contact-heavy crossover
+benchmark + scaled parity regression, `43dbd91474c`). The doc-accuracy slice
+PR #3269 (branch `docs/deformable-linear-solver-selection-accuracy`, open)
+corrects the roadmap's stale "direct-solve node cap (20k)" to the verified current
+architecture (dense LDLT below `kProjectedNewtonDenseDirectDofCap` = 128 DoF /
+~42 nodes, iterative sparse Jacobi-CG above to a 1M-node ceiling, sparse-direct
+`SimplicialLDLT` kept out of the allocation-safe loop) and records the crossover
+benchmark. Next substantive M7 work needs maintainer direction or is blocked:
 
-- Matrix-free-CG auto-selection needs a maintainer crossover-policy decision; a
-  measurement-only crossover benchmark is the safe precursor.
+- Matrix-free-CG auto-selection: the contact-heavy crossover benchmark + mid-size
+  scaled parity regression landed (#3274) as the evidence base; choosing the
+  automatic very-large-mesh selection policy itself is a maintainer decision
+  (both solvers stay opt-in until then).
 - A genuine avg-contacts-per-step axis needs a new evolving multi-step
   self-contact fixture.
 - Process peak-memory tracking needs a memory-column semantics choice.

--- a/docs/dev_tasks/ipc_deformable_solver/RESUME.md
+++ b/docs/dev_tasks/ipc_deformable_solver/RESUME.md
@@ -577,12 +577,13 @@ stale — ignore them.
 (peak-contacts diagnostic, `1819b801228`), PR #3264 (Fig-23 statistics packet,
 `dbe6fcccb1c`), and PR #3274 (matrix-free-vs-sparse-CG contact-heavy crossover
 benchmark + scaled parity regression, `43dbd91474c`). The doc-accuracy slice
-PR #3269 (branch `docs/deformable-linear-solver-selection-accuracy`, open)
-corrects the roadmap's stale "direct-solve node cap (20k)" to the verified current
-architecture (dense LDLT below `kProjectedNewtonDenseDirectDofCap` = 128 DoF /
-~42 nodes, iterative sparse Jacobi-CG above to a 1M-node ceiling, sparse-direct
-`SimplicialLDLT` kept out of the allocation-safe loop) and records the crossover
-benchmark. Next substantive M7 work needs maintainer direction or is blocked:
+PR #3269 (linear-solver-selection accuracy, `28a91b909d6`) is also merged; it
+corrected the roadmap's stale "direct-solve node cap (20k)" to the verified
+current architecture (dense LDLT below `kProjectedNewtonDenseDirectDofCap` = 128
+DoF / ~42 nodes, iterative sparse Jacobi-CG above to a 1M-node ceiling,
+sparse-direct `SimplicialLDLT` kept out of the allocation-safe loop) and records
+the crossover benchmark. Next substantive M7 work needs maintainer direction or
+is blocked:
 
 - Matrix-free-CG auto-selection: the contact-heavy crossover benchmark + mid-size
   scaled parity regression landed (#3274) as the evidence base; choosing the

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -287,7 +287,8 @@ per-step CG iterations, steepest-descent fallbacks, and assembled-Hessian
 footprint, with a mid-size scaled parity regression proving matrix-free matches
 sparse-CG above the dense-direct cap. Remaining hardening: choosing an automatic
 very-large-mesh matrix-free selection policy is a maintainer decision the
-crossover evidence now informs; both solvers stay opt-in until then.
+crossover evidence now informs; sparse Jacobi-CG remains the automatic path
+above the dense-direct cap, while matrix-free stays opt-in until then.
 
 **Fig-23 statistics harness — shape-parity scaffold landed:** the deformable
 solver diagnostics now include the peak active-contact count per step

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -278,8 +278,15 @@ Benchmark rows expose `matrix_free_solves_per_step` plus zero sparse-Hessian
 footprint counters. It is now covered by ground-contact parity regressions: C++
 compares direct sparse, sparse IC-CG, and matrix-free CG on the same contacting
 FEM cube, while dartpy compares direct and matrix-free contact settling.
-Remaining hardening: larger contact-heavy meshes and deciding when matrix-free
-CG becomes the automatic very-large-mesh path.
+A contact-heavy crossover benchmark now measures the trade-off directly:
+`BM_DeformableContactCube{Cg,MatrixFreeCg}Step` runs an unpinned FEM cube settling
+on a stiff ground barrier under both sparse IC-CG and matrix-free block-Jacobi CG
+at increasing resolutions (27/64/125/216 nodes), reporting per-step CG iterations,
+steepest-descent fallbacks, and assembled-Hessian footprint, with a mid-size
+scaled parity regression proving matrix-free matches sparse-CG above the
+dense-direct cap. Remaining hardening: choosing an automatic very-large-mesh
+matrix-free selection policy is a maintainer decision the crossover evidence now
+informs; both solvers stay opt-in until then.
 
 **Fig-23 statistics harness — shape-parity scaffold landed:** the deformable
 solver diagnostics now include the peak active-contact count per step

--- a/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
+++ b/docs/plans/081-deformable-implicit-barrier-solver/ipc-parity-roadmap.md
@@ -276,17 +276,18 @@ The FEM-bar and chunky 3D cube benchmarks report the same `cg_iters_per_step`,
 block-Jacobi preconditioner and reports `projectedNewtonMatrixFreeSolves`.
 Benchmark rows expose `matrix_free_solves_per_step` plus zero sparse-Hessian
 footprint counters. It is now covered by ground-contact parity regressions: C++
-compares direct sparse, sparse IC-CG, and matrix-free CG on the same contacting
-FEM cube, while dartpy compares direct and matrix-free contact settling.
+compares direct sparse, sparse Jacobi-CG, and matrix-free CG on the same
+contacting FEM cube, while dartpy compares direct and matrix-free contact
+settling.
 A contact-heavy crossover benchmark now measures the trade-off directly:
-`BM_DeformableContactCube{Cg,MatrixFreeCg}Step` runs an unpinned FEM cube settling
-on a stiff ground barrier under both sparse IC-CG and matrix-free block-Jacobi CG
-at increasing resolutions (27/64/125/216 nodes), reporting per-step CG iterations,
-steepest-descent fallbacks, and assembled-Hessian footprint, with a mid-size
-scaled parity regression proving matrix-free matches sparse-CG above the
-dense-direct cap. Remaining hardening: choosing an automatic very-large-mesh
-matrix-free selection policy is a maintainer decision the crossover evidence now
-informs; both solvers stay opt-in until then.
+`BM_DeformableContactCube{Cg,MatrixFreeCg}Step` runs an unpinned FEM cube
+settling on a stiff ground barrier under both sparse Jacobi-CG and matrix-free
+block-Jacobi CG at increasing resolutions (27/64/125/216 nodes), reporting
+per-step CG iterations, steepest-descent fallbacks, and assembled-Hessian
+footprint, with a mid-size scaled parity regression proving matrix-free matches
+sparse-CG above the dense-direct cap. Remaining hardening: choosing an automatic
+very-large-mesh matrix-free selection policy is a maintainer decision the
+crossover evidence now informs; both solvers stay opt-in until then.
 
 **Fig-23 statistics harness — shape-parity scaffold landed:** the deformable
 solver diagnostics now include the peak active-contact count per step


### PR DESCRIPTION
## Summary

Doc-maintenance follow-up to PR #3274 (merged). Records the contact-heavy
matrix-free-vs-sparse-CG crossover benchmark + mid-size scaled parity regression
in the PLAN-081 roadmap as the evidence base for a future automatic large-mesh
matrix-free selection policy, and reframes that hardening item as a maintainer
decision the crossover evidence now informs. Sparse Jacobi-CG remains the
automatic path above the dense-direct cap, while matrix-free stays opt-in until
that policy decision. Also marks #3274 and #3269 merged in the IPC deformable
resume handoff and refreshes the current resume checkpoint.

## Motivation / Problem

The PLAN-081 roadmap and IPC deformable resume handoff still needed the
post-merge state from #3269 and #3274 recorded in the active owner docs so the
next M7 work starts from current evidence.

## Changes / Key Changes

- Add the contact-heavy matrix-free-vs-sparse-CG crossover benchmark and scaled
  parity regression to the PLAN-081 roadmap evidence.
- Mark the #3269 and #3274 slices merged in the IPC deformable resume handoff.
- Replace the stale Fig-23 branch resume command with a maintainer-directed
  current checkpoint and archive the merged #3264 validation commands.
- Keep automatic very-large-mesh matrix-free selection as a maintainer policy
  decision informed by the new evidence; sparse Jacobi-CG remains the automatic
  above-cap path, while matrix-free remains opt-in.

## Testing

- `pixi run lint`

## Breaking Changes

None.

## Related Issues / PRs

Follows #3269 and #3274.

## Changelog

**No entry.** Internal planning-doc update; no user-facing change.
