### PR TITLE
Correct rigid IPC tunnel-arrest note: friction stiction, not CCD

### DIFF
--- a/docs/dev_tasks/rigid_ipc_solver/README.md
+++ b/docs/dev_tasks/rigid_ipc_solver/README.md
@@ -215,13 +215,18 @@
         floor/ceiling corridor at high speed, activates rigid IPC contact, stays
         finite, keeps advancing along the tunnel axis, and stays within the
         fixed wall clearances. The three-wall, four-wall, and 8K tunnel rows
-        remain planned: at their tighter 0.1 mm clearance the conservative
-        curved-CCD line search limits each step to about the separation
-        distance, so a fast cube is arrested (intersection-free but ~3 mm of
-        travel) rather than traversing the channel, and the dense 8K walls are
-        too slow for a unit test pending dense-contact performance work. These
-        are next gaps for the conservative-CCD/performance climb, not
-        test-authoring gaps.
+        remain planned. Root cause is DART's lagged-friction stiction at their
+        tighter 0.1 mm clearance: the strong barrier normal forces there drive
+        large friction (A/B evidence on 3-walls at 100 m/s over 6 steps: with
+        default friction the cube freezes after the first partial step, ~3 mm
+        total travel with 12 active friction constraints; with
+        `frictionIterations=0` it traverses ~1.1 m intersection-free). The
+        conservative curved-CCD line search additionally caps each step to
+        ~0.18 m at that speed, but that alone still lets the cube traverse, so
+        friction stiction -- not CCD -- is the dominant arrest. The reference
+        solver traverses these tunnels with friction, so the gap is DART's
+        tight-clearance friction robustness (plus dense-contact performance for
+        the 8K walls), not test authoring or anti-tunneling/CCD.
   - [x] Add the first audited tessellated-plane fixture coverage through the
         opt-in runtime stage. A cube falls onto a fixed two-triangle mesh plane,
         activates contact, stays finite, and preserves nonnegative clearance.
@@ -485,9 +490,10 @@
   - [x] Mark the audited 3D two-wall tunnel unit-test fixture row
         (`fixtures/3D/unit-tests/tunnel/2-walls.json`) as implemented after
         two-wall tunnel corridor runtime coverage landed. The three-wall,
-        four-wall, and 8K tunnel variants remain planned: the conservative
-        curved-CCD line search arrests a fast cube at their tighter 0.1 mm
-        clearance, and the 8K walls are too slow for a unit test.
+        four-wall, and 8K tunnel variants remain planned: DART's lagged-friction
+        stiction freezes a fast cube at their tighter 0.1 mm clearance (see the
+        Phase 3 note above for the friction-on vs friction-off evidence), and
+        the 8K walls are too slow for a unit test.
   - [x] Mark the audited 3D two-triangle tessellated-plane unit-test fixture row
         (`fixtures/3D/unit-tests/tessellated-plane/two-triangles.json`) as
         implemented after cube-on-two-triangle-plane runtime coverage landed.

--- a/docs/dev_tasks/rigid_ipc_solver/RESUME.md
+++ b/docs/dev_tasks/rigid_ipc_solver/RESUME.md
@@ -30,14 +30,21 @@ Delivered a bounded Phase 3/6 runtime-manifest slice:
 - Deferred the three-wall, four-wall, and 8K tunnel rows with evidence. A pre-PR
   adversarial review flagged that a bare `> startX` progress assertion could pass
   a frozen cube; adding a `startX + 0.1` margin then EXPOSED that at the faithful
-  0.1 mm clearance of `3-walls.json`/`4-walls.json` the conservative curved-CCD
-  line search limits each step to about the separation distance, so the cube is
-  arrested (intersection-free but only ~3 mm / ~56 mm of travel) rather than
-  traversing. Loosening the gap would be an overclaim (their fixtures' defining
-  feature is the 0.1 mm tolerance), so those rows stay planned as a
-  conservative-CCD/performance gap. The 8K variant additionally holds active
-  contact against two 8192-triangle walls every step (~minutes/step), too slow
-  for a unit test -- tied to the dense-contact performance work in
+  0.1 mm clearance of `3-walls.json`/`4-walls.json` the fast cube is arrested
+  (intersection-free but only ~3 mm / ~56 mm of travel) rather than traversing.
+  A follow-up A/B diagnostic (3-walls, 100 m/s, 6 steps) pinned the mechanism:
+  with default lagged friction the cube freezes after the first partial step
+  (~3 mm total, 12 active friction constraints); with `frictionIterations=0` it
+  traverses ~1.1 m intersection-free. So the arrest is DART lagged-friction
+  stiction at the strong tight-clearance barrier normal forces -- NOT the
+  conservative curved-CCD line search (which only caps each step to ~0.18 m at
+  that speed, still enough to traverse). An earlier session note mis-attributed
+  this to CCD step-limiting; corrected here and in README/manifest. Loosening the
+  gap or disabling friction would be an overclaim (the fixtures use friction and
+  the 0.1 mm tolerance is their defining feature), so those rows stay planned as
+  a tight-clearance friction-robustness gap. The 8K variant additionally holds
+  active contact against two 8192-triangle walls every step (~minutes/step), too
+  slow for a unit test -- tied to the dense-contact performance work in
   `benchmarks.md`.
 
 Environment note (this checkout): plain `pixi run ninja ...` compiles but fails

--- a/docs/plans/082-rigid-implicit-barrier-contact/rigid_ipc_fixture_manifest.json
+++ b/docs/plans/082-rigid-implicit-barrier-contact/rigid_ipc_fixture_manifest.json
@@ -8618,7 +8618,7 @@
         "meshes/plane.obj"
       ],
       "dart_command_or_ctest_or_benchmark": "pixi run bash -lc 'build/default/cpp/Release/bin/test_rigid_ipc_paper_experiments --gtest_color=no --gtest_filter=RigidIpcPaperExperiments.TwoWallTunnelCubeStaysBetweenWallsFixtureRow'",
-      "notes_or_gap": "Covered by DART-owned two-wall tunnel runtime coverage for the 3D unit-test fixture mechanism. The three-wall, four-wall, and 8K tunnel rows remain planned: at their tighter 0.1 mm clearance the conservative curved-CCD line search limits each step to about the separation distance, so a fast cube is arrested rather than traversing, and the dense 8K walls are too slow for a unit test pending dense-contact performance work."
+      "notes_or_gap": "Covered by DART-owned two-wall tunnel runtime coverage for the 3D unit-test fixture mechanism. The three-wall, four-wall, and 8K tunnel rows remain planned: at their tighter 0.1 mm clearance DART's lagged-friction stiction freezes the fast cube (A/B evidence: default friction ~3 mm travel with 12 active friction constraints vs frictionIterations=0 ~1.1 m intersection-free traversal), not the conservative curved-CCD line search; and the dense 8K walls are too slow for a unit test pending dense-contact performance work."
     },
     {
       "upstream_path": "fixtures/3D/unit-tests/tunnel/3-walls.json",

--- a/scripts/generate_rigid_ipc_fixture_manifest.py
+++ b/scripts/generate_rigid_ipc_fixture_manifest.py
@@ -233,11 +233,13 @@ IMPLEMENTED_FIXTURE_ROWS = {
         "notes_or_gap": (
             "Covered by DART-owned two-wall tunnel runtime coverage for the 3D "
             "unit-test fixture mechanism. The three-wall, four-wall, and 8K "
-            "tunnel rows remain planned: at their tighter 0.1 mm clearance the "
-            "conservative curved-CCD line search limits each step to about the "
-            "separation distance, so a fast cube is arrested rather than "
-            "traversing, and the dense 8K walls are too slow for a unit test "
-            "pending dense-contact performance work."
+            "tunnel rows remain planned: at their tighter 0.1 mm clearance "
+            "DART's lagged-friction stiction freezes the fast cube (A/B "
+            "evidence: default friction ~3 mm travel with 12 active friction "
+            "constraints vs frictionIterations=0 ~1.1 m intersection-free "
+            "traversal), not the conservative curved-CCD line search; and the "
+            "dense 8K walls are too slow for a unit test pending dense-contact "
+            "performance work."
         ),
     },
     "fixtures/3D/unit-tests/erleben/cliff-edges.json": {


### PR DESCRIPTION
## Summary

- Correct a mis-attributed technical claim in the rigid IPC dev-task docs (merged in #3266): the three/four-wall/8K tunnel rows are deferred because DART's **lagged-friction stiction** freezes a fast cube at their tight 0.1 mm clearance, **not** because of the conservative curved-CCD line search.

## Motivation / Problem

- #3266 deferred those tunnel rows with a rationale that named the conservative curved-CCD line search as the cause. A follow-up A/B diagnostic shows that attribution is wrong, so the merged next-gap characterization would send future work to the wrong subsystem (CCD) instead of the real one (tight-clearance friction robustness).

## Evidence (3-walls, 100 m/s, 6 steps)

| Configuration | Total advance | Active friction constraints | CCD limiting |
| --- | --- | --- | --- |
| Default lagged friction | ~3 mm (freezes after step 0) | 12 | not limiting after step 0 (`lastBound=1`) |
| `frictionIterations=0` | ~1.1 m, intersection-free | 0 | caps step to ~0.18 m, still traverses |

So friction stiction — driven by the strong barrier normal forces at 0.1 mm — is the dominant arrest; the CCD alone still lets the cube traverse. The reference rigid-ipc solver traverses these tunnels *with* friction, so the gap is DART's tight-clearance friction robustness (plus dense-contact performance for the 8K walls).

## Changes / Key Changes

- `docs/dev_tasks/rigid_ipc_solver/README.md`, `RESUME.md`: correct the deferral rationale with the friction-vs-CCD evidence.
- `scripts/generate_rigid_ipc_fixture_manifest.py` + regenerated `docs/plans/082-rigid-implicit-barrier-contact/rigid_ipc_fixture_manifest.json`: update the two-wall row's `notes_or_gap` accordingly.
- No test, solver, or public API changes.

## Testing

- `pixi run python scripts/generate_rigid_ipc_fixture_manifest.py --upstream-dir <rigid-ipc@23b6ba6>` — idempotent
- `pixi run python scripts/check_rigid_ipc_fixture_manifest.py` (offline + `--upstream-dir`) — OK, 798 entries
- `pixi run pytest tests/test_rigid_ipc_fixture_manifest_tools.py` — 50/50
- `pixi run lint` — pass

## Breaking Changes

- [x] None
