### PR TITLE
Use overflow-safe hypot in native sphere binary overlap

### DIFF
--- a/dart/collision/native/narrow_phase/sphere_sphere.cpp
+++ b/dart/collision/native/narrow_phase/sphere_sphere.cpp
@@ -103,8 +103,9 @@ bool collideSpheresOnAxis(
 bool spheresOverlap(
     double dx, double dy, double dz, double radius1, double radius2)
 {
-  const double sumRadii = radius1 + radius2;
-  return dx * dx + dy * dy + dz * dz <= sumRadii * sumRadii;
+  // Use std::hypot (overflow-safe) rather than a squared comparison so
+  // large-but-finite inputs agree with the linear axis-aligned contact path.
+  return std::hypot(dx, dy, dz) <= radius1 + radius2;
 }
 
 bool collideSphereCenters(

--- a/tests/unit/collision/native/test_sphere_sphere.cpp
+++ b/tests/unit/collision/native/test_sphere_sphere.cpp
@@ -737,6 +737,36 @@ TEST(SphereSphere, ZeroContactLimitShortCircuitsEvenWithoutContact)
   EXPECT_EQ(result.numContacts(), 0);
 }
 
+TEST(SphereSphere, BinaryCheckDoesNotOverflowOnLargeSeparation)
+{
+  // Overflow-safe binary check: for large-but-finite, clearly-separated
+  // inputs the squared form would overflow to inf and spuriously report a
+  // hit; the hypot-based predicate must agree with the contact path (miss).
+  CollisionOption option;
+  option.enableContact = false;
+
+  CollisionResult result;
+  const double r = 1e154;
+  EXPECT_FALSE(collideSpheres(
+      Eigen::Vector3d(0, 0, 0),
+      r,
+      Eigen::Vector3d(3e154, 0, 0),
+      r,
+      result,
+      option));
+  EXPECT_EQ(result.numContacts(), 0);
+
+  // A genuine overlap at the same magnitude still reports a hit.
+  EXPECT_TRUE(collideSpheres(
+      Eigen::Vector3d(0, 0, 0),
+      r,
+      Eigen::Vector3d(1e154, 0, 0),
+      r,
+      result,
+      option));
+  EXPECT_EQ(result.numContacts(), 0);
+}
+
 // DART 6 supplementary coverage tests (not ported from DART 7)
 TEST(SphereSphere, ShapeOverloadZAxisAndContactLimit)
 {


### PR DESCRIPTION
## Summary

- Make the native sphere-sphere binary-check overlap predicate overflow-safe.
  `spheresOverlap` used a squared-distance comparison
  (`dx²+dy²+dz² <= (r1+r2)²`) that overflows to `inf` for large-but-finite
  inputs, so a clearly-separated pair at radii ~1e154 spuriously reports a hit
  the (linear, overflow-safe) axis-aligned contact path rejects.

## Motivation / Problem

Follow-up to #3298 (which landed `spheresOverlap` for the `maxNumContacts==0`
short-circuit). Flagged by review on the main-branch dual PR (#3283): the
binary `enableContact=false` path now runs `spheresOverlap` before the linear
axis checks, so its overflow diverges from the contact path for finite inputs.

## Changes / Key Changes

- Replace the squared comparison with `std::hypot(dx, dy, dz) <= r1 + r2`
  (C++17 3-arg `std::hypot`, overflow-safe; `<cmath>` already included).
- Regression test `SphereSphere.BinaryCheckDoesNotOverflowOnLargeSeparation`
  (separated miss + genuine overlap at ~1e154 magnitude).

## Testing

- `pixi run lint`: clean.
- `ctest -R UNIT_collision_native_sphere_sphere`: 1/1 pass (incl. new test).

## Breaking Changes

- [x] None — identical results for all physical inputs; only removes a
  spurious hit at non-physical (~1e154) magnitudes.

## Related Issues / PRs

- Dual-PR counterpart on `main`: #3283 (same commit).
- Follows #3298 / the phase-1 native core #3281.