### PR TITLE
Port native narrowphase dispatcher, sphere/box only (phase-2 P2, internal-only)

### DIFF
--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -14,6 +14,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/gjk.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/gjk_inl.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/mpr.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/narrow_phase.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/sat.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/face_clip.hpp
@@ -29,6 +30,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/shapes/shape.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/gjk.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/mpr.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/narrow_phase.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/sat.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/face_clip.cpp

--- a/dart/collision/native/narrow_phase/narrow_phase.cpp
+++ b/dart/collision/native/narrow_phase/narrow_phase.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/box_box.hpp>
+#include <dart/collision/native/narrow_phase/narrow_phase.hpp>
+#include <dart/collision/native/narrow_phase/sphere_sphere.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+
+#include <stdexcept>
+
+namespace dart::collision::native {
+
+namespace {
+
+bool collideShapes(
+    const Shape* shape1,
+    const Eigen::Isometry3d& tf1,
+    const Shape* shape2,
+    const Eigen::Isometry3d& tf2,
+    const CollisionOption& option,
+    CollisionResult& result)
+{
+  if (!shape1 || !shape2) {
+    return false;
+  }
+
+  ShapeType type1 = shape1->getType();
+  ShapeType type2 = shape2->getType();
+
+  if (type1 == ShapeType::Sphere && type2 == ShapeType::Sphere) {
+    const auto* s1 = static_cast<const SphereShape*>(shape1);
+    const auto* s2 = static_cast<const SphereShape*>(shape2);
+    return collideSpheres(*s1, tf1, *s2, tf2, result, option);
+  }
+
+  if (type1 == ShapeType::Box && type2 == ShapeType::Box) {
+    const auto* b1 = static_cast<const BoxShape*>(shape1);
+    const auto* b2 = static_cast<const BoxShape*>(shape2);
+    return collideBoxes(*b1, tf1, *b2, tf2, result, option);
+  }
+
+  return false;
+}
+
+bool collideBatchShapes(
+    span<const NarrowPhasePair> pairs,
+    span<CollisionResult> results,
+    span<bool> hits,
+    bool recordHits,
+    const CollisionOption& option)
+{
+  if (results.size() < pairs.size()) {
+    throw std::invalid_argument(
+        "NarrowPhase::collideBatch requires one result for each pair");
+  }
+  if (recordHits && hits.size() < pairs.size()) {
+    throw std::invalid_argument(
+        "NarrowPhase::collideBatch requires one hit flag for each pair");
+  }
+
+  bool anyHit = false;
+  for (std::size_t i = 0; i < pairs.size(); ++i) {
+    const auto& pair = pairs[i];
+    if (pair.shapeA == nullptr || pair.shapeB == nullptr) {
+      throw std::invalid_argument(
+          "NarrowPhase::collideBatch received a null shape");
+    }
+
+    const bool hit = collideShapes(
+        pair.shapeA, pair.tfA, pair.shapeB, pair.tfB, option, results[i]);
+    if (recordHits) {
+      hits[i] = hit;
+    }
+    anyHit |= hit;
+  }
+
+  return anyHit;
+}
+
+} // namespace
+
+bool NarrowPhase::collide(
+    const Shape* shape1,
+    const Eigen::Isometry3d& tf1,
+    const Shape* shape2,
+    const Eigen::Isometry3d& tf2,
+    const CollisionOption& option,
+    CollisionResult& result)
+{
+  return collideShapes(shape1, tf1, shape2, tf2, option, result);
+}
+
+bool NarrowPhase::collideBatch(
+    span<const NarrowPhasePair> pairs,
+    span<CollisionResult> results,
+    const CollisionOption& option)
+{
+  return collideBatchShapes(pairs, results, span<bool>(), false, option);
+}
+
+bool NarrowPhase::collideBatch(
+    span<const NarrowPhasePair> pairs,
+    span<CollisionResult> results,
+    span<bool> hits,
+    const CollisionOption& option)
+{
+  return collideBatchShapes(pairs, results, hits, true, option);
+}
+
+bool NarrowPhase::isSupported(ShapeType type1, ShapeType type2)
+{
+  if (type1 == ShapeType::Sphere && type2 == ShapeType::Sphere) {
+    return true;
+  }
+  if (type1 == ShapeType::Box && type2 == ShapeType::Box) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/narrow_phase.cpp
+++ b/dart/collision/native/narrow_phase/narrow_phase.cpp
@@ -53,6 +53,10 @@ bool collideShapes(
     return false;
   }
 
+  if (option.maxNumContacts == 0) {
+    return false;
+  }
+
   ShapeType type1 = shape1->getType();
   ShapeType type2 = shape2->getType();
 

--- a/dart/collision/native/narrow_phase/narrow_phase.hpp
+++ b/dart/collision/native/narrow_phase/narrow_phase.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/collision/native/detail/span.hpp>
+#include <dart/collision/native/export.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace dart::collision::native {
+
+enum class ShapeType;
+
+struct DART_COLLISION_NATIVE_API NarrowPhasePair
+{
+  const Shape* shapeA;
+  const Shape* shapeB;
+  Eigen::Isometry3d tfA;
+  Eigen::Isometry3d tfB;
+};
+
+class DART_COLLISION_NATIVE_API NarrowPhase
+{
+public:
+  static bool collide(
+      const Shape* shape1,
+      const Eigen::Isometry3d& tf1,
+      const Shape* shape2,
+      const Eigen::Isometry3d& tf2,
+      const CollisionOption& option,
+      CollisionResult& result);
+
+  static bool collideBatch(
+      span<const NarrowPhasePair> pairs,
+      span<CollisionResult> results,
+      const CollisionOption& option = CollisionOption());
+
+  static bool collideBatch(
+      span<const NarrowPhasePair> pairs,
+      span<CollisionResult> results,
+      span<bool> hits,
+      const CollisionOption& option = CollisionOption());
+
+  static bool isSupported(ShapeType type1, ShapeType type2);
+};
+
+} // namespace dart::collision::native

--- a/tests/unit/collision/native/CMakeLists.txt
+++ b/tests/unit/collision/native/CMakeLists.txt
@@ -20,6 +20,11 @@ dart_add_test(
 )
 dart_add_test(
   "unit"
+  UNIT_collision_native_narrow_phase_dispatch
+  test_narrow_phase_dispatch.cpp
+)
+dart_add_test(
+  "unit"
   UNIT_collision_native_gjk
   test_gjk.cpp
 )

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -36,6 +36,9 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <stdexcept>
+
 using namespace dart::collision::native;
 
 namespace {
@@ -119,6 +122,127 @@ TEST(NarrowPhaseDispatch, ReturnsFalseForUnroutedPairs)
 
   EXPECT_FALSE(hit);
   EXPECT_EQ(result.numContacts(), 0u);
+}
+
+TEST(NarrowPhaseDispatch, ReturnsFalseForNullShape)
+{
+  SphereShape sphere(1.0);
+
+  CollisionResult result;
+  EXPECT_FALSE(NarrowPhase::collide(
+      nullptr,
+      Eigen::Isometry3d::Identity(),
+      &sphere,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      result));
+  EXPECT_FALSE(NarrowPhase::collide(
+      &sphere,
+      Eigen::Isometry3d::Identity(),
+      nullptr,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      result));
+  EXPECT_EQ(result.numContacts(), 0u);
+}
+
+TEST(NarrowPhaseDispatch, BatchWithoutHitVectorReturnsAnyHit)
+{
+  SphereShape sphere1(1.0);
+  SphereShape sphere2(1.0);
+  BoxShape box1(Eigen::Vector3d(1.0, 1.0, 1.0));
+  BoxShape box2(Eigen::Vector3d(1.0, 1.0, 1.0));
+
+  const std::array<NarrowPhasePair, 2> pairs{{
+      {&sphere1,
+       &sphere2,
+       Eigen::Isometry3d::Identity(),
+       translated(3.0, 0.0, 0.0)},
+      {&box1, &box2, Eigen::Isometry3d::Identity(), translated(0.5, 0.0, 0.0)},
+  }};
+  std::array<CollisionResult, 2> results;
+
+  const bool hit = NarrowPhase::collideBatch(pairs, results, CollisionOption());
+
+  EXPECT_TRUE(hit);
+  EXPECT_EQ(results[0].numContacts(), 0u);
+  EXPECT_GE(results[1].numContacts(), 1u);
+}
+
+TEST(NarrowPhaseDispatch, BatchRecordsPerPairHits)
+{
+  SphereShape sphere1(1.0);
+  SphereShape sphere2(1.0);
+  CapsuleShape capsule(0.5, 2.0);
+
+  const std::array<NarrowPhasePair, 3> pairs{{
+      {&sphere1,
+       &sphere2,
+       Eigen::Isometry3d::Identity(),
+       translated(1.5, 0.0, 0.0)},
+      {&sphere1,
+       &sphere2,
+       Eigen::Isometry3d::Identity(),
+       translated(3.0, 0.0, 0.0)},
+      {&sphere1,
+       &capsule,
+       Eigen::Isometry3d::Identity(),
+       Eigen::Isometry3d::Identity()},
+  }};
+  std::array<CollisionResult, 3> results;
+  std::array<bool, 3> hits{{false, true, true}};
+
+  const bool anyHit
+      = NarrowPhase::collideBatch(pairs, results, hits, CollisionOption());
+
+  EXPECT_TRUE(anyHit);
+  EXPECT_TRUE(hits[0]);
+  EXPECT_FALSE(hits[1]);
+  EXPECT_FALSE(hits[2]);
+  EXPECT_GE(results[0].numContacts(), 1u);
+  EXPECT_EQ(results[1].numContacts(), 0u);
+  EXPECT_EQ(results[2].numContacts(), 0u);
+}
+
+TEST(NarrowPhaseDispatch, BatchRejectsMismatchedOutputSpans)
+{
+  SphereShape sphere1(1.0);
+  SphereShape sphere2(1.0);
+
+  const std::array<NarrowPhasePair, 1> pairs{{
+      {&sphere1,
+       &sphere2,
+       Eigen::Isometry3d::Identity(),
+       translated(1.5, 0.0, 0.0)},
+  }};
+
+  EXPECT_THROW(
+      NarrowPhase::collideBatch(
+          pairs, span<CollisionResult>(), CollisionOption()),
+      std::invalid_argument);
+
+  std::array<CollisionResult, 1> results;
+  EXPECT_THROW(
+      NarrowPhase::collideBatch(
+          pairs, results, span<bool>(), CollisionOption()),
+      std::invalid_argument);
+}
+
+TEST(NarrowPhaseDispatch, BatchRejectsNullShapes)
+{
+  SphereShape sphere(1.0);
+
+  const std::array<NarrowPhasePair, 1> pairs{{
+      {nullptr,
+       &sphere,
+       Eigen::Isometry3d::Identity(),
+       Eigen::Isometry3d::Identity()},
+  }};
+  std::array<CollisionResult, 1> results;
+
+  EXPECT_THROW(
+      NarrowPhase::collideBatch(pairs, results, CollisionOption()),
+      std::invalid_argument);
 }
 
 TEST(NarrowPhaseDispatch, ReportsSupportOnlyForSphereSphereAndBoxBox)

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/narrow_phase.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace dart::collision::native;
+
+namespace {
+
+Eigen::Isometry3d translated(double x, double y, double z)
+{
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(x, y, z);
+  return tf;
+}
+
+} // namespace
+
+TEST(NarrowPhaseDispatch, RoutesOverlappingSphereSphere)
+{
+  SphereShape sphere1(1.0);
+  SphereShape sphere2(1.0);
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &sphere1,
+      Eigen::Isometry3d::Identity(),
+      &sphere2,
+      translated(1.5, 0.0, 0.0),
+      CollisionOption(),
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GE(result.numContacts(), 1u);
+}
+
+TEST(NarrowPhaseDispatch, ReturnsFalseForSeparatedSphereSphere)
+{
+  SphereShape sphere1(1.0);
+  SphereShape sphere2(1.0);
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &sphere1,
+      Eigen::Isometry3d::Identity(),
+      &sphere2,
+      translated(3.0, 0.0, 0.0),
+      CollisionOption(),
+      result);
+
+  EXPECT_FALSE(hit);
+  EXPECT_EQ(result.numContacts(), 0u);
+}
+
+TEST(NarrowPhaseDispatch, RoutesOverlappingBoxBox)
+{
+  BoxShape box1(Eigen::Vector3d(1.0, 1.0, 1.0));
+  BoxShape box2(Eigen::Vector3d(1.0, 1.0, 1.0));
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &box1,
+      Eigen::Isometry3d::Identity(),
+      &box2,
+      translated(0.5, 0.0, 0.0),
+      CollisionOption(),
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GE(result.numContacts(), 1u);
+}
+
+TEST(NarrowPhaseDispatch, ReturnsFalseForUnroutedPairs)
+{
+  SphereShape sphere(1.0);
+  CapsuleShape capsule(0.5, 2.0);
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &sphere,
+      Eigen::Isometry3d::Identity(),
+      &capsule,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      result);
+
+  EXPECT_FALSE(hit);
+  EXPECT_EQ(result.numContacts(), 0u);
+}
+
+TEST(NarrowPhaseDispatch, ReportsSupportOnlyForSphereSphereAndBoxBox)
+{
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Sphere));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Box, ShapeType::Box));
+
+  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Box));
+  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Box, ShapeType::Sphere));
+  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Capsule));
+  EXPECT_FALSE(
+      NarrowPhase::isSupported(ShapeType::Capsule, ShapeType::Capsule));
+}
+
+TEST(NarrowPhaseDispatch, RespectsExhaustedContactBudget)
+{
+  SphereShape sphere1(1.0);
+  SphereShape sphere2(1.0);
+
+  CollisionOption option;
+  option.enableContact = true;
+  option.maxNumContacts = 0;
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &sphere1,
+      Eigen::Isometry3d::Identity(),
+      &sphere2,
+      translated(1.5, 0.0, 0.0),
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+  EXPECT_EQ(result.numContacts(), 0u);
+}

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -261,20 +261,36 @@ TEST(NarrowPhaseDispatch, RespectsExhaustedContactBudget)
 {
   SphereShape sphere1(1.0);
   SphereShape sphere2(1.0);
+  BoxShape box1(Eigen::Vector3d(1.0, 1.0, 1.0));
+  BoxShape box2(Eigen::Vector3d(1.0, 1.0, 1.0));
 
   CollisionOption option;
   option.enableContact = true;
   option.maxNumContacts = 0;
 
-  CollisionResult result;
-  const bool hit = NarrowPhase::collide(
+  CollisionResult sphereResult;
+  const bool sphereHit = NarrowPhase::collide(
       &sphere1,
       Eigen::Isometry3d::Identity(),
       &sphere2,
       translated(1.5, 0.0, 0.0),
       option,
-      result);
+      sphereResult);
 
-  EXPECT_FALSE(hit);
-  EXPECT_EQ(result.numContacts(), 0u);
+  EXPECT_FALSE(sphereHit);
+  EXPECT_EQ(sphereResult.numContacts(), 0u);
+
+  option.enableContact = false;
+
+  CollisionResult boxResult;
+  const bool boxHit = NarrowPhase::collide(
+      &box1,
+      Eigen::Isometry3d::Identity(),
+      &box2,
+      translated(0.5, 0.0, 0.0),
+      option,
+      boxResult);
+
+  EXPECT_FALSE(boxHit);
+  EXPECT_EQ(boxResult.numContacts(), 0u);
 }


### PR DESCRIPTION
## Summary

- Second slice (**P2**) of the phase-2 native collision adapter
  (`docs/dev_tasks/dart6_dependency_minimization/07-phase2-adapter-scoping.md`
  §2.1, §3): land `dart/collision/native/narrow_phase/narrow_phase.{hpp,cpp}`
  as a **bespoke reduced dispatcher** routing **only sphere-sphere and box-box**
  pairs to the ported colliders, returning `false` for every other pair.

## Motivation / Problem

The adapter's `collide()` (later slices) drives BruteForce broadphase -> this
narrowphase dispatcher -> DART 6 `Contact`. `main`'s `narrow_phase.cpp` (1344
lines) `#include`s all 14 pair headers and cannot compile without them, so P2
is a hand-trimmed, progressively-re-expanded artifact -- **not** a verbatim port.

## Changes / Key Changes

- `narrow_phase.{hpp,cpp}` trimmed to the sphere-sphere and box-box dispatch
  branches; header exposes only the `Shape*+tf` `collide`, `collideBatch`, and
  `isSupported` -- the `const CollisionObject&` overload family
  (collide/distance/raycast/sphereCast/capsuleCast) and the EnTT-coupled
  `collision_object.hpp` include are dropped.
- Substitutions vs `main` (the **entire** delta, per the §2.1 fidelity gate):
  `std::span` -> the `detail/span.hpp` shim; one `enum class ShapeType;`
  forward declaration (minimal compile fix after dropping `collision_object.hpp`;
  the `.cpp` includes `shapes/shape.hpp` for the definition). Everything else in
  the diff is **deletions** (dropped overloads, Compound handling, non-routed
  branches). `collideWithFlippedNormals` is dropped -- it is only reached from
  removed asymmetric-pair branches; it returns when P4+ add asymmetric pairs.
- `test_narrow_phase_dispatch.cpp`: routes overlapping/separated sphere-sphere,
  overlapping box-box, **unrouted pair -> false** (the P2 invariant), direct null
  shape -> false, both `collideBatch` overloads, per-pair hit recording,
  mismatched output spans, batch null-shape rejection, `isSupported` true only
  for sphere/box, and `maxNumContacts == 0` -> false for routed pairs, including
  the box-box binary-check path.
- CMake: add the two files + register `UNIT_collision_native_narrow_phase_dispatch`.

**No wiring:** no detector, no registration, no `World`/`ConstraintSolver` change,
no `CollisionDetectorType` enum. FCL stays default.

> **Reviewer note:** `narrow_phase.{hpp,cpp}` is a **bespoke reduced dispatcher**,
> not a clean `main` diff -- expect it to re-expand in P4-P9 (§2.1 tracks the
> re-convergence to `main` modulo the known deltas).

## Testing

- `pixi run build-tests`: green after merging current `origin/release-6.20` into
  head `09f207e562ca`.
- `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native_narrow_phase_dispatch --output-on-failure`: **1/1 pass**; the dispatch test covers the Codecov follow-up coverage plus the Codex zero-budget box-box regression (`enableContact == false`, `maxNumContacts == 0`).
- `pixi run lint`: green; commit hook `pixi run check-lint-quick`: green.
- Portability: `rg -n 'entt|std::span' dart/collision/native/narrow_phase/narrow_phase.{hpp,cpp}` remains clean; production files still avoid EnTT and `std::span`.
- **§2.1 fidelity gate:** production `narrow_phase.{hpp,cpp}` remains the reduced dispatcher; this follow-up only adds the zero-contact-budget guard before routed dispatch.
- Hosted GitHub Actions, ReadTheDocs, and Codecov are pending on head `09f207e562ca`.

## Breaking Changes

- [x] None -- internal-only addition; no public surface, no behavior change.

## Related Issues / PRs

- Phase-2 plan: #3302. Sibling slice: #3303 (P1 broadphase). Builds on #3281.