### PR TITLE
Fix Debug writer validation regressions

### DIFF
--- a/tests/integration/io/test_sdf_writer.cpp
+++ b/tests/integration/io/test_sdf_writer.cpp
@@ -698,6 +698,22 @@ dynamics::RevoluteJoint* createLimitProbeJoint(
   return hinge;
 }
 
+void injectMalformedAxisForWriterTest(
+    dynamics::RevoluteJoint& joint, const Eigen::Vector3d& axis)
+{
+  // setAxis() recomputes joint caches and asserts in Debug for NaN axes before
+  // the writer can validate the serialized state.
+  const_cast<Eigen::Vector3d&>(joint.getAxis()) = axis;
+}
+
+void injectMalformedPitchForWriterTest(
+    dynamics::ScrewJoint& joint, double pitch)
+{
+  // setPitch() recomputes joint caches and asserts in Debug for non-finite
+  // pitch values before the writer can validate the serialized state.
+  const_cast<double&>(joint.getAspectProperties().mPitch) = pitch;
+}
+
 } // namespace
 
 //==============================================================================
@@ -5026,7 +5042,8 @@ TEST(SdfWriter, RelativeFileMeshUriReturnsError)
 TEST(SdfWriter, HostQualifiedFileMeshUriReturnsError)
 {
   auto retriever = std::make_shared<MapResourceRetriever>();
-  addTriangleObj(*retriever, "file://meshes/triangle.obj");
+  const common::Uri meshUri("file://meshes/triangle.obj");
+  addTriangleObj(*retriever, meshUri.toString());
 
   auto skeleton = dynamics::Skeleton::create("host_qualified_file_mesh_uri");
   auto [joint, body]
@@ -5035,10 +5052,7 @@ TEST(SdfWriter, HostQualifiedFileMeshUriReturnsError)
   body->setName("body");
   body->createShapeNodeWith<dynamics::VisualAspect>(
       std::make_shared<dynamics::MeshShape>(
-          Eigen::Vector3d::Ones(),
-          makeTriangleMesh(),
-          common::Uri("meshes/triangle.obj"),
-          retriever),
+          Eigen::Vector3d::Ones(), makeTriangleMesh(), meshUri, retriever),
       "host_qualified_file_mesh_uri");
 
   const auto result = io::SdfWriter::tryWriteSkeletonToString(*skeleton);
@@ -5386,7 +5400,8 @@ TEST(SdfWriter, NonFiniteJointAxisReturnsError)
       = skeleton->createJointAndBodyNodePair<dynamics::RevoluteJoint>(
           base, hingeProperties, tipProperties);
   (void)tip;
-  hinge->setAxis(
+  injectMalformedAxisForWriterTest(
+      *hinge,
       Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0));
 
   const auto result = io::SdfWriter::tryWriteSkeletonToString(*skeleton);
@@ -5534,7 +5549,8 @@ TEST(SdfWriter, NonFiniteScrewJointPitchReturnsError)
       = skeleton->createJointAndBodyNodePair<dynamics::ScrewJoint>(
           base, screwProperties, tipProperties);
   (void)tip;
-  screw->setPitch(std::numeric_limits<double>::quiet_NaN());
+  injectMalformedPitchForWriterTest(
+      *screw, std::numeric_limits<double>::quiet_NaN());
 
   const auto result = io::SdfWriter::tryWriteSkeletonToString(*skeleton);
   ASSERT_TRUE(result.isErr());

--- a/tests/integration/io/test_urdf_writer.cpp
+++ b/tests/integration/io/test_urdf_writer.cpp
@@ -483,6 +483,14 @@ const dynamics::VisualAspect* getOnlyVisual(const dynamics::Skeleton& skeleton)
   return visualNode->getVisualAspect();
 }
 
+void injectMalformedAxisForWriterTest(
+    dynamics::RevoluteJoint& joint, const Eigen::Vector3d& axis)
+{
+  // setAxis() recomputes joint caches and asserts in Debug for NaN axes before
+  // the writer can validate the serialized state.
+  const_cast<Eigen::Vector3d&>(joint.getAxis()) = axis;
+}
+
 } // namespace
 
 //==============================================================================
@@ -1456,7 +1464,8 @@ TEST(UrdfWriter, NonFiniteJointAxisReturnsError)
   auto* hinge
       = dynamic_cast<dynamics::RevoluteJoint*>(skeleton->getJoint("hinge"));
   ASSERT_NE(hinge, nullptr);
-  hinge->setAxis(
+  injectMalformedAxisForWriterTest(
+      *hinge,
       Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0));
 
   const auto result = io::UrdfWriter::tryWriteSkeletonToString(*skeleton);


### PR DESCRIPTION
## Summary

- Fix Debug-mode SDF/URDF writer validation regressions on `main` by keeping invalid test fixtures from triggering joint-cache assertions before writer validation runs.
- Correct the SDF host-qualified file URI regression test so it exercises the actual `file://host/path` rejection path consistently across platforms.

## Motivation / Problem

- Current `main` CI has Debug writer integration failures where tests that are meant to validate writer error handling abort inside `RevoluteJoint::setAxis()` or `ScrewJoint::setPitch()` before the writer can return a structured diagnostic.
- Windows CI also exposed that the host-qualified mesh URI test populated one URI but constructed the `MeshShape` with a different relative URI, so it did not reliably test the intended policy.

## Changes / Key Changes

- Add local test helpers that inject malformed writer-visible joint properties without calling setters that recompute Debug-only joint caches.
- Use those helpers in the non-finite SDF and URDF joint-axis tests, and in the SDF screw-pitch test.
- Reuse the same `file://meshes/triangle.obj` URI for the SDF host-qualified mesh resource and `MeshShape`.

## Testing

- `pixi run clang-format -i tests/integration/io/test_sdf_writer.cpp tests/integration/io/test_urdf_writer.cpp`
- `pixi run cmake --build build/default/cpp/Debug --target INTEGRATION_io_SdfWriter INTEGRATION_io_UrdfWriter -j 12`
- `ctest --test-dir build/default/cpp/Debug -R 'INTEGRATION_io_(SdfWriter|UrdfWriter)' --output-on-failure`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Addresses current `main` CI failures in `CI Windows` run 28762133341 job 85282825288 and `CI macOS` run 28762133336 job 85283533240.
- DART 6 LTS has a separate release-branch CI fix in the companion PR.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
      - No entry required: this only repairs CI regression tests and does not change released API, runtime behavior, packaging, or user-facing docs.
- [x] Add unit tests for new functionality
      - Existing integration regression tests were corrected.
- [x] Document new methods and classes
      - N/A: no new public API.
- [x] Add Python bindings (dartpy) if applicable
      - N/A: no binding changes.
