### PR TITLE
Fix FreeBSD split impulse validation

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -52,10 +52,9 @@ jobs:
     # host setup. They do not carry the `ubuntu-24.04` label, so pinning it keeps
     # this job on GitHub-hosted runners where the VM action works.
     runs-on: ubuntu-24.04
-    # Advisory: hosted runners lack nested KVM so the VM runs under slower TCG
-    # emulation, and a few tests are known-flaky under emulation. Keep it
-    # non-blocking, as the former job was.
-    continue-on-error: true
+    # Hosted runners lack nested KVM so the VM runs under slower TCG emulation.
+    # Keep the timeout high enough for the slow VM, but do not mask ctest
+    # failures: release validation must go red when the FreeBSD test suite fails.
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -445,14 +445,12 @@ void World::suppressShallowSupportedFreeRootDrift(
   }
 
   const Eigen::Vector3d up = -gravity.normalized();
-  constexpr double kRootLinearLegacyDriftSpeed = 1e-5;
   constexpr double kRootLinearDriftSpeedCap = 2e-4;
   constexpr double kRootLinearDriftFinalQuietRatio = 0.5;
-  // Use the bounded platform-jitter gate for the legacy always-awake path too.
-  // FreeBSD's VM-backed contact solve can leak a larger cross-axis Baumgarte
-  // component than Linux while still remaining well inside the tiny drift band.
-  // Explicit or pre-contact low-speed motion is still preserved by the target
-  // selection below, so this only expands the contact-solve delta we remove.
+  // Use the configured final-quiet threshold when deactivation is enabled, so
+  // callers can tighten this gate by tuning DeactivationOptions. The legacy
+  // always-awake path has no threshold, so it keeps the bounded platform-jitter
+  // cap that absorbs FreeBSD VM-backed cross-axis Baumgarte leakage.
   double rootLinearDriftSpeed = kRootLinearDriftSpeedCap;
   if (mDeactivationOptions.mEnabled) {
     const double finalQuietLinearSpeed = std::max(
@@ -460,9 +458,7 @@ void World::suppressShallowSupportedFreeRootDrift(
         kFinalSleepLinearRatio * mDeactivationOptions.mLinearSpeedThreshold);
     rootLinearDriftSpeed = std::min(
         kRootLinearDriftSpeedCap,
-        std::max(
-            kRootLinearLegacyDriftSpeed,
-            kRootLinearDriftFinalQuietRatio * finalQuietLinearSpeed));
+        kRootLinearDriftFinalQuietRatio * finalQuietLinearSpeed);
   }
   constexpr double kRootAngularDriftSpeed = 5e-4;
   const bool preSolveClearsStoredTarget

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -369,8 +369,12 @@ void World::clearUnsupportedShallowSupportFreeRootVelocityStates(
     state.mTiltVelocity.setZero();
     state.mHasUnsupportedLateralVelocity = false;
     state.mHasUnsupportedTiltVelocity = false;
+    state.mHasResetLateralVelocity = false;
+    state.mHasResetTiltVelocity = false;
     state.mUnsupportedLateralVelocity.setZero();
     state.mUnsupportedTiltVelocity.setZero();
+    state.mResetLateralVelocity.setZero();
+    state.mResetTiltVelocity.setZero();
 
     if (!canStoreUnsupportedVelocities || i >= preSolveVelocities.size())
       continue;
@@ -405,6 +409,48 @@ void World::updateShallowSupportFreeRootVelocityVersions()
     if (skeleton)
       mShallowSupportFreeRootVelocityStates[i].mObservedVelocityVersion
           = skeleton->getVelocityVersion();
+  }
+}
+
+//==============================================================================
+void World::captureResetShallowSupportFreeRootVelocityTargets()
+{
+  syncShallowSupportFreeRootVelocityStates();
+
+  if (mGravity.squaredNorm() == 0.0)
+    return;
+
+  const Eigen::Vector3d up = -mGravity.normalized();
+  for (std::size_t i = 0; i < mSkeletons.size(); ++i) {
+    const auto& skeleton = mSkeletons[i];
+    if (!skeleton || !skeleton->isMobile())
+      continue;
+
+    const auto* rootBody = getRootBodyNodeIfAny(*skeleton);
+    if (rootBody == nullptr)
+      continue;
+
+    const auto* freeJoint
+        = dynamic_cast<const dynamics::FreeJoint*>(rootBody->getParentJoint());
+    if (freeJoint == nullptr)
+      continue;
+
+    auto& state = mShallowSupportFreeRootVelocityStates[i];
+    const Eigen::Vector3d linearVelocity = rootBody->getLinearVelocity();
+    const Eigen::Vector3d verticalVelocity = up * linearVelocity.dot(up);
+    const Eigen::Vector3d lateralVelocity = linearVelocity - verticalVelocity;
+    if (hasFiniteNonzeroVelocity(lateralVelocity)) {
+      state.mHasResetLateralVelocity = true;
+      state.mResetLateralVelocity = lateralVelocity;
+    }
+
+    const Eigen::Vector3d angularVelocity = rootBody->getAngularVelocity();
+    const Eigen::Vector3d yawVelocity = up * angularVelocity.dot(up);
+    const Eigen::Vector3d tiltVelocity = angularVelocity - yawVelocity;
+    if (hasFiniteNonzeroVelocity(tiltVelocity)) {
+      state.mHasResetTiltVelocity = true;
+      state.mResetTiltVelocity = tiltVelocity;
+    }
   }
 }
 
@@ -505,6 +551,12 @@ void World::suppressShallowSupportedFreeRootDrift(
     targetLateralVelocity = state.mUnsupportedLateralVelocity;
     targetPreservesLateralVelocity
         = hasFiniteNonzeroVelocity(targetLateralVelocity);
+  } else if (
+      !preSolveClearsStoredTarget && state.mHasResetLateralVelocity
+      && state.mResetLateralVelocity.allFinite()) {
+    targetLateralVelocity = state.mResetLateralVelocity;
+    targetPreservesLateralVelocity
+        = hasFiniteNonzeroVelocity(targetLateralVelocity);
   }
 
   const bool clampedLateralVelocity
@@ -549,6 +601,11 @@ void World::suppressShallowSupportedFreeRootDrift(
       && state.mUnsupportedTiltVelocity.allFinite()) {
     targetTiltVelocity = state.mUnsupportedTiltVelocity;
     targetPreservesTiltVelocity = hasFiniteNonzeroVelocity(targetTiltVelocity);
+  } else if (
+      !preSolveClearsStoredTarget && state.mHasResetTiltVelocity
+      && state.mResetTiltVelocity.allFinite()) {
+    targetTiltVelocity = state.mResetTiltVelocity;
+    targetPreservesTiltVelocity = hasFiniteNonzeroVelocity(targetTiltVelocity);
   }
 
   const bool clampedTiltVelocity
@@ -572,8 +629,12 @@ void World::suppressShallowSupportedFreeRootDrift(
 
   state.mHasUnsupportedLateralVelocity = false;
   state.mHasUnsupportedTiltVelocity = false;
+  state.mHasResetLateralVelocity = false;
+  state.mHasResetTiltVelocity = false;
   state.mUnsupportedLateralVelocity.setZero();
   state.mUnsupportedTiltVelocity.setZero();
+  state.mResetLateralVelocity.setZero();
+  state.mResetTiltVelocity.setZero();
 }
 
 //==============================================================================
@@ -926,6 +987,7 @@ void World::reset()
   invalidateLastStepRestingWorldState();
   clearUnsupportedShallowSupportFreeRootVelocityStates({});
   updateShallowSupportFreeRootVelocityVersions();
+  captureResetShallowSupportFreeRootVelocityTargets();
 
   for (auto& skel : mSkeletons) {
     skel->clearConstraintImpulses();

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -448,14 +448,21 @@ void World::suppressShallowSupportedFreeRootDrift(
   constexpr double kRootLinearLegacyDriftSpeed = 1e-5;
   constexpr double kRootLinearDriftSpeedCap = 2e-4;
   constexpr double kRootLinearDriftFinalQuietRatio = 0.5;
-  double rootLinearDriftSpeed = kRootLinearLegacyDriftSpeed;
+  // Use the bounded platform-jitter gate for the legacy always-awake path too.
+  // FreeBSD's VM-backed contact solve can leak a larger cross-axis Baumgarte
+  // component than Linux while still remaining well inside the tiny drift band.
+  // Explicit or pre-contact low-speed motion is still preserved by the target
+  // selection below, so this only expands the contact-solve delta we remove.
+  double rootLinearDriftSpeed = kRootLinearDriftSpeedCap;
   if (mDeactivationOptions.mEnabled) {
     const double finalQuietLinearSpeed = std::max(
         0.0,
         kFinalSleepLinearRatio * mDeactivationOptions.mLinearSpeedThreshold);
     rootLinearDriftSpeed = std::min(
         kRootLinearDriftSpeedCap,
-        kRootLinearDriftFinalQuietRatio * finalQuietLinearSpeed);
+        std::max(
+            kRootLinearLegacyDriftSpeed,
+            kRootLinearDriftFinalQuietRatio * finalQuietLinearSpeed));
   }
   constexpr double kRootAngularDriftSpeed = 5e-4;
   const bool preSolveClearsStoredTarget
@@ -481,10 +488,12 @@ void World::suppressShallowSupportedFreeRootDrift(
       = preSolveVelocity.mLinear - preSolveVerticalVelocity;
   Eigen::Vector3d targetLateralVelocity = Eigen::Vector3d::Zero();
   bool targetPreservesLateralVelocity = false;
+  // Unedited shallow-contact residuals inside the same platform drift band are
+  // contact leakage, not a new intentional baseline.
   const bool preservePreSolveLateralVelocity
       = hasFiniteNonzeroVelocity(preSolveLateralVelocity)
         && (preSolveClearsStoredTarget
-            || preSolveLateralVelocity.norm() > kRootLinearLegacyDriftSpeed);
+            || preSolveLateralVelocity.norm() > rootLinearDriftSpeed);
   if (preservePreSolveLateralVelocity) {
     targetLateralVelocity = preSolveLateralVelocity;
     targetPreservesLateralVelocity = true;

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -416,10 +416,14 @@ protected:
     bool mPreserveTiltVelocity = false;
     bool mHasUnsupportedLateralVelocity = false;
     bool mHasUnsupportedTiltVelocity = false;
+    bool mHasResetLateralVelocity = false;
+    bool mHasResetTiltVelocity = false;
     Eigen::Vector3d mLateralVelocity = Eigen::Vector3d::Zero();
     Eigen::Vector3d mTiltVelocity = Eigen::Vector3d::Zero();
     Eigen::Vector3d mUnsupportedLateralVelocity = Eigen::Vector3d::Zero();
     Eigen::Vector3d mUnsupportedTiltVelocity = Eigen::Vector3d::Zero();
+    Eigen::Vector3d mResetLateralVelocity = Eigen::Vector3d::Zero();
+    Eigen::Vector3d mResetTiltVelocity = Eigen::Vector3d::Zero();
   };
 
   /// Runs the post-step rest-detection pass: puts quiet mobile skeletons to
@@ -480,6 +484,9 @@ protected:
 
   /// Records current per-skeleton velocity versions after internal step writes.
   void updateShallowSupportFreeRootVelocityVersions();
+
+  /// Captures reset-time free-root velocity targets for the next step.
+  void captureResetShallowSupportFreeRootVelocityTargets();
 
   /// Removes tiny shallow-support solver drift from a free-root skeleton.
   void suppressShallowSupportedFreeRootDrift(

--- a/tests/integration/test_SplitImpulse.cpp
+++ b/tests/integration/test_SplitImpulse.cpp
@@ -391,6 +391,36 @@ TEST(Issue201, ShallowSupportRespectsTunedDeactivationDriftGate)
 }
 
 //==============================================================================
+// Reset-time initial velocities are caller-provided state, even though reset()
+// refreshes the observed velocity version. They should remain valid shallow
+// support targets instead of being classified as solver drift.
+TEST(Issue201, ShallowSupportPreservesResetInitialLowSpeedMotion)
+{
+  auto world = simulation::World::create();
+  auto floor = createFloor();
+  floor->setMobile(false);
+  world->addSkeleton(floor);
+
+  const double penetration = 5e-5;
+  auto box = createBox(kBoxSize / 2.0 - penetration);
+  world->addSkeleton(box);
+
+  auto* rootBody = box->getRootBodyNode();
+  ASSERT_NE(rootBody, nullptr);
+  auto* rootJoint = dynamic_cast<FreeJoint*>(rootBody->getParentJoint());
+  ASSERT_NE(rootJoint, nullptr);
+
+  const double lateralSpeed = 5e-5;
+  rootJoint->setLinearVelocity(
+      Eigen::Vector3d(lateralSpeed, 0.0, 0.0), Frame::World(), Frame::World());
+  world->reset();
+  world->step();
+
+  ASSERT_GT(world->getLastCollisionResult().getNumContacts(), 0u);
+  EXPECT_NEAR(rootBody->getLinearVelocity().x(), lateralSpeed, 1e-8);
+}
+
+//==============================================================================
 // Low-speed passive motion that existed before the first shallow support
 // contact is also a valid baseline. The suppression must remove only the
 // contact-solve delta, not the pre-contact motion.

--- a/tests/integration/test_SplitImpulse.cpp
+++ b/tests/integration/test_SplitImpulse.cpp
@@ -355,6 +355,42 @@ TEST(Issue201, ShallowSupportPreservesIntentionalLowSpeedMotion)
 }
 
 //==============================================================================
+// When deactivation thresholds are tuned lower than the default, the shallow
+// support drift gate must follow the configured final-quiet band instead of a
+// fixed legacy floor.
+TEST(Issue201, ShallowSupportRespectsTunedDeactivationDriftGate)
+{
+  auto world = simulation::World::create();
+  auto options = world->getDeactivationOptions();
+  options.mLinearSpeedThreshold = 1e-5;
+  options.mTimeUntilSleep = 0.0;
+  world->setDeactivationOptions(options);
+
+  auto floor = createFloor();
+  floor->setMobile(false);
+  world->addSkeleton(floor);
+
+  const double penetration = 5e-5;
+  auto box = createBox(kBoxSize / 2.0 - penetration);
+  world->addSkeleton(box);
+
+  auto* rootBody = box->getRootBodyNode();
+  ASSERT_NE(rootBody, nullptr);
+  auto* rootJoint = dynamic_cast<FreeJoint*>(rootBody->getParentJoint());
+  ASSERT_NE(rootJoint, nullptr);
+
+  const double lateralSpeed = 8e-6;
+  rootJoint->setLinearVelocity(
+      Eigen::Vector3d(lateralSpeed, 0.0, 0.0), Frame::World(), Frame::World());
+  world->reset();
+  world->step();
+
+  ASSERT_GT(world->getLastCollisionResult().getNumContacts(), 0u);
+  EXPECT_NEAR(rootBody->getLinearVelocity().x(), lateralSpeed, 1e-8);
+  EXPECT_FALSE(box->isSleepCandidate());
+}
+
+//==============================================================================
 // Low-speed passive motion that existed before the first shallow support
 // contact is also a valid baseline. The suppression must remove only the
 // contact-solve delta, not the pre-contact motion.


### PR DESCRIPTION
## Summary
- Expand shallow-support free-root drift suppression to cover the FreeBSD VM contact-solver jitter still within the intended tiny-drift band.
- Keep explicit or pre-contact low-speed motion preserved while removing contact-solve lateral drift.
- Make FreeBSD release validation fail on ctest failures instead of masking them with `continue-on-error`.

## Evidence
The current `release-6.20` FreeBSD workflow reported success, but its log contained:
- `test_SplitImpulse` failed in `Issue201.ShallowSupportedFreeRootDoesNotDriftSideways`
- `99% tests passed, 1 tests failed out of 124`

## Testing
- `pixi run build-tests`
- `pixi run bash -lc 'ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/Release -R "^test_SplitImpulse$" --output-on-failure'`
- `pixi run bash -lc 'ctest --test-dir build/$PIXI_ENVIRONMENT_NAME/cpp/Release -R "^(test_SplitImpulse|test_IslandDeactivation|test_World)$" --output-on-failure'`
- `pixi run check-lint-cpp`
- `pixi run check-lint-spell`
- `git diff --check`
