### PR TITLE
WP-PG.42: SIMD-screen DART broadphase candidates

### DIFF
--- a/.github/workflows/ci_simd.yml
+++ b/.github/workflows/ci_simd.yml
@@ -14,7 +14,9 @@ on:
       - "release-*"
     paths:
       - "dart/simd/**"
+      - "dart/collision/dart/**"
       - "tests/unit/simd/**"
+      - "tests/unit/collision/test_DARTCollisionDetector.cpp"
       - "tests/benchmark/simd/**"
       - ".github/workflows/ci_simd.yml"
   pull_request:
@@ -22,7 +24,9 @@ on:
       - "**"
     paths:
       - "dart/simd/**"
+      - "dart/collision/dart/**"
       - "tests/unit/simd/**"
+      - "tests/unit/collision/test_DARTCollisionDetector.cpp"
       - "tests/benchmark/simd/**"
       - ".github/workflows/ci_simd.yml"
   workflow_dispatch:
@@ -89,7 +93,7 @@ jobs:
             -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
             "$SIMD_CMAKE_FLAGS"'
 
-      - name: Build SIMD tests
+      - name: Build SIMD tests and benchmarks
         run: |
           pixi run bash -c 'cmake --build build/simd --target \
             UNIT_simd_vec_scalar \
@@ -103,8 +107,11 @@ jobs:
             UNIT_simd_geometry \
             UNIT_simd_math \
             UNIT_simd_public_header_dynamic_vector \
-            UNIT_simd_public_header_math'
+            UNIT_simd_public_header_math \
+            bm_simd \
+            bm_math \
+            test_DARTCollisionDetector'
 
       - name: Run SIMD tests
         run: |
-          pixi run bash -c 'ctest --test-dir build/simd -R "UNIT_simd" --output-on-failure'
+          pixi run bash -c 'ctest --test-dir build/simd -R "UNIT_simd|test_DARTCollisionDetector" --output-on-failure'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,11 @@
     bounding-box corners:
     [#3056](https://github.com/dartsim/dart/issues/3056)
 
+  * Speed up DART-native finite-shape broadphase sweeps on AVX-width builds by
+    screening sorted AABB candidate batches with `dart/simd`, while keeping
+    baseline-ISA builds on the scalar sweep path:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
   * Reduce DART-native broadphase setup work by caching local bounds
     center/half-extents and using those cached bounds directly when primitive
     collision objects have an identity linear transform:

--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -47,6 +47,7 @@
 #include "dart/dynamics/ShapeFrame.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/dynamics/SphereShape.hpp"
+#include "dart/simd/simd.hpp"
 
 #include <algorithm>
 #include <condition_variable>
@@ -273,6 +274,19 @@ struct BroadphaseEntry
   bool plane{false};
 };
 
+struct SortedBroadphaseBounds
+{
+  std::vector<double> minX;
+  std::vector<double> minY;
+  std::vector<double> minZ;
+  std::vector<double> maxX;
+  std::vector<double> maxY;
+  std::vector<double> maxZ;
+
+  void clear();
+  void update(const std::vector<const BroadphaseEntry*>& sortedEntries);
+};
+
 struct ContactBoundEntry
 {
   Eigen::Vector3d min{Eigen::Vector3d::Zero()};
@@ -285,6 +299,9 @@ constexpr double kContactPointKeyLowerBound = -9223372036854775808.0;
 constexpr double kContactPointKeyUpperBound = 9223372036854775808.0;
 constexpr std::size_t kInvalidContactPointIndex
     = std::numeric_limits<std::size_t>::max();
+constexpr std::size_t kBroadphaseSimdWidth = 4u;
+constexpr bool kUseNativeBroadphaseSimd
+    = dart::simd::preferred_width_v<double> >= kBroadphaseSimdWidth;
 
 struct ContactPointKey
 {
@@ -350,6 +367,8 @@ struct BroadphaseScratch
   std::vector<BroadphaseEntry> otherEntries2;
   std::vector<const BroadphaseEntry*> sortedEntries1;
   std::vector<const BroadphaseEntry*> sortedEntries2;
+  SortedBroadphaseBounds sortedBounds1;
+  SortedBroadphaseBounds sortedBounds2;
   std::vector<BroadphaseEntry> contactBoundFiniteEntries;
   std::vector<ContactBoundEntry> contactBoundEntries;
   std::vector<std::size_t> parallelPairIndices;
@@ -469,6 +488,7 @@ bool processPlanePlanePairs(
 bool processFiniteFinitePairs(
     const std::vector<BroadphaseEntry>& entries,
     std::vector<const BroadphaseEntry*>& sortedEntries,
+    SortedBroadphaseBounds& sortedBounds,
     const CollisionOption& option,
     CollisionResult* result,
     bool& collisionFound,
@@ -478,6 +498,7 @@ bool processFiniteFinitePairs(
     const std::vector<BroadphaseEntry>& entries1,
     const std::vector<BroadphaseEntry>& entries2,
     std::vector<const BroadphaseEntry*>& sortedEntries2,
+    SortedBroadphaseBounds& sortedBounds2,
     const CollisionOption& option,
     CollisionResult* result,
     bool& collisionFound,
@@ -636,6 +657,7 @@ bool DARTCollisionDetector::collide(
   if (processFiniteFinitePairs(
           scratch.finiteEntries1,
           scratch.sortedEntries1,
+          scratch.sortedBounds1,
           option,
           result,
           collisionFound,
@@ -794,6 +816,7 @@ bool DARTCollisionDetector::collide(
           scratch.finiteEntries1,
           scratch.finiteEntries2,
           scratch.sortedEntries2,
+          scratch.sortedBounds2,
           option,
           result,
           collisionFound,
@@ -1316,6 +1339,40 @@ std::size_t ContactPointIndex::findOrCreateBucketIndex(
 }
 
 //==============================================================================
+void SortedBroadphaseBounds::clear()
+{
+  minX.clear();
+  minY.clear();
+  minZ.clear();
+  maxX.clear();
+  maxY.clear();
+  maxZ.clear();
+}
+
+//==============================================================================
+void SortedBroadphaseBounds::update(
+    const std::vector<const BroadphaseEntry*>& sortedEntries)
+{
+  const auto size = sortedEntries.size();
+  minX.resize(size);
+  minY.resize(size);
+  minZ.resize(size);
+  maxX.resize(size);
+  maxY.resize(size);
+  maxZ.resize(size);
+
+  for (std::size_t i = 0u; i < size; ++i) {
+    const auto& entry = *sortedEntries[i];
+    minX[i] = entry.min.x();
+    minY[i] = entry.min.y();
+    minZ[i] = entry.min.z();
+    maxX[i] = entry.max.x();
+    maxY[i] = entry.max.y();
+    maxZ[i] = entry.max.z();
+  }
+}
+
+//==============================================================================
 void BroadphaseScratch::clear()
 {
   broadphaseEntries.clear();
@@ -1327,6 +1384,8 @@ void BroadphaseScratch::clear()
   otherEntries2.clear();
   sortedEntries1.clear();
   sortedEntries2.clear();
+  sortedBounds1.clear();
+  sortedBounds2.clear();
   contactBoundFiniteEntries.clear();
   contactBoundEntries.clear();
   parallelPairIndices.clear();
@@ -1903,6 +1962,54 @@ bool overlaps(const BroadphaseEntry& entry1, const BroadphaseEntry& entry2)
 }
 
 //==============================================================================
+std::uint32_t computeFiniteOverlapMask4(
+    const BroadphaseEntry& entry,
+    const SortedBroadphaseBounds& bounds,
+    std::size_t begin)
+{
+  using Vec4d = dart::simd::Vec<double, kBroadphaseSimdWidth>;
+
+  const auto entryMinX = Vec4d::broadcast(entry.min.x());
+  const auto entryMinY = Vec4d::broadcast(entry.min.y());
+  const auto entryMinZ = Vec4d::broadcast(entry.min.z());
+  const auto entryMaxX = Vec4d::broadcast(entry.max.x());
+  const auto entryMaxY = Vec4d::broadcast(entry.max.y());
+  const auto entryMaxZ = Vec4d::broadcast(entry.max.z());
+
+  const auto candidateMinX = Vec4d::loadu(bounds.minX.data() + begin);
+  const auto candidateMinY = Vec4d::loadu(bounds.minY.data() + begin);
+  const auto candidateMinZ = Vec4d::loadu(bounds.minZ.data() + begin);
+  const auto candidateMaxX = Vec4d::loadu(bounds.maxX.data() + begin);
+  const auto candidateMaxY = Vec4d::loadu(bounds.maxY.data() + begin);
+  const auto candidateMaxZ = Vec4d::loadu(bounds.maxZ.data() + begin);
+
+  const auto overlapMask
+      = (candidateMinX <= entryMaxX) & (candidateMaxX >= entryMinX)
+        & (candidateMinY <= entryMaxY) & (candidateMaxY >= entryMinY)
+        & (candidateMinZ <= entryMaxZ) & (candidateMaxZ >= entryMinZ);
+  return overlapMask.bitmask();
+}
+
+//==============================================================================
+bool processFiniteFinitePair(
+    const BroadphaseEntry& entry1,
+    const BroadphaseEntry& entry2,
+    const CollisionOption& option,
+    CollisionResult* result,
+    bool& collisionFound,
+    CollisionResult& pairResult)
+{
+  auto* collObj1 = entry1.object;
+  auto* collObj2 = entry2.object;
+  const auto& filter = option.collisionFilter;
+  if (filter && filter->ignoresCollision(collObj1, collObj2))
+    return false;
+
+  return processPair(
+      collObj1, collObj2, option, result, collisionFound, pairResult);
+}
+
+//==============================================================================
 bool contactBoundsOverlap(
     const ContactBoundEntry& entry1,
     const ContactBoundEntry& entry2,
@@ -2309,11 +2416,14 @@ bool processPlanePlanePairs(
 bool processFiniteFinitePairs(
     const std::vector<BroadphaseEntry>& entries,
     std::vector<const BroadphaseEntry*>& sortedEntries,
+    SortedBroadphaseBounds& sortedBounds,
     const CollisionOption& option,
     CollisionResult* result,
     bool& collisionFound,
     CollisionResult& pairResult)
 {
+  DART_PROFILE_SCOPED_N("DART native finite-finite same-group pairs");
+
   sortedEntries.reserve(entries.size());
   for (const auto& entry : entries)
     sortedEntries.push_back(&entry);
@@ -2324,25 +2434,53 @@ bool processFiniteFinitePairs(
       [](const BroadphaseEntry* lhs, const BroadphaseEntry* rhs) {
         return lhs->min.x() < rhs->min.x();
       });
+  if constexpr (kUseNativeBroadphaseSimd) {
+    sortedBounds.update(sortedEntries);
+  }
 
-  const auto& filter = option.collisionFilter;
   for (std::size_t i = 0u; i + 1u < sortedEntries.size(); ++i) {
     const auto& entry1 = *sortedEntries[i];
-    for (std::size_t j = i + 1u; j < sortedEntries.size(); ++j) {
+    std::size_t j = i + 1u;
+    while (j < sortedEntries.size()) {
       const auto& entry2 = *sortedEntries[j];
       if (entry2.min.x() > entry1.max.x())
         break;
 
-      if (!overlaps(entry1, entry2))
-        continue;
+      if constexpr (kUseNativeBroadphaseSimd) {
+        if (j + kBroadphaseSimdWidth <= sortedEntries.size()) {
+          const std::uint32_t overlapMask
+              = computeFiniteOverlapMask4(entry1, sortedBounds, j);
+          for (std::size_t lane = 0u; lane < kBroadphaseSimdWidth; ++lane) {
+            if ((overlapMask & (std::uint32_t{1u} << lane)) == 0u)
+              continue;
 
-      auto* collObj1 = entry1.object;
-      auto* collObj2 = entry2.object;
-      if (filter && filter->ignoresCollision(collObj1, collObj2))
-        continue;
-      if (processPair(
-              collObj1, collObj2, option, result, collisionFound, pairResult)) {
+            if (processFiniteFinitePair(
+                    entry1,
+                    *sortedEntries[j + lane],
+                    option,
+                    result,
+                    collisionFound,
+                    pairResult)) {
+              return true;
+            }
+          }
+          j += kBroadphaseSimdWidth;
+          continue;
+        }
+      }
+
+      if (!overlaps(entry1, entry2))
+        ++j;
+      else if (processFiniteFinitePair(
+                   entry1,
+                   entry2,
+                   option,
+                   result,
+                   collisionFound,
+                   pairResult)) {
         return true;
+      } else {
+        ++j;
       }
     }
   }
@@ -2355,11 +2493,14 @@ bool processFiniteFinitePairs(
     const std::vector<BroadphaseEntry>& entries1,
     const std::vector<BroadphaseEntry>& entries2,
     std::vector<const BroadphaseEntry*>& sortedEntries2,
+    SortedBroadphaseBounds& sortedBounds2,
     const CollisionOption& option,
     CollisionResult* result,
     bool& collisionFound,
     CollisionResult& pairResult)
 {
+  DART_PROFILE_SCOPED_N("DART native finite-finite cross-group pairs");
+
   sortedEntries2.reserve(entries2.size());
   for (const auto& entry : entries2)
     sortedEntries2.push_back(&entry);
@@ -2370,25 +2511,57 @@ bool processFiniteFinitePairs(
       [](const BroadphaseEntry* lhs, const BroadphaseEntry* rhs) {
         return lhs->min.x() < rhs->min.x();
       });
+  if constexpr (kUseNativeBroadphaseSimd) {
+    sortedBounds2.update(sortedEntries2);
+  }
 
-  const auto& filter = option.collisionFilter;
   for (const auto& entry1 : entries1) {
-    for (const auto* entry2Ptr : sortedEntries2) {
+    std::size_t j = 0u;
+    while (j < sortedEntries2.size()) {
+      const auto* entry2Ptr = sortedEntries2[j];
       const auto& entry2 = *entry2Ptr;
-      if (entry2.max.x() < entry1.min.x())
-        continue;
       if (entry2.min.x() > entry1.max.x())
         break;
-      if (!overlaps(entry1, entry2))
-        continue;
 
-      auto* collObj1 = entry1.object;
-      auto* collObj2 = entry2.object;
-      if (filter && filter->ignoresCollision(collObj1, collObj2))
+      if constexpr (kUseNativeBroadphaseSimd) {
+        if (j + kBroadphaseSimdWidth <= sortedEntries2.size()) {
+          const std::uint32_t overlapMask
+              = computeFiniteOverlapMask4(entry1, sortedBounds2, j);
+          for (std::size_t lane = 0u; lane < kBroadphaseSimdWidth; ++lane) {
+            if ((overlapMask & (std::uint32_t{1u} << lane)) == 0u)
+              continue;
+
+            if (processFiniteFinitePair(
+                    entry1,
+                    *sortedEntries2[j + lane],
+                    option,
+                    result,
+                    collisionFound,
+                    pairResult)) {
+              return true;
+            }
+          }
+          j += kBroadphaseSimdWidth;
+          continue;
+        }
+      }
+
+      if (entry2.max.x() < entry1.min.x()) {
+        ++j;
         continue;
-      if (processPair(
-              collObj1, collObj2, option, result, collisionFound, pairResult)) {
+      }
+      if (!overlaps(entry1, entry2))
+        ++j;
+      else if (processFiniteFinitePair(
+                   entry1,
+                   entry2,
+                   option,
+                   result,
+                   collisionFound,
+                   pairResult)) {
         return true;
+      } else {
+        ++j;
       }
     }
   }

--- a/docs/dev_tasks/dart6_performance_generalization/05-simd-enablement-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/05-simd-enablement-lane.md
@@ -12,9 +12,41 @@ Round-1 evidence says the cost is structural, not arithmetic — so this
 lane is deliberately *third* in sequencing: kernels land where WS-A/WS-C
 restructuring has exposed batchable loops, not before.
 
+Current execution note (2026-07-05): standalone WP-PG.40 PR #3270 was
+closed by maintainer direction so the D1/D2 contract and prototype evidence
+ride with the first real SIMD kernel PR, not a docs-only packet. The first
+production-consumer slice is `wp-pg-42-soa-broadphase-simd`: it keeps the
+DART 6 packaged default at baseline ISA, extends `ci_simd.yml` so the
+DART detector builds/runs under scalar/SSE4.2/AVX/AVX2, and starts
+WP-PG.42 with AVX-width SIMD-screened finite broadphase candidate
+batches while scalar/SSE/NEON builds keep the previous scalar sweep shape.
+WS-F phase 1 (#3281) has landed only the internal native collision math
+core; there is still no DART 6 detector adapter or phase-4 native
+broadphase SIMD work, so this slice does not duplicate WS-F.
+
+Local evidence (2026-07-05, js workstation, GCC 15.2, CPU scaling enabled;
+treat small deltas as noisy): `origin/release-6.20@c371060c9fa` was compared
+against the `wp-pg-42-soa-broadphase-simd` worktree. The focused detector test
+passed in default, scalar-forced, SSE4.2, AVX, and AVX2 builds; after adding
+finite-finite text-profiler scopes, the focused detector test was rebuilt and
+re-run in scalar/SSE4.2/AVX/AVX2. The workflow-equivalent SIMD target set also
+passed in scalar/SSE4.2/AVX/AVX2 before the profiler-label-only edit.
+`BM_INTEGRATION_contact_container` DART rows preserved contacts/resting/mobile
+exactly (60 rows: 96/0/60; 120 rows: 272/0/120). Default/package-safe builds
+compile out the AVX-width batch loop and showed no regression signal; after the
+profiler-label edit, the default DART rows were 60/1 341 ms, 60/16 340 ms,
+120/1 3939 ms, and 120/16 3881 ms, still below the recorded default baseline
+120 rows (4152 ms and 4110 ms). AVX2 builds exercise the batch loop; post-edit
+macro rows were 60/1 249 ms, 60/16 254 ms, 120/1 2965 ms, and 120/16 2977 ms,
+with counters unchanged. A profiled native contact-container sample shows the
+new finite-finite same-group sweep scope is material on the 60-object row
+(24.34 ms / 7.18% of 200 profiled steps) and visible but solver-dominated on
+the 120-object row (30.29 ms / 1.61% of 100 profiled steps).
+
 #### WP-PG.40 — FP-determinism + ISA delivery contracts (design packet)
 
-- Status: open — resolves D1 and D2
+- Status: folded into the first actual SIMD kernel PR per #3270 maintainer
+  direction; WP-PG.42 carries the active D1/D2 evidence path.
 - Objective: decide and document (in the README decisions section plus a
   compatibility note owner doc): (a) the FP contract for SIMD kernels on
   state-affecting paths (proposal: bit-identical to scalar — no
@@ -55,7 +87,11 @@ restructuring has exposed batchable loops, not before.
 
 #### WP-PG.42 — SoA broadphase sweep batching (coordinate with WS-F)
 
-- Status: gated — coordinate before claiming
+- Status: claimed — `wp-pg-42-soa-broadphase-simd` starts with
+  AVX-width SIMD-screened finite candidate batches in the existing DART
+  detector, plus CI matrix coverage for the production consumer. Remaining
+  scope in this packet still includes measured before/after evidence and
+  any version-gated AABB recomputation follow-up that survives profiling.
 - Objective: split the DART-native detector's `BroadphaseEntry` into SoA
   min/max arrays and batch the y/z overlap tests inside the x-sweep
   (`DARTCollisionDetector.cpp:2329-2347`) with `dart/simd`; version-gate

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -4,8 +4,10 @@ Status board only; packet definitions live in the lane docs. Update this
 file (and RESUME.md) in every PR that claims or completes a packet.
 
 Baseline: `origin/release-6.20` @ `70b92010311` (2026-07-04).
-Related open queue at last refresh: none blocking (all enablers merged:
-#3209, #3226, #3229, #3230, #3234).
+Related open queue at last refresh: none blocking (enablers merged:
+#3209, #3226, #3229, #3230, #3234, #3281). WP-PG.40 standalone PR
+#3270 was closed by maintainer direction and its D1/D2 evidence now rides
+with the first real SIMD-kernel PR.
 
 ## Lane status
 
@@ -14,9 +16,9 @@ Related open queue at last refresh: none blocking (all enablers merged:
 | WS-A constraint/LCP | 02-constraint-lcp-lane.md | PG.10–PG.15 | open (PG.13 evidence-gated; PG.14 blocked D3; PG.15 blocked D7) |
 | WS-B ODE backend | 03-ode-backend-lane.md | PG.20–PG.23 | open (PG.23 blocked D8; lane re-review at WS-F phase 5) |
 | WS-C dynamics batching | 04-dynamics-batching-lane.md | PG.30–PG.33 | open (PG.33 gated) |
-| WS-D SIMD enablement | 05-simd-enablement-lane.md | PG.40–PG.42 | open (PG.41/42 blocked on PG.40) |
+| WS-D SIMD enablement | 05-simd-enablement-lane.md | PG.40–PG.42 | active (PG.40 folded into PG.42; PG.41 waits for PG.10 seam evidence) |
 | WS-E infra/evidence | 06-infra-evidence-lane.md | PG.01–PG.04 | open (**PG.01 first**) |
-| WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phase 0 evidence harness complete (#3209/#3230 merged); phase 1 not started |
+| WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phase 1 internal math core merged (#3281); no DART 6 detector adapter or phase-4 broadphase SIMD yet |
 
 ## Packet board
 
@@ -40,9 +42,9 @@ Related open queue at last refresh: none blocking (all enablers merged:
 | WP-PG.31 shallow-support scratch | WS-C | open | — | — |
 | WP-PG.32 frame arena + alloc gate | WS-C | open | — | — |
 | WP-PG.33 SoA integration | WS-C | gated | — | — |
-| WP-PG.40 FP/ISA contracts | WS-D | open | — | — |
-| WP-PG.41 batch math seam | WS-D | blocked (PG.40) | — | — |
-| WP-PG.42 SoA broadphase | WS-D | gated (WS-F coord) | — | — |
+| WP-PG.40 FP/ISA contracts | WS-D | folded into WP-PG.42 | #3270 closed | maintainer direction: carry D1/D2 evidence with actual SIMD kernel PR |
+| WP-PG.41 batch math seam | WS-D | blocked (PG.10 seam evidence) | — | — |
+| WP-PG.42 SoA broadphase | WS-D | claimed — local | `wp-pg-42-soa-broadphase-simd` | AVX-width finite sweep SIMD screen, scalar/SSE/NEON fallback, SIMD CI consumer coverage, contact-container macro rows, finite-finite profile scope |
 
 Claim flow: set the packet row to `claimed — <who/session>` with the
 `wp-pg-<nn>-<slug>` branch name, update RESUME.md, and open the packet PR
@@ -52,8 +54,9 @@ against the packet's acceptance evidence.
 
 ## Cross-lane coordination notes
 
-- WS-F consumes WS-D kernels in its phase 4; WS-D's WP-PG.42 must check
-  WS-F phase status before claiming (avoid double-building broadphase).
+- WS-F consumes WS-D kernels in its phase 4; WS-D's WP-PG.42 checked live
+  phase status before claiming. As of #3281, WS-F has internal native
+  collision math only, with no DART 6 detector adapter or broadphase SIMD.
 - WS-B investment is re-reviewed when WS-F reaches phase 5 (facade
   decision) — see D5 in the README.
 - WS-A WP-PG.12 and WS-C WP-PG.30 share the single-free-body

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -9,21 +9,32 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
 
 ## Next packet
 
-**WP-PG.01 — Round-2 baseline evidence packet**
-([06-infra-evidence-lane.md](06-infra-evidence-lane.md)). Everything else
-depends on it. Branch `wp-pg-01-baseline-evidence` off
-`origin/release-6.20`; capture the exact cell matrix in
-[01-baseline-evidence.md](01-baseline-evidence.md) (canonical commands
-are spelled there, including `pixi run -e gazebo download-gz-sim` for the
-3k scenes); triage the six prior-art branches; commit the guard-row
-tables into that doc; PR title `WP-PG.01: Round-2 baseline evidence
-packet`.
+**Current claimed packet: WP-PG.42 — SoA broadphase sweep batching**
+([05-simd-enablement-lane.md](05-simd-enablement-lane.md)). Branch
+`wp-pg-42-soa-broadphase-simd` off `origin/release-6.20` carries the
+first production `dart/simd` consumer in DART 6: AVX-width finite
+broadphase candidate screening in the existing DART detector, with
+scalar/SSE/NEON builds preserving the previous scalar sweep shape. The
+standalone WP-PG.40 PR #3270 was closed by maintainer direction; its
+D1/D2 evidence rides with this actual SIMD-kernel PR.
+
+Immediate next step: refresh the local evidence after any edits, including
+the focused detector test, scalar/SSE4.2/AVX/AVX2 SIMD workflow-equivalent
+matrix, contact-container macro rows, and the `--profile` finite-finite
+sweep share now exposed by this branch's text-profiler labels.
+
+After WP-PG.42 lands, return to **WP-PG.01 — Round-2 baseline evidence
+packet** ([06-infra-evidence-lane.md](06-infra-evidence-lane.md)) unless a
+newer maintainer direction overrides it. Branch `wp-pg-01-baseline-evidence`
+off `origin/release-6.20`; capture the exact cell matrix in
+[01-baseline-evidence.md](01-baseline-evidence.md), triage the six
+prior-art branches, and commit the guard-row tables into that doc.
 
 Available in parallel after (or alongside, in a second session):
-WP-PG.02, WP-PG.03, WP-PG.40 (no deps; resolves D1/D2), then WP-PG.10,
-WP-PG.11, WP-PG.20, WP-PG.22, WP-PG.30, WP-PG.31. Packets marked
-blocked/gated (PG.04, PG.13, PG.14, PG.15, PG.23, PG.33, PG.41, PG.42)
-must not be claimed until their decision or evidence gate lands.
+WP-PG.02, WP-PG.03, then WP-PG.10, WP-PG.11, WP-PG.20, WP-PG.22,
+WP-PG.30, WP-PG.31. WP-PG.40 is folded into WP-PG.42. Packets marked
+blocked/gated (PG.04, PG.13, PG.14, PG.15, PG.23, PG.33, PG.41) must not
+be claimed until their decision or evidence gate lands.
 
 ## Verify commands (every packet)
 
@@ -59,3 +70,7 @@ reduction now vs WS-F phase 3) — see README "Open decisions".
   branch handoff (prior-art inventory + rejected-experiments list).
   Adversarial plan review applied (sequencing consistency, WP-PG.11
   re-scope, WP-PG.13 premise correction, success criteria added).
+- 2026-07-05: WP-PG.40 standalone PR #3270 closed per maintainer
+  direction. WP-PG.42 claimed on `wp-pg-42-soa-broadphase-simd`; live
+  WS-F check found #3281 merged only internal native collision math, so
+  this branch remains the DART 6 detector SIMD-consumer path.

--- a/tests/unit/collision/test_DARTCollisionDetector.cpp
+++ b/tests/unit/collision/test_DARTCollisionDetector.cpp
@@ -30,6 +30,7 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <dart/collision/CollisionFilter.hpp>
 #include <dart/collision/CollisionObject.hpp>
 #include <dart/collision/dart/DARTCollisionDetector.hpp>
 
@@ -89,6 +90,26 @@ PlaneSphereGroups makePlaneSphereGroups(double sphereX1, double sphereX2)
 
   return groups;
 }
+
+class AnchorOnlyCollisionFilter : public collision::CollisionFilter
+{
+public:
+  explicit AnchorOnlyCollisionFilter(const dynamics::ShapeFrame* anchor)
+    : mAnchor(anchor)
+  {
+  }
+
+  bool ignoresCollision(
+      const collision::CollisionObject* object1,
+      const collision::CollisionObject* object2) const override
+  {
+    return object1->getShapeFrame() != mAnchor
+           && object2->getShapeFrame() != mAnchor;
+  }
+
+private:
+  const dynamics::ShapeFrame* mAnchor;
+};
 
 } // namespace
 
@@ -175,6 +196,118 @@ TEST(DARTCollisionDetector, DetectsTranslatedIdentityBounds)
       || (shapeFrame1 == sphereFrame2.get()
           && shapeFrame2 == sphereFrame1.get()));
   EXPECT_GT(contact.penetrationDepth, 0.0);
+}
+
+//==============================================================================
+TEST(DARTCollisionDetector, BatchedFiniteSweepPreservesCandidateOrder)
+{
+  auto detector = collision::DARTCollisionDetector::create();
+
+  auto anchorFrame
+      = dynamics::SimpleFrame::createShared(dynamics::Frame::World());
+  anchorFrame->setShape(std::make_shared<dynamics::SphereShape>(1.0));
+  anchorFrame->setTranslation(Eigen::Vector3d::Zero());
+
+  const std::vector<Eigen::Vector3d> candidatePositions{
+      {0.1, 0.0, 0.0},
+      {0.2, 3.5, 0.0},
+      {0.3, -0.25, 0.0},
+      {0.4, 0.0, 3.5},
+      {0.5, 0.3, 0.4},
+      {0.6, -3.5, 0.0},
+      {0.7, 0.0, -0.2},
+      {0.8, 0.0, 3.5},
+  };
+  const std::vector<std::size_t> expectedContactCandidates{0u, 2u, 4u, 6u};
+
+  std::vector<dynamics::SimpleFramePtr> candidateFrames;
+  candidateFrames.reserve(candidatePositions.size());
+  for (const auto& position : candidatePositions) {
+    auto frame = dynamics::SimpleFrame::createShared(dynamics::Frame::World());
+    frame->setShape(std::make_shared<dynamics::SphereShape>(1.0));
+    frame->setTranslation(position);
+    candidateFrames.push_back(frame);
+  }
+
+  auto anchorGroup = detector->createCollisionGroup(anchorFrame.get());
+  auto candidateGroup = detector->createCollisionGroup();
+  for (const auto& candidateFrame : candidateFrames)
+    candidateGroup->addShapeFrame(candidateFrame.get());
+
+  collision::CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 10u;
+
+  collision::CollisionResult result;
+  ASSERT_TRUE(anchorGroup->collide(candidateGroup.get(), option, &result));
+  ASSERT_EQ(expectedContactCandidates.size(), result.getNumContacts());
+
+  for (std::size_t i = 0u; i < expectedContactCandidates.size(); ++i) {
+    SCOPED_TRACE(i);
+    const auto& contact = result.getContact(i);
+    EXPECT_EQ(anchorFrame.get(), contact.collisionObject1->getShapeFrame());
+    EXPECT_EQ(
+        candidateFrames[expectedContactCandidates[i]].get(),
+        contact.collisionObject2->getShapeFrame());
+    EXPECT_GT(contact.penetrationDepth, 0.0);
+  }
+}
+
+//==============================================================================
+TEST(DARTCollisionDetector, BatchedSingleGroupSweepPreservesCandidateOrder)
+{
+  auto detector = collision::DARTCollisionDetector::create();
+
+  auto anchorFrame
+      = dynamics::SimpleFrame::createShared(dynamics::Frame::World());
+  anchorFrame->setShape(std::make_shared<dynamics::SphereShape>(1.0));
+  anchorFrame->setTranslation(Eigen::Vector3d::Zero());
+
+  const std::vector<Eigen::Vector3d> candidatePositions{
+      {0.1, 0.0, 0.0},
+      {0.2, 3.5, 0.0},
+      {0.3, -0.25, 0.0},
+      {0.4, 0.0, 3.5},
+      {0.5, 0.3, 0.4},
+      {0.6, -3.5, 0.0},
+      {0.7, 0.0, -0.2},
+      {0.8, 0.0, 3.5},
+  };
+  const std::vector<std::size_t> expectedContactCandidates{0u, 2u, 4u, 6u};
+
+  std::vector<dynamics::SimpleFramePtr> candidateFrames;
+  candidateFrames.reserve(candidatePositions.size());
+  for (const auto& position : candidatePositions) {
+    auto frame = dynamics::SimpleFrame::createShared(dynamics::Frame::World());
+    frame->setShape(std::make_shared<dynamics::SphereShape>(1.0));
+    frame->setTranslation(position);
+    candidateFrames.push_back(frame);
+  }
+
+  auto group = detector->createCollisionGroup();
+  group->addShapeFrame(anchorFrame.get());
+  for (const auto& candidateFrame : candidateFrames)
+    group->addShapeFrame(candidateFrame.get());
+
+  collision::CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 10u;
+  option.collisionFilter
+      = std::make_shared<AnchorOnlyCollisionFilter>(anchorFrame.get());
+
+  collision::CollisionResult result;
+  ASSERT_TRUE(group->collide(option, &result));
+  ASSERT_EQ(expectedContactCandidates.size(), result.getNumContacts());
+
+  for (std::size_t i = 0u; i < expectedContactCandidates.size(); ++i) {
+    SCOPED_TRACE(i);
+    const auto& contact = result.getContact(i);
+    EXPECT_EQ(anchorFrame.get(), contact.collisionObject1->getShapeFrame());
+    EXPECT_EQ(
+        candidateFrames[expectedContactCandidates[i]].get(),
+        contact.collisionObject2->getShapeFrame());
+    EXPECT_GT(contact.penetrationDepth, 0.0);
+  }
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Speed up DART-native finite-shape broadphase sweeps on AVX-width builds by screening sorted AABB candidate batches with `dart/simd`.
- Keep packaged baseline-ISA, scalar-forced, SSE, and NEON builds on the previous scalar sweep shape.
- Extend SIMD CI coverage so the production DART collision consumer and SIMD benchmark targets build in the scalar/SSE4.2/AVX/AVX2 matrix.

## Motivation / Problem

PR #3229 backported the `dart/simd` abstraction to DART 6.20, but it intentionally added infrastructure without any runtime consumer. WP-PG.42 makes that infrastructure earn its keep in an existing DART-native collision path while preserving the DART 6 packaging contract: no exported `-march` requirement, no default behavior drift, and scalar fallback for baseline builds.

## Changes / Key Changes

- Adds SoA min/max scratch for sorted finite broadphase entries in `DARTCollisionDetector.cpp`.
- Uses a 4-wide `dart::simd::Vec<double, 4>` overlap mask for finite-finite candidate screening when the native double SIMD width is at least four lanes.
- Preserves candidate order and early termination semantics with regression tests for group-vs-group and same-group sweeps.
- Adds finite-finite text-profiler scopes so the packet has direct profile evidence for the changed sweep.
- Updates `.github/workflows/ci_simd.yml` to build `test_DARTCollisionDetector`, `bm_simd`, and `bm_math`, and to run the detector test in the SIMD matrix.
- Records WP-PG.40 folding, WS-F coordination, benchmark/profile evidence, and resume state in the active dev-task docs.
- Adds the DART 6.20 changelog entry under Collision.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| SIMD backport | `dart/simd` was tested infrastructure with no production DART 6 runtime consumer. | The DART-native finite-finite broadphase sweep uses SIMD candidate screening on AVX-width builds. |
| Packaging ISA | SIMD delivery decisions were unresolved for runtime use. | Packaged baseline-ISA, scalar-forced, SSE, and NEON builds keep the scalar sweep path; no exported target gets `-march`. |
| CI coverage | SIMD CI built SIMD unit tests only; benchmark path filters did not build benchmark targets. | SIMD CI also builds/runs the DART detector test and builds `bm_simd`/`bm_math` across the scalar/SSE4.2/AVX/AVX2 matrix. |
| Evidence | Broadphase SIMD packet lacked a measured runtime seam. | Text-profiler scopes show finite-finite sweep share on contact-container rows, and macro rows preserve contact/resting/mobile counters. |

## Testing

From `/home/js/dev/dartsim/dart/task_3-wp-pg-42` before moving the branch into the requested checkout:

- `pixi run lint`
- `pixi run check-lint`
- `pixi run build`
- `pixi run test` — 134/134 passed
- `ctest --test-dir build/default/cpp/Release -R '^test_DARTCollisionDetector$' --output-on-failure`
- Focused `test_DARTCollisionDetector` rebuilt and passed in scalar, SSE4.2, AVX, and AVX2 builds.
- Workflow-equivalent SIMD target/test matrix passed for scalar, SSE4.2, AVX, and AVX2 before the profiler-label-only edit.
- `BM_INTEGRATION_contact_container` DART rows refreshed for default and AVX2 builds; contacts/resting/mobile counters stayed unchanged.
- Profile samples with `contact_benchmark --profile`: finite-finite same-group sweep was 24.34 ms / 7.18% on the 60-object row and 30.29 ms / 1.61% on the 120-object row.

After importing the branch into `/home/js/dev/dartsim/dart/main` per maintainer instruction:

- `pixi run check-lint`
- `pixi run cmake --build build/default/cpp/Release --target test_DARTCollisionDetector --parallel 8`
- `ctest --test-dir build/default/cpp/Release -R '^test_DARTCollisionDetector$' --output-on-failure`

Interrupted check:

- `DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run -e gazebo test-gz` was started in the previous worktree and interrupted when the work was moved to `/home/js/dev/dartsim/dart/main`; no Gazebo result is claimed here.

## Breaking Changes

- [x] None — private DART-native collision implementation and CI/dev-task documentation only; no public API, component, or package ISA change.

## Related Issues / PRs (backports)

- Contributes to #3056.
- Builds on the SIMD backport from #3229.
- Coordinates with the native collision work from #3281; that PR has internal native collision math only and does not yet add a DART 6 detector adapter or phase-4 broadphase SIMD.
- WP-PG.40 standalone PR #3270 was closed by maintainer direction; its D1/D2 evidence rides with this actual SIMD-kernel PR.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes — N/A; private implementation only, dev-task evidence updated
- [x] Add Python bindings (dartpy) if applicable — N/A
