### PR TITLE
Pin release dartpy wheel checkout to event SHA

### DIFF
--- a/.github/workflows/publish_dartpy.yml
+++ b/.github/workflows/publish_dartpy.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.checkout_ref || github.event.inputs.ref || github.ref }}
+          ref: ${{ github.event.inputs.checkout_ref || github.event.inputs.ref || github.sha }}
 
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.9.6
@@ -147,7 +147,7 @@ jobs:
       CMAKE_TOOLCHAIN_FILE: ""
       DART_PARALLEL_JOBS: 8
       DARTPY_REF: ${{ github.event.inputs.ref || github.ref }}
-      DARTPY_CHECKOUT_REF: ${{ github.event.inputs.checkout_ref || github.event.inputs.ref || github.ref }}
+      DARTPY_CHECKOUT_REF: ${{ github.event.inputs.checkout_ref || github.event.inputs.ref || github.sha }}
       MACOSX_DEPLOYMENT_TARGET: "15.0"
 
     steps:


### PR DESCRIPTION
## Summary

- Pin release dartpy wheel workflow checkouts to the immutable event SHA when no manual checkout ref is supplied.
- Preserve manual `ref` / `checkout_ref` behavior for explicit release publishing and ad hoc wheel builds.

## Motivation / Problem

- Release branch `Publish dartpy` run https://github.com/dartsim/dart/actions/runs/28748335447 recorded head `949a9c2ff5ed6309beef0aa1345101d36c813f02`, but queued Linux wheel jobs checked out later `release-6.20` commits after the branch moved.
- That made the failed job evidence non-reproducible for the recorded run head and let old workflow definitions build newer release-branch contents.

## Changes / Key Changes

- Change the default checkout ref in the format job from `github.ref` to `github.sha`.
- Change the default `DARTPY_CHECKOUT_REF` in the wheel matrix from `github.ref` to `github.sha`.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Release push checkout | Queued jobs defaulted to the moving `release-6.20` ref. | Queued jobs default to the immutable event commit SHA. |
| Manual wheel builds | `checkout_ref` or `ref` inputs could select a target checkout. | Same behavior is preserved. |

## Testing

- `git diff --check`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish_dartpy.yml')); print('valid yaml')"`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Investigates release `Publish dartpy` failures in run https://github.com/dartsim/dart/actions/runs/28748335447.
- Related release workflow replacement: #3279.

---

#### Checklist

- [x] Milestone set (`DART 6.20.0`)
- [x] CHANGELOG.md updated if required (N/A: CI workflow correctness only)
- [x] Add unit tests for new functionality (N/A: workflow checkout semantics)
- [x] Document new methods and classes (N/A)
- [x] Add Python bindings (dartpy) if applicable (N/A)
