### PR TITLE
Fix native sphere-sphere zero-contact-limit short-circuit

### DIFF
--- a/dart/collision/native/narrow_phase/sphere_sphere.cpp
+++ b/dart/collision/native/narrow_phase/sphere_sphere.cpp
@@ -119,6 +119,13 @@ bool collideSphereCenters(
   const double dy = center2.y() - center1.y();
   const double dz = center2.z() - center1.z();
 
+  // A zero contact limit short-circuits detection and returns false (see the
+  // CollisionOption::maxNumContacts contract); this must precede the
+  // enableContact binary-check path.
+  if (option.maxNumContacts == 0) {
+    return false;
+  }
+
   if (!option.enableContact) {
     return spheresOverlap(dx, dy, dz, radius1, radius2);
   }
@@ -199,6 +206,13 @@ bool collideSpheres(
   const double dz = translation2.z() - center1Z;
   const double radius1 = detail::getRadius(sphere1);
   const double radius2 = detail::getRadius(sphere2);
+
+  // A zero contact limit short-circuits detection and returns false (see the
+  // CollisionOption::maxNumContacts contract); this must precede the
+  // enableContact binary-check path.
+  if (option.maxNumContacts == 0) {
+    return false;
+  }
 
   if (!option.enableContact) {
     return spheresOverlap(dx, dy, dz, radius1, radius2);

--- a/tests/unit/collision/native/test_sphere_sphere.cpp
+++ b/tests/unit/collision/native/test_sphere_sphere.cpp
@@ -709,6 +709,34 @@ TEST(SphereSphere, BinaryCheckReportsHitWithoutContacts)
   EXPECT_EQ(result.numContacts(), 0);
 }
 
+TEST(SphereSphere, ZeroContactLimitShortCircuitsEvenWithoutContact)
+{
+  // maxNumContacts == 0 disables detection and must return false regardless of
+  // enableContact, even for an overlapping pair. This takes precedence over the
+  // enableContact binary-check path.
+  CollisionOption option;
+  option.enableContact = false;
+  option.maxNumContacts = 0;
+
+  CollisionResult result;
+  EXPECT_FALSE(collideSpheres(
+      Eigen::Vector3d(0, 0, 0),
+      1.0,
+      Eigen::Vector3d(1.5, 0, 0),
+      1.0,
+      result,
+      option));
+  EXPECT_EQ(result.numContacts(), 0);
+
+  SphereShape sphere1(1.0);
+  SphereShape sphere2(1.0);
+  Eigen::Isometry3d tf1 = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d tf2 = Eigen::Isometry3d::Identity();
+  tf2.translation() = Eigen::Vector3d(0.0, 1.5, 0.0);
+  EXPECT_FALSE(collideSpheres(sphere1, tf1, sphere2, tf2, result, option));
+  EXPECT_EQ(result.numContacts(), 0);
+}
+
 // DART 6 supplementary coverage tests (not ported from DART 7)
 TEST(SphereSphere, ShapeOverloadZAxisAndContactLimit)
 {


### PR DESCRIPTION
## Summary

- Fix a contract regression in the native sphere-sphere pair introduced by
  #3281: `CollisionOption::maxNumContacts == 0` must short-circuit
  detection and return false, but the `enableContact` binary-check early
  return ran before the cap check, so a `{enableContact=false,
  maxNumContacts=0}` caller reported an overlap instead of `false`.

## Motivation / Problem

The documented `CollisionOption` contract
(`dart/collision/collision_option.hpp`): *"A value of 0 short-circuits
collision detection and returns false immediately."* DART 7's original
`sphere_sphere.cpp` honored this via its leading
`numContacts() >= maxNumContacts` check (`0 >= 0` -> false). The
`enableContact` fix ported in #3281 added an earlier return that bypassed
that check for the zero-limit-with-contacts-disabled combination. Flagged
by review on the main-branch dual PR (#3283).

## Changes / Key Changes

- Both `collideSpheres` entry points now short-circuit `maxNumContacts == 0`
  to `false` **before** the `enableContact` binary-check path.
- Regression test `SphereSphere.ZeroContactLimitShortCircuitsEvenWithoutContact`
  covering both overloads with an overlapping pair.
- Scope is limited to sphere-sphere (the pair changed by #3281). The
  documented-contract inconsistency in other native pairs
  (`box_box`/`convex_convex`/`mesh_mesh` return `true` on
  `maxNumContacts == 0`) is pre-existing upstream DART 7 behavior and is
  intentionally not widened here.

## Testing

- `pixi run lint`: clean.
- `ctest -R UNIT_collision_native_sphere_sphere`: 1/1 pass (includes the
  new regression test).

## Breaking Changes

- [x] None — restores the documented contract; `binaryCheck()`
  (`maxNumContacts = 1`) and contact-generating paths are unchanged.

## Related Issues / PRs

- Dual-PR counterpart on `main`: #3283.
- Follows up the phase-1 native core port #3281 (internal-only).