### PR TITLE
Improve soft_bodies visualization capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -418,6 +418,12 @@
 
 * Examples
 
+  * Improve the C++ `soft_bodies` example with a framed Y-up view, headless PNG
+    capture, translucent soft meshes, display controls for embedded visuals,
+    and two-sided soft mesh rendering so generated soft-body faces do not look
+    missing from normal camera angles:
+    [#3304](https://github.com/dartsim/dart/pull/3304)
+
   * Add an OSG/ImGui `ssik_ik_gui` example for interactively selecting ssik
     prebuilt IK modules and changing target and solver options online. Every IK
     solution is shown at once as a DART skeleton built from the arm's kinematics

--- a/dart/gui/osg/render/SoftMeshShapeNode.cpp
+++ b/dart/gui/osg/render/SoftMeshShapeNode.cpp
@@ -107,9 +107,6 @@ void SoftMeshShapeNode::refresh()
 
   setNodeMask(mVisualAspect->isHidden() ? 0x0 : ~0x0);
 
-  if (mShape->getDataVariance() == dart::dynamics::Shape::STATIC)
-    return;
-
   extractData(false);
 }
 
@@ -279,13 +276,15 @@ void SoftMeshShapeDrawable::refresh(bool firstTime)
     setNormalArray(mNormals, ::osg::Array::BIND_PER_VERTEX);
   }
 
-  if (mSoftMeshShape->checkDataVariance(dart::dynamics::Shape::DYNAMIC_COLOR)
-      || firstTime) {
+  // VisualAspect color and alpha can change independently from the underlying
+  // SoftMeshShape data-variance flags, so re-read them on every refresh.
+  {
     // Set color
     const ::osg::Vec4d color = eigToOsgVec4d(mVisualAspect->getRGBA());
     mColors->resize(1);
     (*mColors)[0] = color;
     setColorArray(mColors, ::osg::Array::BIND_OVERALL);
+    dirtyDisplayList();
 
     // Set alpha specific properties
     ::osg::StateSet* ss = getOrCreateStateSet();

--- a/dart/gui/osg/render/SoftMeshShapeNode.cpp
+++ b/dart/gui/osg/render/SoftMeshShapeNode.cpp
@@ -38,10 +38,10 @@
 #include "dart/dynamics/SoftMeshShape.hpp"
 #include "dart/gui/osg/Utils.hpp"
 
-#include <osg/CullFace>
 #include <osg/Depth>
 #include <osg/Geode>
 #include <osg/Geometry>
+#include <osg/LightModel>
 
 namespace dart {
 namespace gui {
@@ -142,10 +142,15 @@ SoftMeshShapeGeode::SoftMeshShapeGeode(
     mVisualAspect(parentNode->getVisualAspect()),
     mDrawable(nullptr)
 {
-  getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
-  getOrCreateStateSet()->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
-  getOrCreateStateSet()->setAttributeAndModes(
-      new ::osg::CullFace(::osg::CullFace::BACK));
+  ::osg::StateSet* ss = getOrCreateStateSet();
+  ss->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+  ss->setRenderingHint(::osg::StateSet::TRANSPARENT_BIN);
+  ss->setMode(GL_CULL_FACE, ::osg::StateAttribute::OFF);
+
+  ::osg::ref_ptr<::osg::LightModel> lightModel = new ::osg::LightModel;
+  lightModel->setTwoSided(true);
+  ss->setAttributeAndModes(lightModel, ::osg::StateAttribute::ON);
+
   extractData();
 }
 

--- a/examples/soft_bodies/main.cpp
+++ b/examples/soft_bodies/main.cpp
@@ -36,9 +36,18 @@
 
 #include <dart/dart.hpp>
 
+#include <osg/GraphicsContext>
+#include <osg/Viewport>
 #include <osgViewer/Viewer>
 
+#include <algorithm>
+#include <array>
 #include <iostream>
+#include <string>
+#include <vector>
+
+#include <cstdlib>
+#include <cstring>
 
 using namespace dart::dynamics;
 
@@ -198,12 +207,193 @@ public:
   RecordingWorld* mRecWorld;
 };
 
+struct Options
+{
+  double scale = 1.0;
+  bool showHelp = false;
+  bool headless = false;
+  std::string shotPath = "soft_bodies.png";
+  int steps = 120;
+  int width = 640;
+  int height = 480;
+};
+
+void printUsage(const char* executable)
+{
+  dart::gui::osg::printGuiScaleUsage(std::cout, executable);
+  std::cout << "\nAdditional options:\n"
+            << "  --headless       Render off-screen to a PNG and exit.\n"
+            << "  --shot PATH      Output PNG path for --headless (default "
+               "soft_bodies.png).\n"
+            << "  --steps N        Simulation steps before a headless capture "
+               "(default 120).\n"
+            << "  --width W        Headless capture width before --gui-scale "
+               "(default 640).\n"
+            << "  --height H       Headless capture height before --gui-scale "
+               "(default 480).\n";
+}
+
+Options parseOptions(int argc, char* argv[])
+{
+  Options options;
+
+  std::vector<char*> forwarded;
+  forwarded.push_back(argv[0]);
+  for (int i = 1; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--headless") == 0) {
+      options.headless = true;
+    } else if (std::strcmp(argv[i], "--shot") == 0 && i + 1 < argc) {
+      options.shotPath = argv[++i];
+    } else if (std::strcmp(argv[i], "--steps") == 0 && i + 1 < argc) {
+      options.steps = std::atoi(argv[++i]);
+    } else if (std::strcmp(argv[i], "--width") == 0 && i + 1 < argc) {
+      options.width = std::atoi(argv[++i]);
+    } else if (std::strcmp(argv[i], "--height") == 0 && i + 1 < argc) {
+      options.height = std::atoi(argv[++i]);
+    } else {
+      forwarded.push_back(argv[i]);
+    }
+  }
+
+  const dart::gui::osg::GuiScaleOptions gui
+      = dart::gui::osg::parseGuiScaleOptions(
+          static_cast<int>(forwarded.size()), forwarded.data(), &std::cerr);
+  options.scale = gui.scale;
+  options.showHelp = gui.showHelp;
+  return options;
+}
+
+void styleSoftBodyVisuals(const dart::simulation::WorldPtr& world)
+{
+  const std::array<Eigen::Vector4d, 5> softBodyColors = {
+      Eigen::Vector4d(0.35, 0.48, 1.00, 1.0),
+      Eigen::Vector4d(0.95, 0.45, 0.30, 1.0),
+      Eigen::Vector4d(0.30, 0.72, 0.48, 1.0),
+      Eigen::Vector4d(0.95, 0.76, 0.28, 1.0),
+      Eigen::Vector4d(0.70, 0.45, 0.90, 1.0),
+  };
+
+  std::size_t softBodyIndex = 0;
+  for (std::size_t i = 0; i < world->getNumSkeletons(); ++i) {
+    const SkeletonPtr& skeleton = world->getSkeleton(i);
+    for (std::size_t j = 0; j < skeleton->getNumBodyNodes(); ++j) {
+      auto* softBodyNode = skeleton->getBodyNode(j)->asSoftBodyNode();
+      if (!softBodyNode)
+        continue;
+
+      const Eigen::Vector4d& color
+          = softBodyColors[softBodyIndex % softBodyColors.size()];
+      ++softBodyIndex;
+
+      for (std::size_t k = 0; k < softBodyNode->getNumShapeNodes(); ++k) {
+        auto* shapeNode = softBodyNode->getShapeNode(k);
+        auto* visualAspect = shapeNode->getVisualAspect(false);
+        if (!visualAspect)
+          continue;
+
+        const auto shape = shapeNode->getShape();
+        if (shape && shape->getType() == SoftMeshShape::getStaticType()) {
+          visualAspect->setRGBA(color);
+          visualAspect->show();
+        } else {
+          visualAspect->hide();
+        }
+      }
+    }
+  }
+}
+
+void applySoftBodiesCameraPose(dart::gui::osg::Viewer& viewer)
+{
+  const ::osg::Vec3 eye(3.0f, 1.5f, 3.0f);
+  const ::osg::Vec3 center(0.0f, 0.0f, 0.0f);
+  const ::osg::Vec3 up(0.0f, 1.0f, 0.0f);
+
+  viewer.setUpwardsDirection(up);
+  viewer.getCameraManipulator()->setHomePosition(eye, center, up);
+  viewer.setCameraManipulator(viewer.getCameraManipulator());
+  viewer.getCamera()->setViewMatrixAsLookAt(eye, center, up);
+}
+
+int runHeadless(
+    dart::gui::osg::Viewer& viewer,
+    RecordingWorld* node,
+    const dart::simulation::WorldPtr& world,
+    const Options& options)
+{
+  const int width = dart::gui::osg::scaleWindowExtent(
+      std::max(1, options.width), options.scale);
+  const int height = dart::gui::osg::scaleWindowExtent(
+      std::max(1, options.height), options.scale);
+
+  ::osg::ref_ptr<::osg::GraphicsContext::Traits> traits
+      = new ::osg::GraphicsContext::Traits;
+  traits->readDISPLAY();
+  traits->setUndefinedScreenDetailsToDefaultScreen();
+  traits->x = 0;
+  traits->y = 0;
+  traits->width = width;
+  traits->height = height;
+  traits->red = traits->green = traits->blue = 8;
+  traits->alpha = 8;
+  traits->depth = 24;
+  traits->windowDecoration = false;
+  traits->pbuffer = true;
+  traits->doubleBuffer = true;
+
+  ::osg::ref_ptr<::osg::GraphicsContext> gc
+      = ::osg::GraphicsContext::createGraphicsContext(traits.get());
+  if (!gc) {
+    std::cerr << "[headless] Failed to create an off-screen GL context "
+                 "(no usable DISPLAY?).\n";
+    return 1;
+  }
+
+  auto* camera = viewer.getCamera();
+  camera->setGraphicsContext(gc.get());
+  camera->setViewport(new ::osg::Viewport(0, 0, width, height));
+  camera->setProjectionMatrixAsPerspective(
+      30.0, static_cast<double>(width) / height, 0.1, 1000.0);
+  const GLenum buffer = traits->doubleBuffer ? GL_BACK : GL_FRONT;
+  camera->setDrawBuffer(buffer);
+  camera->setReadBuffer(buffer);
+
+  viewer.setThreadingModel(osgViewer::ViewerBase::SingleThreaded);
+  viewer.simulate(false);
+  node->simulate(false);
+  applySoftBodiesCameraPose(viewer);
+
+  viewer.realize();
+  if (!viewer.isRealized()) {
+    std::cerr << "[headless] Viewer failed to realize off-screen.\n";
+    return 1;
+  }
+  if (auto* queue = viewer.getEventQueue()) {
+    queue->windowResize(0, 0, width, height);
+    queue->setMouseInputRange(0.0f, 0.0f, width, height);
+  }
+
+  for (int i = 0; i < std::max(0, options.steps); ++i) {
+    world->step();
+    node->grabTimeSlice();
+  }
+
+  applySoftBodiesCameraPose(viewer);
+  viewer.frame();
+  viewer.frame();
+  viewer.captureScreen(options.shotPath);
+  viewer.frame();
+
+  std::cout << "[headless] wrote " << options.shotPath << " (" << width << "x"
+            << height << ", steps " << std::max(0, options.steps) << ")\n";
+  return 0;
+}
+
 int main(int argc, char* argv[])
 {
-  const dart::gui::osg::GuiScaleOptions options
-      = dart::gui::osg::parseGuiScaleOptions(argc, argv, &std::cerr);
+  const Options options = parseOptions(argc, argv);
   if (options.showHelp) {
-    dart::gui::osg::printGuiScaleUsage(std::cout, argv[0]);
+    printUsage(argv[0]);
     return 0;
   }
 
@@ -211,6 +401,12 @@ int main(int argc, char* argv[])
 
   dart::simulation::WorldPtr world = dart::utils::SkelParser::readWorld(
       "dart://sample/skel/softBodies.skel");
+  if (!world) {
+    std::cerr << "Failed to load dart://sample/skel/softBodies.skel\n";
+    return 1;
+  }
+
+  styleSoftBodyVisuals(world);
 
   osg::ref_ptr<RecordingWorld> node = new RecordingWorld(world);
 
@@ -219,8 +415,12 @@ int main(int argc, char* argv[])
   dart::gui::osg::Viewer viewer;
   viewer.addWorldNode(node);
   viewer.addEventHandler(new RecordingEventHandler(node));
+  applySoftBodiesCameraPose(viewer);
 
   std::cout << viewer.getInstructions() << std::endl;
+
+  if (options.headless)
+    return runHeadless(viewer, node.get(), world, options);
 
   viewer.setUpViewInWindow(
       0,

--- a/examples/soft_bodies/main.cpp
+++ b/examples/soft_bodies/main.cpp
@@ -43,13 +43,21 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <cstdlib>
 #include <cstring>
 
 using namespace dart::dynamics;
+
+struct SoftBodyDisplayOptions
+{
+  float softMeshAlpha = 0.5f;
+  bool showEmbeddedVisuals = true;
+};
 
 class RecordingWorld : public dart::gui::osg::RealTimeWorldNode
 {
@@ -216,6 +224,7 @@ struct Options
   int steps = 120;
   int width = 640;
   int height = 480;
+  SoftBodyDisplayOptions display;
 };
 
 void printUsage(const char* executable)
@@ -230,7 +239,9 @@ void printUsage(const char* executable)
             << "  --width W        Headless capture width before --gui-scale "
                "(default 640).\n"
             << "  --height H       Headless capture height before --gui-scale "
-               "(default 480).\n";
+               "(default 480).\n"
+            << "  --soft-alpha A   Soft mesh alpha in [0, 1] (default 0.5).\n"
+            << "  --hide-embedded  Hide embedded rigid visualization shapes.\n";
 }
 
 Options parseOptions(int argc, char* argv[])
@@ -250,6 +261,11 @@ Options parseOptions(int argc, char* argv[])
       options.width = std::atoi(argv[++i]);
     } else if (std::strcmp(argv[i], "--height") == 0 && i + 1 < argc) {
       options.height = std::atoi(argv[++i]);
+    } else if (std::strcmp(argv[i], "--soft-alpha") == 0 && i + 1 < argc) {
+      options.display.softMeshAlpha
+          = static_cast<float>(std::clamp(std::atof(argv[++i]), 0.0, 1.0));
+    } else if (std::strcmp(argv[i], "--hide-embedded") == 0) {
+      options.display.showEmbeddedVisuals = false;
     } else {
       forwarded.push_back(argv[i]);
     }
@@ -263,14 +279,17 @@ Options parseOptions(int argc, char* argv[])
   return options;
 }
 
-void styleSoftBodyVisuals(const dart::simulation::WorldPtr& world)
+void styleSoftBodyVisuals(
+    const dart::simulation::WorldPtr& world,
+    const SoftBodyDisplayOptions& display)
 {
+  const double alpha = std::clamp<double>(display.softMeshAlpha, 0.0, 1.0);
   const std::array<Eigen::Vector4d, 5> softBodyColors = {
-      Eigen::Vector4d(0.35, 0.48, 1.00, 1.0),
-      Eigen::Vector4d(0.95, 0.45, 0.30, 1.0),
-      Eigen::Vector4d(0.30, 0.72, 0.48, 1.0),
-      Eigen::Vector4d(0.95, 0.76, 0.28, 1.0),
-      Eigen::Vector4d(0.70, 0.45, 0.90, 1.0),
+      Eigen::Vector4d(0.35, 0.48, 1.00, alpha),
+      Eigen::Vector4d(0.95, 0.45, 0.30, alpha),
+      Eigen::Vector4d(0.30, 0.72, 0.48, alpha),
+      Eigen::Vector4d(0.95, 0.76, 0.28, alpha),
+      Eigen::Vector4d(0.70, 0.45, 0.90, alpha),
   };
 
   std::size_t softBodyIndex = 0;
@@ -295,6 +314,8 @@ void styleSoftBodyVisuals(const dart::simulation::WorldPtr& world)
         if (shape && shape->getType() == SoftMeshShape::getStaticType()) {
           visualAspect->setRGBA(color);
           visualAspect->show();
+        } else if (display.showEmbeddedVisuals) {
+          visualAspect->show();
         } else {
           visualAspect->hide();
         }
@@ -302,6 +323,66 @@ void styleSoftBodyVisuals(const dart::simulation::WorldPtr& world)
     }
   }
 }
+
+void applySoftBodiesCameraPose(dart::gui::osg::Viewer& viewer);
+
+class SoftBodiesWidget : public dart::gui::osg::ImGuiWidget
+{
+public:
+  SoftBodiesWidget(
+      dart::gui::osg::ImGuiViewer* viewer,
+      dart::simulation::WorldPtr world,
+      SoftBodyDisplayOptions* display)
+    : mViewer(viewer), mWorld(std::move(world)), mDisplay(display)
+  {
+  }
+
+  void render() override
+  {
+    const float guiScale
+        = static_cast<float>(mViewer->getImGuiHandler()->getGuiScale());
+    const float margin = 12.0f * guiScale;
+    ImGui::SetNextWindowPos(ImVec2(margin, margin), ImGuiCond_Once);
+    ImGui::SetNextWindowSize(
+        ImVec2(300.0f * guiScale, 190.0f * guiScale), ImGuiCond_Once);
+    ImGui::SetNextWindowBgAlpha(0.92f);
+    if (!ImGui::Begin(
+            "Soft Bodies",
+            nullptr,
+            ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings)) {
+      ImGui::End();
+      return;
+    }
+
+    bool changed = false;
+    bool simulating = mViewer->isSimulating();
+    if (ImGui::Checkbox("Run simulation", &simulating))
+      mViewer->simulate(simulating);
+
+    changed |= ImGui::SliderFloat(
+        "Soft mesh alpha", &mDisplay->softMeshAlpha, 0.0f, 1.0f, "%.2f");
+    changed
+        |= ImGui::Checkbox("Embedded visuals", &mDisplay->showEmbeddedVisuals);
+
+    if (ImGui::Button("Reset view"))
+      applySoftBodiesCameraPose(*mViewer);
+
+    ImGui::Separator();
+    ImGui::Text("Time %.3f s", mWorld->getTime());
+    ImGui::SameLine();
+    ImGui::Text("FPS %.0f", ImGui::GetIO().Framerate);
+
+    if (changed)
+      styleSoftBodyVisuals(mWorld, *mDisplay);
+
+    ImGui::End();
+  }
+
+private:
+  dart::gui::osg::ImGuiViewer* mViewer;
+  dart::simulation::WorldPtr mWorld;
+  SoftBodyDisplayOptions* mDisplay;
+};
 
 void applySoftBodiesCameraPose(dart::gui::osg::Viewer& viewer)
 {
@@ -391,7 +472,7 @@ int runHeadless(
 
 int main(int argc, char* argv[])
 {
-  const Options options = parseOptions(argc, argv);
+  Options options = parseOptions(argc, argv);
   if (options.showHelp) {
     printUsage(argv[0]);
     return 0;
@@ -406,27 +487,32 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  styleSoftBodyVisuals(world);
+  styleSoftBodyVisuals(world, options.display);
 
   osg::ref_ptr<RecordingWorld> node = new RecordingWorld(world);
 
   node->simulate(true);
 
-  dart::gui::osg::Viewer viewer;
-  viewer.addWorldNode(node);
-  viewer.addEventHandler(new RecordingEventHandler(node));
-  applySoftBodiesCameraPose(viewer);
+  osg::ref_ptr<dart::gui::osg::ImGuiViewer> viewer
+      = new dart::gui::osg::ImGuiViewer();
+  viewer->addWorldNode(node);
+  viewer->addEventHandler(new RecordingEventHandler(node));
+  viewer->getImGuiHandler()->setGuiScale(options.scale);
+  applySoftBodiesCameraPose(*viewer);
 
-  std::cout << viewer.getInstructions() << std::endl;
+  std::cout << viewer->getInstructions() << std::endl;
 
   if (options.headless)
-    return runHeadless(viewer, node.get(), world, options);
+    return runHeadless(*viewer, node.get(), world, options);
 
-  viewer.setUpViewInWindow(
+  viewer->getImGuiHandler()->addWidget(std::make_shared<SoftBodiesWidget>(
+      viewer.get(), world, &options.display));
+
+  viewer->setUpViewInWindow(
       0,
       0,
       dart::gui::osg::scaleWindowExtent(640, options.scale),
       dart::gui::osg::scaleWindowExtent(480, options.scale));
 
-  viewer.run();
+  viewer->run();
 }

--- a/examples/soft_bodies/main.cpp
+++ b/examples/soft_bodies/main.cpp
@@ -42,9 +42,11 @@
 
 #include <algorithm>
 #include <array>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -331,9 +333,10 @@ class SoftBodiesWidget : public dart::gui::osg::ImGuiWidget
 public:
   SoftBodiesWidget(
       dart::gui::osg::ImGuiViewer* viewer,
+      RecordingWorld* node,
       dart::simulation::WorldPtr world,
       SoftBodyDisplayOptions* display)
-    : mViewer(viewer), mWorld(std::move(world)), mDisplay(display)
+    : mViewer(viewer), mNode(node), mWorld(std::move(world)), mDisplay(display)
   {
   }
 
@@ -359,8 +362,10 @@ public:
     if (ImGui::Checkbox("Run simulation", &simulating))
       mViewer->simulate(simulating);
 
+    ImGui::TextUnformatted("Soft mesh alpha");
+    ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
     changed |= ImGui::SliderFloat(
-        "Soft mesh alpha", &mDisplay->softMeshAlpha, 0.0f, 1.0f, "%.2f");
+        "##soft_mesh_alpha", &mDisplay->softMeshAlpha, 0.0f, 1.0f, "%.2f");
     changed
         |= ImGui::Checkbox("Embedded visuals", &mDisplay->showEmbeddedVisuals);
 
@@ -372,14 +377,28 @@ public:
     ImGui::SameLine();
     ImGui::Text("FPS %.0f", ImGui::GetIO().Framerate);
 
-    if (changed)
+    if (changed) {
       styleSoftBodyVisuals(mWorld, *mDisplay);
+      refreshDisplay();
+    }
 
     ImGui::End();
   }
 
 private:
+  void refreshDisplay()
+  {
+    if (!mNode)
+      return;
+
+    const bool wasSimulating = mNode->isSimulating();
+    mNode->simulate(false);
+    mNode->refresh();
+    mNode->simulate(wasSimulating);
+  }
+
   dart::gui::osg::ImGuiViewer* mViewer;
+  RecordingWorld* mNode;
   dart::simulation::WorldPtr mWorld;
   SoftBodyDisplayOptions* mDisplay;
 };
@@ -402,6 +421,35 @@ int runHeadless(
     const dart::simulation::WorldPtr& world,
     const Options& options)
 {
+  const std::filesystem::path shotPath(options.shotPath);
+  std::error_code fileError;
+  const std::filesystem::file_status shotStatus
+      = std::filesystem::status(shotPath, fileError);
+  const bool targetMissing
+      = fileError == std::make_error_code(std::errc::no_such_file_or_directory);
+  if (fileError && !targetMissing) {
+    std::cerr << "[headless] Failed to inspect capture target: "
+              << options.shotPath << "\n";
+    return 1;
+  }
+
+  if (!targetMissing && std::filesystem::exists(shotStatus)) {
+    if (!std::filesystem::is_regular_file(shotStatus)) {
+      std::cerr
+          << "[headless] Capture target exists but is not a regular file: "
+          << options.shotPath << "\n";
+      return 1;
+    }
+
+    fileError.clear();
+    std::filesystem::remove(shotPath, fileError);
+    if (fileError) {
+      std::cerr << "[headless] Failed to remove existing capture target: "
+                << options.shotPath << "\n";
+      return 1;
+    }
+  }
+
   const int width = dart::gui::osg::scaleWindowExtent(
       std::max(1, options.width), options.scale);
   const int height = dart::gui::osg::scaleWindowExtent(
@@ -465,6 +513,15 @@ int runHeadless(
   viewer.captureScreen(options.shotPath);
   viewer.frame();
 
+  fileError.clear();
+  const bool wroteFile = std::filesystem::is_regular_file(shotPath, fileError)
+                         && std::filesystem::file_size(shotPath, fileError) > 0;
+  if (fileError || !wroteFile) {
+    std::cerr << "[headless] Failed to write capture: " << options.shotPath
+              << "\n";
+    return 1;
+  }
+
   std::cout << "[headless] wrote " << options.shotPath << " (" << width << "x"
             << height << ", steps " << std::max(0, options.steps) << ")\n";
   return 0;
@@ -491,11 +548,10 @@ int main(int argc, char* argv[])
 
   osg::ref_ptr<RecordingWorld> node = new RecordingWorld(world);
 
-  node->simulate(true);
-
   osg::ref_ptr<dart::gui::osg::ImGuiViewer> viewer
       = new dart::gui::osg::ImGuiViewer();
   viewer->addWorldNode(node);
+  viewer->simulate(true);
   viewer->addEventHandler(new RecordingEventHandler(node));
   viewer->getImGuiHandler()->setGuiScale(options.scale);
   applySoftBodiesCameraPose(*viewer);
@@ -506,7 +562,7 @@ int main(int argc, char* argv[])
     return runHeadless(*viewer, node.get(), world, options);
 
   viewer->getImGuiHandler()->addWidget(std::make_shared<SoftBodiesWidget>(
-      viewer.get(), world, &options.display));
+      viewer.get(), node.get(), world, &options.display));
 
   viewer->setUpViewInWindow(
       0,


### PR DESCRIPTION
## Summary

- Improve the `soft_bodies` example so it opens on a framed Y-up 3D scene instead of a solid-color/blank-looking view.
- Add a bounded headless PNG capture path for visual debugging and CI-style smoke checks.
- Render soft mesh geometry two-sided so generated soft-body face winding does not appear as holes from normal camera angles.
- Render soft meshes at 50% alpha by default and add ImGui/CLI controls for soft mesh alpha and embedded rigid visuals.

## Motivation / Problem

The `soft_bodies` example accepted `--gui-scale`, but it had no bounded headless capture path and did not set a camera pose for the Y-up soft-body scene. In practice the workflow could show only a solid-color/blank-looking window or a poorly framed scene. Once the scene was visible, the soft mesh renderer also exposed missing-looking faces on generated box meshes because back-face culling hid triangles whose winding faced away from the camera.

For debugging the soft-body setup, the embedded rigid visuals are useful context. Fully opaque soft meshes can hide those embedded shapes, so the example now makes the deformable flesh translucent by default and exposes live controls for adjusting visibility.

## Changes / Key Changes

- Add `--headless`, `--shot`, `--steps`, `--width`, and `--height` options to `examples/soft_bodies`.
- Validate headless output by removing stale regular-file targets before capture and requiring a non-empty PNG afterward.
- Add `--soft-alpha` and `--hide-embedded` options for command-line display control.
- Add a fixed Y-up camera pose for both interactive and headless runs.
- Style generated soft meshes with distinct translucent colors while keeping embedded rigid visuals visible by default.
- Add an ImGui panel with simulation, soft mesh alpha, embedded visual, and reset-view controls.
- Keep the alpha slider readable at large `--gui-scale` values and refresh the OSG soft-mesh color/alpha state live when display controls change.
- Disable soft mesh face culling and enable two-sided lighting in the OSG soft mesh renderer.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| `pixi run ex soft_bodies -- --gui-scale 2` | Could open to a solid-color/blank-looking window with no framed scene. | Opens on a visible 3D soft-body scene with an ImGui display-control panel. |
| Headless visual debugging | No bounded capture path in this example; failed image writes could still return success. | `--headless --shot <path>` writes a deterministic PNG, verifies the file, and exits nonzero if capture output is missing. |
| Soft mesh faces | Generated soft-body box faces could look like holes from normal camera angles. | Soft meshes render two-sided, so those surfaces remain visible. |
| Embedded visuals | Rigid proxy visuals either cluttered opaque soft bodies or had to be hidden globally. | Soft meshes are translucent by default, and embedded visuals can be toggled live or hidden with `--hide-embedded`. |
| High GUI scale | The alpha slider label could be clipped at `--gui-scale 4`. | The alpha label is separate from a full-width slider, so it remains readable. |

Local visual artifacts inspected:

- Before renderer fix: `/tmp/soft_bodies-before-hole-fix.png`
- After renderer fix: `/tmp/soft_bodies-after-hole-fix.png`
- Transparent soft mesh with embedded visuals: `/tmp/soft_bodies-imgui-controls.png`
- Review-fix capture at `--gui-scale 4`: `/tmp/soft_bodies-review-fixes.png`

## Testing

- `pixi run ex soft_bodies -- --gui-scale 2 --headless --shot /tmp/soft_bodies-headless-styled.png --steps 120`
- `./build/default/cpp/Release/bin/soft_bodies --gui-scale 2 --headless --shot /tmp/soft_bodies-final.png --steps 120`
- `pixi run ex soft_bodies -- --gui-scale 2 --headless --shot /tmp/soft_bodies-after-hole-fix.png --steps 120 --width 896 --height 768`
- `pixi run ex soft_bodies -- --gui-scale 2 --headless --shot /tmp/soft_bodies-imgui-controls.png --steps 120 --width 896 --height 768`
- `pixi run ex soft_bodies -- --gui-scale 4 --headless --shot /tmp/soft_bodies-review-fixes.png --steps 120 --width 896 --height 768`
- `timeout 6s ./build/default/cpp/Release/bin/soft_bodies --gui-scale 4` (expected timeout after live GUI smoke; no crash before timeout)
- `if ./build/default/cpp/Release/bin/soft_bodies --headless --shot /tmp/dart-soft-bodies-missing-dir/out.png --steps 1 --width 64 --height 64; then echo 'unexpected success'; exit 1; else echo 'missing output path failed as expected'; fi`
- `./build/default/cpp/Release/bin/soft_bodies --headless --soft-alpha 1 --shot /tmp/soft_bodies-alpha-1-current.png --steps 120 --width 256 --height 192`
- `./build/default/cpp/Release/bin/soft_bodies --headless --soft-alpha 0.2 --shot /tmp/soft_bodies-alpha-02-current.png --steps 120 --width 256 --height 192`
- `sha256sum /tmp/soft_bodies-alpha-1-current.png /tmp/soft_bodies-alpha-02-current.png`
- `./build/default/cpp/Release/bin/soft_bodies --help`
- `pixi run lint`
- `pixi run build`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- None

---

#### Checklist

- [x] Milestone set: DART 6.20.0
- [x] CHANGELOG.md updated if required: added DART 6.20.0 Examples entry for #3304
- [x] Add unit tests for new functionality: N/A, visual example and renderer behavior verified by headless capture plus build
- [x] Document new methods and classes: N/A, no public API added
- [x] Add Python bindings (dartpy) if applicable: N/A