### PR TITLE
Build only non-simulation tests for ASAN

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -2417,7 +2417,8 @@ build-asan = { cmd = [
 set -euo pipefail
 BUILD_TYPE=${BUILD_TYPE:-asan}
 PARALLEL_JOBS=${DART_PARALLEL_JOBS:-$(python scripts/parallel_jobs.py)}
-CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/${BUILD_TYPE} python scripts/cmake_build.py --target tests --parallel ${PARALLEL_JOBS}
+ASAN_BUILD_TARGET=${DART_ASAN_BUILD_TARGET:-tests_no_simulation}
+CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/${BUILD_TYPE} python scripts/cmake_build.py --target "${ASAN_BUILD_TARGET}" --parallel "${PARALLEL_JOBS}"
 """,
 ], depends-on = [
   "config-asan",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -201,6 +201,13 @@ add_custom_target(
   DEPENDS ${integration_tests} ${unit_tests} ${extra_test_targets}
 )
 
+# Build the non-simulation CTest surface without the simulation-only test
+# executables. ASAN uses this to match its ctest -LE simulation runtime filter.
+add_custom_target(
+  tests_no_simulation
+  DEPENDS ${integration_tests} ${unit_tests}
+)
+
 # Add custom target to build all the tests and run the tests
 if(MSVC)
   add_custom_target(


### PR DESCRIPTION
## Summary

- Adds a `tests_no_simulation` CMake meta-target for the CTest surface that excludes `simulation`-labeled tests.
- Updates the ASAN Pixi build step to build that target instead of the full `tests` target.

## Motivation / Problem

- Main-branch ASAN validation timed out while still compiling, reaching only 616/1017 Ninja edges before cancellation.
- The job already runs `ctest -LE simulation`, but the build step still compiled the `dart_simulation_tests` meta-target. That made ASAN pay for simulation-only test executables that it never executed.

## Changes / Key Changes

- Adds `tests_no_simulation` beside the existing `tests` target.
- Makes `pixi run build-asan` default to `tests_no_simulation`, with `DART_ASAN_BUILD_TARGET` available for explicit override.
- Keeps the ASAN runtime filter unchanged.

## Testing

- `pixi run config-asan`
- `cmake --build build/default/cpp/asan --target help | rg '^(\.\.\.)?tests(_no_simulation)?|dart_simulation_tests'`
- `pixi run -- ninja -C build/default/cpp/asan -t query tests/tests_no_simulation`
- `pixi run -- ninja -C build/default/cpp/asan -t query tests/tests`
- `git diff --check`
- `pixi run check-lint-quick`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up for main-branch ASAN timeout observed in CI Linux run 28734852313.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required: not required, CI-only build target change.
- [x] Add unit tests for new functionality: not applicable, build/CI target wiring.
- [x] Document new methods and classes: not applicable.
- [x] Add Python bindings (dartpy) if applicable: not applicable.
