### PR TITLE
Clarify release-branch AI agent guidance

### DIFF
--- a/.claude/commands/dart-docs-update.md
+++ b/.claude/commands/dart-docs-update.md
@@ -1,5 +1,5 @@
 ---
-description: update documentation without code changes
+description: update docs or AI instruction visibility without code changes
 argument-hint: "<doc-topic>"
 agent: build
 ---
@@ -27,7 +27,9 @@ Update documentation: $ARGUMENTS
 3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
 4. Classify new or moved docs by lifecycle first, then audience, then topic,
    using `docs/information-architecture.md`
-5. Update indexes and cross-references that point to changed docs
+5. Update indexes and cross-references that point to changed docs. For AI docs,
+   keep always-loaded entrypoints compact: improve owner placement or pointers
+   instead of duplicating procedures.
 6. Use `docs/ai/verification.md` to select the docs-only or AI docs/adapters
    gate set, then run `pixi run lint` before committing
 7. Record the `CHANGELOG.md` decision using `docs/onboarding/changelog.md`.

--- a/.codex/skills/dart-docs-update/SKILL.md
+++ b/.codex/skills/dart-docs-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dart-docs-update
-description: "DART Docs Update: update documentation without code changes"
+description: "DART Docs Update: update docs or AI instruction visibility without code changes"
 ---
 <!-- AUTO-GENERATED FILE - DO NOT EDIT MANUALLY -->
 <!-- Source: .claude/commands/dart-docs-update.md -->
@@ -47,7 +47,9 @@ Update documentation: $ARGUMENTS
 3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
 4. Classify new or moved docs by lifecycle first, then audience, then topic,
    using `docs/information-architecture.md`
-5. Update indexes and cross-references that point to changed docs
+5. Update indexes and cross-references that point to changed docs. For AI docs,
+   keep always-loaded entrypoints compact: improve owner placement or pointers
+   instead of duplicating procedures.
 6. Use `docs/ai/verification.md` to select the docs-only or AI docs/adapters
    gate set, then run `pixi run lint` before committing
 7. Record the `CHANGELOG.md` decision using `docs/onboarding/changelog.md`.

--- a/.opencode/command/dart-docs-update.md
+++ b/.opencode/command/dart-docs-update.md
@@ -1,5 +1,5 @@
 ---
-description: update documentation without code changes
+description: update docs or AI instruction visibility without code changes
 argument-hint: "<doc-topic>"
 agent: build
 ---
@@ -31,7 +31,9 @@ Update documentation: $ARGUMENTS
 3. For AI workflow changes, run `pixi run sync-ai-commands`; do not hand-edit generated `.opencode/` or `.codex/` files
 4. Classify new or moved docs by lifecycle first, then audience, then topic,
    using `docs/information-architecture.md`
-5. Update indexes and cross-references that point to changed docs
+5. Update indexes and cross-references that point to changed docs. For AI docs,
+   keep always-loaded entrypoints compact: improve owner placement or pointers
+   instead of duplicating procedures.
 6. Use `docs/ai/verification.md` to select the docs-only or AI docs/adapters
    gate set, then run `pixi run lint` before committing
 7. Record the `CHANGELOG.md` decision using `docs/onboarding/changelog.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
     coverage — instead of silencing the symptom or widening scope to route
     around it.
 
+  * Clarify release-branch AI-native guidance so always-loaded agent rules stay
+    compact, consequential decisions use release-wide context and proportionate
+    evidence, and in-scope failures are root-caused instead of hidden.
+
   * Replace the vendored `dart/external/convhull_3d` implementation with a
     DART-owned native `dart/math/detail/ConvexHull.hpp` implementation used by
     `math::computeConvexHull3D`, while keeping the legacy implementation only

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -5,6 +5,21 @@ Claude Code, and OpenCode. It is intentionally smaller than the DART 7 `main`
 workflow surface and focuses on the workflows needed to maintain the DART 6 LTS
 line.
 
+## Visibility And Context Budget
+
+`AGENTS.md`, this start list, and workflow `Required Reading` blocks are the
+visibility contract for release-branch agents. Do not copy the same rule into
+every workflow; move it to the owner doc, then add only the pointer needed for
+the workflow to load it.
+
+Always-loaded surfaces such as `AGENTS.md`, `docs/ai/principles.md`, and
+`docs/ai/verification.md` must stay compact. Put procedures, compatibility
+details, and examples in the owner docs named by those entrypoints.
+
+When a documented rule is missed, diagnose whether the issue is owner
+placement, weak wording, missing required reading, a workflow description, or
+generated-adapter sync.
+
 Start with:
 
 - [`principles.md`](principles.md)

--- a/docs/ai/components.md
+++ b/docs/ai/components.md
@@ -11,5 +11,9 @@ The DART 6.20 release branch uses a small cross-agent workflow surface:
 - `docs/ai/workflows.md`: human-readable workflow map and gates.
 - `docs/information-architecture.md`: release-branch docs placement owner.
 
+AI docs are agent context, not a dumping ground. Keep always-loaded entrypoints
+compact and make rules visible through owner placement, read-order pointers,
+workflow required reading, and generated-adapter sync instead of duplication.
+
 Use `.claude/` as the editable source. Do not hand-edit generated `.codex/` or
 `.opencode/` files; rerun the sync script instead.

--- a/docs/ai/principles.md
+++ b/docs/ai/principles.md
@@ -1,6 +1,8 @@
 # AI Principles
 
 These principles apply to AI-assisted work on the DART 6.20 support branch.
+Keep this file short: it spends always-loaded agent context, so put procedures
+and compatibility detail in the owner docs named by `AGENTS.md`.
 
 ## Evidence First
 
@@ -9,13 +11,25 @@ These principles apply to AI-assisted work on the DART 6.20 support branch.
 - Treat live GitHub state and current command output as authoritative.
 - Do not rely on stale branch notes when a current checkout or PR can be
   inspected.
+- Before substantial or consequential work, read enough release-branch context
+  to understand the real invariant: `AGENTS.md`,
+  `docs/information-architecture.md`, owner docs, affected modules and call
+  paths, current release/PR state, and the verification bar. Use that context to
+  choose the smallest compatibility-preserving change, not an ad hoc local
+  patch or special case. Keep context proportionate for tiny fixes.
 - Before a non-trivial fix, surface your unknowns rather than coding a guess:
   your plan is a map, not the territory of the real code. Convert consequential
   unknowns into knowns first — reproduce the bug, read the affected code, or get
   an independent blind-spot review — instead of discovering them mid-change.
-- Fix bugs at the root cause: reproduce the failure as the smallest case, fix
-  the underlying cause, and add regression coverage — do not silence the symptom
-  or widen scope to route around it.
+- Back consequential decisions with proportionate evidence: code inspection,
+  logs, focused tests, benchmarks, source research, or prototypes according to
+  the claim. Do not decide major workflow or compatibility choices from
+  intuition when direct evidence is practical.
+- For unexpected in-scope failures, reproduce the smallest failing case, fix the
+  underlying cause, and add regression coverage. Preserve the real invariant at
+  the right owner doc or module boundary; do not suppress logs, loosen checks,
+  skip cases, or route around symptoms. For pre-existing or external failures,
+  classify them with evidence and report or park them without weakening gates.
 
 ## Compatibility First
 


### PR DESCRIPTION
## Summary

- Backports the AI-agent guidance clarity from #3292 to the DART 6.20 support branch in release-branch form.
- Keeps always-loaded AI docs compact while making release-wide context, proportionate evidence, and in-scope root-cause handling explicit for DART 6.20 agents.

## Motivation / Problem

The DART 6.20 branch has its own smaller AI workflow surface and compatibility-focused docs. The main-branch guidance from #3292 is useful for release maintenance too, but it needs to be adapted instead of cherry-picked wholesale so DART 6.20 does not import main-only workflow capabilities.

## Changes / Key Changes

- Clarifies `docs/ai/principles.md` for release-branch context gathering, proportionate evidence, and root-cause handling.
- Adds visibility and context-budget guidance to `docs/ai/README.md` and `docs/ai/components.md`.
- Updates the release-branch `dart-docs-update` workflow source and regenerates the Codex/OpenCode adapters.
- Adds a DART 6.20 changelog entry for the contributor/AI-workflow guidance change.

## Testing

- `pixi run sync-ai-commands`
- `pixi run lint`
- `pixi run lint` again after merging latest `origin/release-6.20`
- `pixi run check-ai-commands`
- `git diff --check origin/release-6.20...HEAD`

`pixi run check-docs-policy` is not available on `release-6.20`, so it is not an applicable release-branch gate.

## Breaking Changes

- [x] None
- No API, package, build, or runtime behavior changes.

## Related Issues / PRs (backports)

- Backport/adaptation of #3292.
- No DART 7 follow-up needed; the source change is already merged on `main`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality (N/A: docs and AI workflow guidance only)
- [x] Document new methods and classes (N/A: no API changes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no Python API changes)
