### PR TITLE
Add the oracle role to the dart-new-team-task workflow

### DIFF
--- a/.claude/commands/dart-new-team-task.md
+++ b/.claude/commands/dart-new-team-task.md
@@ -69,13 +69,22 @@ bounded single-session task.
      (worktrees for parallel mutation).
    - **Review lanes stay independent**: a session that implemented a packet
      never approves it.
+   - **Critical decisions, hard failures, and research synthesis go to the
+     oracle**: the strongest available Claude model (this orchestrator
+     session, or a dedicated deep-reasoning pass when coordination state
+     crowds it out). Escalate when a consequential decision is hard to
+     reverse or must be made from conflicting or incomplete evidence, when a
+     packet bounces twice or a failure resists worker root-causing, or when
+     research must be synthesized into a design call. Spend oracle passes on
+     judgment, not on routine implementation or searches.
    - Fallback public path: without Codex or team tooling, execute packets
      sequentially via `dart-execute-packet`; the packet contract is
      unchanged.
 6. **Supervise and steer** - Monitor progress; unblock, reassign, or re-cut
    packets on scope mismatch. Review every returned packet against its
    acceptance evidence before recording it done. Root-cause failures instead
-   of patching around them; fold newly discovered unknowns back into step 2.
+   of patching around them, escalating to the oracle when workers stall;
+   fold newly discovered unknowns back into step 2.
 7. **Verify and close** - Run the task-specific gates from
    `docs/ai/verification.md` and `pixi run lint` before commits; record
    evidence per packet. Complete the principle audit. Promote durable
@@ -115,6 +124,11 @@ Logistics:
 - Use team mode for parallel lanes: named Claude teammates for iterative
   build/test and coordination work; keep authoring and review lanes
   separate; keep concurrent file ownership disjoint.
+- Use the strongest Claude model as the oracle, smartly: critical decision
+  making, challenging issues Codex cannot resolve properly (escalate after
+  two bounced attempts or a failure workers cannot root-cause), and deep
+  research synthesis; do not spend oracle passes on routine implementation
+  or searches; those stay with workers.
 - Set the session goal (/goal) to the Done-when contract so orchestration
   cannot stop early.
 - Read docs/ai/principles.md and docs/ai/north-star.md before starting;

--- a/.codex/skills/dart-new-team-task/SKILL.md
+++ b/.codex/skills/dart-new-team-task/SKILL.md
@@ -89,13 +89,22 @@ bounded single-session task.
      (worktrees for parallel mutation).
    - **Review lanes stay independent**: a session that implemented a packet
      never approves it.
+   - **Critical decisions, hard failures, and research synthesis go to the
+     oracle**: the strongest available Claude model (this orchestrator
+     session, or a dedicated deep-reasoning pass when coordination state
+     crowds it out). Escalate when a consequential decision is hard to
+     reverse or must be made from conflicting or incomplete evidence, when a
+     packet bounces twice or a failure resists worker root-causing, or when
+     research must be synthesized into a design call. Spend oracle passes on
+     judgment, not on routine implementation or searches.
    - Fallback public path: without Codex or team tooling, execute packets
      sequentially via `dart-execute-packet`; the packet contract is
      unchanged.
 6. **Supervise and steer** - Monitor progress; unblock, reassign, or re-cut
    packets on scope mismatch. Review every returned packet against its
    acceptance evidence before recording it done. Root-cause failures instead
-   of patching around them; fold newly discovered unknowns back into step 2.
+   of patching around them, escalating to the oracle when workers stall;
+   fold newly discovered unknowns back into step 2.
 7. **Verify and close** - Run the task-specific gates from
    `docs/ai/verification.md` and `pixi run lint` before commits; record
    evidence per packet. Complete the principle audit. Promote durable
@@ -135,6 +144,11 @@ Logistics:
 - Use team mode for parallel lanes: named Claude teammates for iterative
   build/test and coordination work; keep authoring and review lanes
   separate; keep concurrent file ownership disjoint.
+- Use the strongest Claude model as the oracle, smartly: critical decision
+  making, challenging issues Codex cannot resolve properly (escalate after
+  two bounced attempts or a failure workers cannot root-cause), and deep
+  research synthesis; do not spend oracle passes on routine implementation
+  or searches; those stay with workers.
 - Set the session goal (/goal) to the Done-when contract so orchestration
   cannot stop early.
 - Read docs/ai/principles.md and docs/ai/north-star.md before starting;

--- a/.opencode/command/dart-new-team-task.md
+++ b/.opencode/command/dart-new-team-task.md
@@ -73,13 +73,22 @@ bounded single-session task.
      (worktrees for parallel mutation).
    - **Review lanes stay independent**: a session that implemented a packet
      never approves it.
+   - **Critical decisions, hard failures, and research synthesis go to the
+     oracle**: the strongest available Claude model (this orchestrator
+     session, or a dedicated deep-reasoning pass when coordination state
+     crowds it out). Escalate when a consequential decision is hard to
+     reverse or must be made from conflicting or incomplete evidence, when a
+     packet bounces twice or a failure resists worker root-causing, or when
+     research must be synthesized into a design call. Spend oracle passes on
+     judgment, not on routine implementation or searches.
    - Fallback public path: without Codex or team tooling, execute packets
      sequentially via `dart-execute-packet`; the packet contract is
      unchanged.
 6. **Supervise and steer** - Monitor progress; unblock, reassign, or re-cut
    packets on scope mismatch. Review every returned packet against its
    acceptance evidence before recording it done. Root-cause failures instead
-   of patching around them; fold newly discovered unknowns back into step 2.
+   of patching around them, escalating to the oracle when workers stall;
+   fold newly discovered unknowns back into step 2.
 7. **Verify and close** - Run the task-specific gates from
    `docs/ai/verification.md` and `pixi run lint` before commits; record
    evidence per packet. Complete the principle audit. Promote durable
@@ -119,6 +128,11 @@ Logistics:
 - Use team mode for parallel lanes: named Claude teammates for iterative
   build/test and coordination work; keep authoring and review lanes
   separate; keep concurrent file ownership disjoint.
+- Use the strongest Claude model as the oracle, smartly: critical decision
+  making, challenging issues Codex cannot resolve properly (escalate after
+  two bounced attempts or a failure workers cannot root-cause), and deep
+  research synthesis; do not spend oracle passes on routine implementation
+  or searches; those stay with workers.
 - Set the session goal (/goal) to the Done-when contract so orchestration
   cannot stop early.
 - Read docs/ai/principles.md and docs/ai/north-star.md before starting;

--- a/docs/ai/orchestration.md
+++ b/docs/ai/orchestration.md
@@ -26,7 +26,11 @@ from public docs and `pixi run ...` commands without a specific AI tool.
   executor output against the packet's acceptance evidence before the work is
   recorded as done. Team-scale tasks enter through `dart-new-team-task`,
   which front-loads a decision interview and routes evidence-resolvable
-  uncertainties to spikes and research instead of questions.
+  uncertainties to spikes and research instead of questions. The
+  orchestrator's strongest model also serves as the oracle: critical
+  decisions, escalations executors cannot resolve, and research synthesis
+  get its deepest reasoning, while routine implementation stays with
+  executors.
 - **Executor** — owns implementation of one packet at a time. The executor
   takes a well-defined packet, makes the local edits, runs the packet's
   gates, records the evidence, and hands back. Executors do not widen scope,


### PR DESCRIPTION
## Summary

- Adds an explicit oracle role to the `dart-new-team-task` workflow: the
  strongest available Claude model handles critical decision making, hard
  failures that executor workers cannot resolve, and research synthesis,
  while routine implementation and searches stay with workers.

## Motivation / Problem

- The team-scale kickoff workflow (added in 11ffeac12e6) routed
  implementation to Codex executors and coordination to Claude teammates,
  but did not say where the deepest reasoning should be spent. Without an
  explicit oracle role, orchestrators either burn the strongest model on
  routine work or, worse, keep re-spinning workers on problems that need a
  judgment call.

## Changes / Key Changes

- New oracle routing bullet in the workflow's decompose-and-route step with
  concrete escalation triggers: a consequential decision that is hard to
  reverse or rests on conflicting/incomplete evidence, a packet that
  bounces twice or a failure workers cannot root-cause, or research that
  must be synthesized into a design call.
- The supervise-and-steer step escalates to the oracle when workers stall
  instead of patching around failures.
- The kickoff prompt template's `Logistics` block gains a matching oracle
  bullet scoped so oracle passes are not spent on routine work.
- One-sentence oracle note on the orchestrator role in
  `docs/ai/orchestration.md`.
- Generated `.codex/skills/` and `.opencode/command/` surfaces synced.

## Testing

- `pixi run lint` (exit 0)
- `pixi run sync-ai-commands`, `pixi run check-ai-commands` (exit 0)
- `pixi run check-lint-md`, `pixi run check-docs-policy`,
  `pixi run check-lint-spell` (exit 0)
- Wording verified by three independent review agents (intent fidelity,
  cross-branch consistency, structural budget); all four findings fixed
  before commit (escalation-trigger precision and oracle-economy scoping).
- Principle audit (docs/ai/principles.md): single source of truth kept
  (escalation thresholds stated once per surface); change scoped to the
  oracle role only.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Backport to `release-6.20`: applied on PR #3284 (same amendment commit)
- Follows up `main` commit 11ffeac12e602c90727c0f8026104706d3c911a1

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
      (N/A: contributor-facing AI workflow docs)
- [x] Add unit tests for new functionality (N/A: docs/AI workflow surfaces;
      covered by `pixi run check-ai-commands` structural checks)
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)
