### PR TITLE
Fix scalar macOS broadphase build (DART 6 LTS)

### DIFF
--- a/dart/collision/dart/DARTCollisionDetector.cpp
+++ b/dart/collision/dart/DARTCollisionDetector.cpp
@@ -1962,26 +1962,27 @@ bool overlaps(const BroadphaseEntry& entry1, const BroadphaseEntry& entry2)
 }
 
 //==============================================================================
-std::uint32_t computeFiniteOverlapMask4(
+template <std::size_t Width>
+std::uint32_t computeFiniteOverlapMask(
     const BroadphaseEntry& entry,
     const SortedBroadphaseBounds& bounds,
     std::size_t begin)
 {
-  using Vec4d = dart::simd::Vec<double, kBroadphaseSimdWidth>;
+  using Vecd = dart::simd::Vec<double, Width>;
 
-  const auto entryMinX = Vec4d::broadcast(entry.min.x());
-  const auto entryMinY = Vec4d::broadcast(entry.min.y());
-  const auto entryMinZ = Vec4d::broadcast(entry.min.z());
-  const auto entryMaxX = Vec4d::broadcast(entry.max.x());
-  const auto entryMaxY = Vec4d::broadcast(entry.max.y());
-  const auto entryMaxZ = Vec4d::broadcast(entry.max.z());
+  const auto entryMinX = Vecd::broadcast(entry.min.x());
+  const auto entryMinY = Vecd::broadcast(entry.min.y());
+  const auto entryMinZ = Vecd::broadcast(entry.min.z());
+  const auto entryMaxX = Vecd::broadcast(entry.max.x());
+  const auto entryMaxY = Vecd::broadcast(entry.max.y());
+  const auto entryMaxZ = Vecd::broadcast(entry.max.z());
 
-  const auto candidateMinX = Vec4d::loadu(bounds.minX.data() + begin);
-  const auto candidateMinY = Vec4d::loadu(bounds.minY.data() + begin);
-  const auto candidateMinZ = Vec4d::loadu(bounds.minZ.data() + begin);
-  const auto candidateMaxX = Vec4d::loadu(bounds.maxX.data() + begin);
-  const auto candidateMaxY = Vec4d::loadu(bounds.maxY.data() + begin);
-  const auto candidateMaxZ = Vec4d::loadu(bounds.maxZ.data() + begin);
+  const auto candidateMinX = Vecd::loadu(bounds.minX.data() + begin);
+  const auto candidateMinY = Vecd::loadu(bounds.minY.data() + begin);
+  const auto candidateMinZ = Vecd::loadu(bounds.minZ.data() + begin);
+  const auto candidateMaxX = Vecd::loadu(bounds.maxX.data() + begin);
+  const auto candidateMaxY = Vecd::loadu(bounds.maxY.data() + begin);
+  const auto candidateMaxZ = Vecd::loadu(bounds.maxZ.data() + begin);
 
   const auto overlapMask
       = (candidateMinX <= entryMaxX) & (candidateMaxX >= entryMinX)
@@ -2449,7 +2450,8 @@ bool processFiniteFinitePairs(
       if constexpr (kUseNativeBroadphaseSimd) {
         if (j + kBroadphaseSimdWidth <= sortedEntries.size()) {
           const std::uint32_t overlapMask
-              = computeFiniteOverlapMask4(entry1, sortedBounds, j);
+              = computeFiniteOverlapMask<kBroadphaseSimdWidth>(
+                  entry1, sortedBounds, j);
           for (std::size_t lane = 0u; lane < kBroadphaseSimdWidth; ++lane) {
             if ((overlapMask & (std::uint32_t{1u} << lane)) == 0u)
               continue;
@@ -2526,7 +2528,8 @@ bool processFiniteFinitePairs(
       if constexpr (kUseNativeBroadphaseSimd) {
         if (j + kBroadphaseSimdWidth <= sortedEntries2.size()) {
           const std::uint32_t overlapMask
-              = computeFiniteOverlapMask4(entry1, sortedBounds2, j);
+              = computeFiniteOverlapMask<kBroadphaseSimdWidth>(
+                  entry1, sortedBounds2, j);
           for (std::size_t lane = 0u; lane < kBroadphaseSimdWidth; ++lane) {
             if ((overlapMask & (std::uint32_t{1u} << lane)) == 0u)
               continue;


### PR DESCRIPTION
## Summary

- Fix the release-6.20 macOS scalar build by making the DART-native broadphase SIMD overlap helper instantiate only when the SIMD path is compiled.

## Motivation / Problem

- AppleClang warning-as-error builds on release-6.20 fail on arm64 scalar configurations because `computeFiniteOverlapMask4()` is an internal function whose only call sites are discarded by `if constexpr (kUseNativeBroadphaseSimd)`.
- The root issue is helper instantiation in scalar builds, not the warning itself, so the fix keeps the helper unavailable unless the SIMD path actually uses it.

## Changes / Key Changes

- Convert the fixed-width internal overlap helper into a width-parameterized function template.
- Instantiate it only from the existing native-SIMD broadphase branches.
- Preserve the scalar broadphase path and SIMD behavior.

## Testing

- `pixi run clang-format -i dart/collision/dart/DARTCollisionDetector.cpp`
- `pixi run config`
- `pixi run cmake --build build/default/cpp/Release --target dart -j 12`
- `pixi run lint`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Addresses release-6.20 `CI macOS` run 28766439435 job 85291604587, plus superseded jobs 85289560052 and 85289560128 from run 28765744101 with the same AppleClang error.
- Main has a separate writer-test CI fix in the companion PR.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
      - No new entry required: this is a narrow internal build/CI hardening fix for the existing DART-native broadphase implementation already represented in the release collision changelog section.
- [x] Add unit tests for new functionality
      - N/A: no behavior change; this fixes scalar-build compilation of existing code.
- [x] Document new methods and classes
      - N/A: no public API.
- [x] Add Python bindings (dartpy) if applicable
      - N/A: no binding changes.
