### PR TITLE
Bound release Windows CI runtime

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -41,6 +41,9 @@ jobs:
     runs-on: windows-2025-vs2026
     env:
       CMAKE_GENERATOR: Visual Studio 18 2026
+    # Fail fast on hung Windows jobs instead of consuming the protected-branch
+    # runner indefinitely.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -65,8 +68,6 @@ jobs:
           $env:BUILD_TYPE = "${{ matrix.build_type }}"; `
           pixi run test-all
 
-      - name: Install
-        run: |
-          $env:DART_VERBOSE = "ON"; `
-          $env:BUILD_TYPE = "${{ matrix.build_type }}"; `
-          pixi run install
+      # Linux CI covers install. On Windows, pixi run install configures a
+      # separate install build tree after test-all has already passed, which
+      # duplicates work and can keep the protected-branch runner busy for hours.


### PR DESCRIPTION
## Summary

- Adds a 120-minute timeout to the release-6.20 Windows CI job.
- Removes the redundant post-test Windows `pixi run install` step; Linux release CI still owns install validation.

## Motivation / Problem

- The release-6.20 post-merge Windows job completed `Test DART and dartpy`, then remained in `Install` for over an hour with no job timeout configured.
- On this release branch, `pixi run install` configures a separate install build tree after `test-all` has already passed, so the Windows step duplicates work instead of installing the already-tested tree.

## Changes / Key Changes

- Adds `timeout-minutes: 120` so Windows CI cannot consume the protected-branch runner indefinitely.
- Stops running the redundant Windows install phase and documents that Linux CI covers install.

## Testing

- `git diff --check`
- `pixi run check-lint-quick`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up for release-6.20 Windows CI run 28737323099 hanging in the `Install` step after tests passed.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required: not required, CI-only workflow change.
- [x] Add unit tests for new functionality: not applicable, workflow-only change.
- [x] Document new methods and classes: not applicable.
- [x] Add Python bindings (dartpy) if applicable: not applicable.
