### PR TITLE
Add native collision detector adapter skeleton

### DIFF
--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -8,7 +8,11 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/contact_point.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/types.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/contact_manifold.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionDetector.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionGroup.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionObject.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/detail/span.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/detail/NativeShapeConversion.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/shapes/shape.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sdf/signed_distance_field.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/broad_phase.hpp
@@ -29,6 +33,10 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/aabb.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/types.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/contact_manifold.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionDetector.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionGroup.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionObject.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/detail/NativeShapeConversion.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/shapes/shape.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/gjk.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/mpr.cpp

--- a/dart/collision/native/NativeCollisionDetector.cpp
+++ b/dart/collision/native/NativeCollisionDetector.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/native/NativeCollisionDetector.hpp"
+
+#include "dart/collision/CollisionGroup.hpp"
+#include "dart/collision/native/NativeCollisionGroup.hpp"
+#include "dart/collision/native/NativeCollisionObject.hpp"
+#include "dart/common/Console.hpp"
+
+namespace dart {
+namespace collision {
+
+namespace {
+
+//==============================================================================
+bool checkGroupValidity(
+    const NativeCollisionDetector* detector, CollisionGroup* group)
+{
+  if (!group) {
+    dterr << "[NativeCollisionDetector::collide] Attempting to check collision "
+          << "with a nullptr collision group.\n";
+    return false;
+  }
+
+  if (detector != group->getCollisionDetector().get()) {
+    dterr << "[NativeCollisionDetector::collide] Attempting to check collision "
+          << "for a collision group that is created from a different collision "
+          << "detector instance.\n";
+
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace
+
+//==============================================================================
+std::shared_ptr<NativeCollisionDetector> NativeCollisionDetector::create()
+{
+  return std::shared_ptr<NativeCollisionDetector>(
+      new NativeCollisionDetector());
+}
+
+//==============================================================================
+NativeCollisionDetector::~NativeCollisionDetector() = default;
+
+//==============================================================================
+std::shared_ptr<CollisionDetector>
+NativeCollisionDetector::cloneWithoutCollisionObjects() const
+{
+  return NativeCollisionDetector::create();
+}
+
+//==============================================================================
+const std::string& NativeCollisionDetector::getType() const
+{
+  return getStaticType();
+}
+
+//==============================================================================
+const std::string& NativeCollisionDetector::getStaticType()
+{
+  static const std::string type = "native";
+  return type;
+}
+
+//==============================================================================
+std::unique_ptr<CollisionGroup> NativeCollisionDetector::createCollisionGroup()
+{
+  return std::make_unique<NativeCollisionGroup>(shared_from_this());
+}
+
+//==============================================================================
+bool NativeCollisionDetector::collide(
+    CollisionGroup* group,
+    const CollisionOption& /*option*/,
+    CollisionResult* result)
+{
+  if (result)
+    result->clear();
+
+  if (!checkGroupValidity(this, group))
+    return false;
+
+  static_cast<NativeCollisionGroup*>(group)->updateEngineData();
+  return false;
+}
+
+//==============================================================================
+bool NativeCollisionDetector::collide(
+    CollisionGroup* group1,
+    CollisionGroup* group2,
+    const CollisionOption& /*option*/,
+    CollisionResult* result)
+{
+  if (result)
+    result->clear();
+
+  if (!checkGroupValidity(this, group1))
+    return false;
+
+  if (!checkGroupValidity(this, group2))
+    return false;
+
+  static_cast<NativeCollisionGroup*>(group1)->updateEngineData();
+  static_cast<NativeCollisionGroup*>(group2)->updateEngineData();
+  return false;
+}
+
+//==============================================================================
+double NativeCollisionDetector::distance(
+    CollisionGroup* /*group*/,
+    const DistanceOption& /*option*/,
+    DistanceResult* /*result*/)
+{
+  dtwarn << "[NativeCollisionDetector::distance] This collision detector does "
+         << "not support (signed) distance queries. Returning 0.0.\n";
+
+  return 0.0;
+}
+
+//==============================================================================
+double NativeCollisionDetector::distance(
+    CollisionGroup* /*group1*/,
+    CollisionGroup* /*group2*/,
+    const DistanceOption& /*option*/,
+    DistanceResult* /*result*/)
+{
+  dtwarn << "[NativeCollisionDetector::distance] This collision detector does "
+         << "not support (signed) distance queries. Returning 0.0.\n";
+
+  return 0.0;
+}
+
+//==============================================================================
+NativeCollisionDetector::NativeCollisionDetector() : CollisionDetector()
+{
+  mCollisionObjectManager.reset(new ManagerForSharableCollisionObjects(this));
+}
+
+//==============================================================================
+std::unique_ptr<CollisionObject> NativeCollisionDetector::createCollisionObject(
+    const dynamics::ShapeFrame* shapeFrame)
+{
+  return std::unique_ptr<NativeCollisionObject>(
+      new NativeCollisionObject(this, shapeFrame));
+}
+
+//==============================================================================
+void NativeCollisionDetector::refreshCollisionObject(
+    CollisionObject* /*object*/)
+{
+  // Do nothing. NativeCollisionObject refreshes lazily in updateEngineData().
+}
+
+} // namespace collision
+} // namespace dart

--- a/dart/collision/native/NativeCollisionDetector.hpp
+++ b/dart/collision/native/NativeCollisionDetector.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_NATIVE_NATIVECOLLISIONDETECTOR_HPP_
+#define DART_COLLISION_NATIVE_NATIVECOLLISIONDETECTOR_HPP_
+
+#include <dart/collision/CollisionDetector.hpp>
+
+#include <memory>
+
+namespace dart {
+namespace collision {
+
+class NativeCollisionDetector : public CollisionDetector
+{
+public:
+  using CollisionDetector::createCollisionGroup;
+
+  static std::shared_ptr<NativeCollisionDetector> create();
+
+  ~NativeCollisionDetector() override;
+
+  // Documentation inherited
+  std::shared_ptr<CollisionDetector> cloneWithoutCollisionObjects()
+      const override;
+
+  // Documentation inherited
+  const std::string& getType() const override;
+
+  /// Get collision detector type for this class.
+  static const std::string& getStaticType();
+
+  // Documentation inherited
+  std::unique_ptr<CollisionGroup> createCollisionGroup() override;
+
+  // Documentation inherited
+  bool collide(
+      CollisionGroup* group,
+      const CollisionOption& option = CollisionOption(false, 1u, nullptr),
+      CollisionResult* result = nullptr) override;
+
+  // Documentation inherited
+  bool collide(
+      CollisionGroup* group1,
+      CollisionGroup* group2,
+      const CollisionOption& option = CollisionOption(false, 1u, nullptr),
+      CollisionResult* result = nullptr) override;
+
+  // Documentation inherited
+  double distance(
+      CollisionGroup* group,
+      const DistanceOption& option = DistanceOption(false, 0.0, nullptr),
+      DistanceResult* result = nullptr) override;
+
+  // Documentation inherited
+  double distance(
+      CollisionGroup* group1,
+      CollisionGroup* group2,
+      const DistanceOption& option = DistanceOption(false, 0.0, nullptr),
+      DistanceResult* result = nullptr) override;
+
+protected:
+  NativeCollisionDetector();
+
+  // Documentation inherited
+  std::unique_ptr<CollisionObject> createCollisionObject(
+      const dynamics::ShapeFrame* shapeFrame) override;
+
+  // Documentation inherited
+  void refreshCollisionObject(CollisionObject* object) override;
+};
+
+} // namespace collision
+} // namespace dart
+
+#endif // DART_COLLISION_NATIVE_NATIVECOLLISIONDETECTOR_HPP_

--- a/dart/collision/native/NativeCollisionGroup.cpp
+++ b/dart/collision/native/NativeCollisionGroup.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/native/NativeCollisionGroup.hpp"
+
+#include "dart/collision/native/NativeCollisionObject.hpp"
+
+#include <algorithm>
+
+namespace dart {
+namespace collision {
+
+//==============================================================================
+NativeCollisionGroup::NativeCollisionGroup(
+    const CollisionDetectorPtr& collisionDetector)
+  : CollisionGroup(collisionDetector),
+    mBroadPhase(std::make_unique<native::BruteForceBroadPhase>())
+{
+  // Do nothing
+}
+
+//==============================================================================
+void NativeCollisionGroup::initializeEngineData()
+{
+  // Do nothing
+}
+
+//==============================================================================
+void NativeCollisionGroup::addCollisionObjectToEngine(CollisionObject* object)
+{
+  if (mObjectToId.find(object) != mObjectToId.end())
+    return;
+
+  auto* nativeObject = static_cast<NativeCollisionObject*>(object);
+  nativeObject->updateEngineData();
+
+  const std::size_t id = assignId(nativeObject);
+  mObjectToId[object] = id;
+  mIdToObject[id] = nativeObject;
+  mCollisionObjects.push_back(object);
+  mBroadPhase->add(id, nativeObject->getNativeAabb());
+}
+
+//==============================================================================
+void NativeCollisionGroup::addCollisionObjectsToEngine(
+    const std::vector<CollisionObject*>& collObjects)
+{
+  for (auto* collObject : collObjects)
+    addCollisionObjectToEngine(collObject);
+}
+
+//==============================================================================
+void NativeCollisionGroup::removeCollisionObjectFromEngine(
+    CollisionObject* object)
+{
+  const auto search = mObjectToId.find(object);
+  if (search == mObjectToId.end())
+    return;
+
+  const std::size_t id = search->second;
+  mBroadPhase->remove(id);
+  mObjectToId.erase(search);
+  mIdToObject.erase(id);
+  mFreeIds.push_back(id);
+  mCollisionObjects.erase(
+      std::remove(mCollisionObjects.begin(), mCollisionObjects.end(), object),
+      mCollisionObjects.end());
+}
+
+//==============================================================================
+void NativeCollisionGroup::removeAllCollisionObjectsFromEngine()
+{
+  mBroadPhase->clear();
+  mCollisionObjects.clear();
+  mIdToObject.clear();
+  mObjectToId.clear();
+  mFreeIds.clear();
+  mNextId = 0u;
+}
+
+//==============================================================================
+void NativeCollisionGroup::updateCollisionGroupEngineData()
+{
+  for (auto* object : mCollisionObjects) {
+    auto* nativeObject = static_cast<NativeCollisionObject*>(object);
+    const auto search = mObjectToId.find(object);
+    if (search != mObjectToId.end())
+      mBroadPhase->update(search->second, nativeObject->getNativeAabb());
+  }
+}
+
+//==============================================================================
+std::size_t NativeCollisionGroup::assignId(NativeCollisionObject* /*object*/)
+{
+  if (!mFreeIds.empty()) {
+    const std::size_t id = mFreeIds.back();
+    mFreeIds.pop_back();
+    return id;
+  }
+
+  return mNextId++;
+}
+
+} // namespace collision
+} // namespace dart

--- a/dart/collision/native/NativeCollisionGroup.hpp
+++ b/dart/collision/native/NativeCollisionGroup.hpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_NATIVE_NATIVECOLLISIONGROUP_HPP_
+#define DART_COLLISION_NATIVE_NATIVECOLLISIONGROUP_HPP_
+
+#include <dart/collision/CollisionGroup.hpp>
+#include <dart/collision/native/broad_phase/brute_force.hpp>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <cstddef>
+
+namespace dart {
+namespace collision {
+
+class NativeCollisionDetector;
+class NativeCollisionObject;
+
+class NativeCollisionGroup : public CollisionGroup
+{
+public:
+  friend class NativeCollisionDetector;
+
+  explicit NativeCollisionGroup(const CollisionDetectorPtr& collisionDetector);
+
+  ~NativeCollisionGroup() override = default;
+
+protected:
+  // Documentation inherited
+  void initializeEngineData() override;
+
+  // Documentation inherited
+  void addCollisionObjectToEngine(CollisionObject* object) override;
+
+  // Documentation inherited
+  void addCollisionObjectsToEngine(
+      const std::vector<CollisionObject*>& collObjects) override;
+
+  // Documentation inherited
+  void removeCollisionObjectFromEngine(CollisionObject* object) override;
+
+  // Documentation inherited
+  void removeAllCollisionObjectsFromEngine() override;
+
+  // Documentation inherited
+  void updateCollisionGroupEngineData() override;
+
+private:
+  std::size_t assignId(NativeCollisionObject* object);
+
+  std::unique_ptr<native::BroadPhase> mBroadPhase;
+  std::vector<CollisionObject*> mCollisionObjects;
+  std::unordered_map<std::size_t, NativeCollisionObject*> mIdToObject;
+  std::unordered_map<CollisionObject*, std::size_t> mObjectToId;
+  std::vector<std::size_t> mFreeIds;
+  std::size_t mNextId{0u};
+};
+
+} // namespace collision
+} // namespace dart
+
+#endif // DART_COLLISION_NATIVE_NATIVECOLLISIONGROUP_HPP_

--- a/dart/collision/native/NativeCollisionObject.cpp
+++ b/dart/collision/native/NativeCollisionObject.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/native/NativeCollisionObject.hpp"
+
+#include "dart/collision/native/detail/NativeShapeConversion.hpp"
+#include "dart/dynamics/Shape.hpp"
+
+namespace dart {
+namespace collision {
+
+//==============================================================================
+NativeCollisionObject::NativeCollisionObject(
+    CollisionDetector* collisionDetector,
+    const dynamics::ShapeFrame* shapeFrame)
+  : CollisionObject(collisionDetector, shapeFrame)
+{
+  updateEngineData();
+}
+
+//==============================================================================
+const native::Shape* NativeCollisionObject::getNativeShape() const
+{
+  return mNativeShape.get();
+}
+
+//==============================================================================
+const Eigen::Isometry3d& NativeCollisionObject::getNativeTransform() const
+{
+  return mNativeTransform;
+}
+
+//==============================================================================
+const native::Aabb& NativeCollisionObject::getNativeAabb() const
+{
+  return mNativeAabb;
+}
+
+//==============================================================================
+void NativeCollisionObject::updateEngineData()
+{
+  const auto shape = getShape();
+  const auto* shapePtr = shape.get();
+  const std::size_t shapeVersion = shapePtr ? shapePtr->getVersion() : 0u;
+
+  if (shapePtr != mLastKnownShape || shapeVersion != mLastKnownShapeVersion)
+    rebuildNativeShape();
+
+  mNativeTransform = getTransform();
+  if (mNativeShape) {
+    mNativeAabb = native::Aabb::transformed(
+        mNativeShape->computeLocalAabb(), mNativeTransform);
+  } else {
+    mNativeAabb = native::Aabb();
+  }
+}
+
+//==============================================================================
+void NativeCollisionObject::rebuildNativeShape()
+{
+  const auto shape = getShape();
+  mLastKnownShape = shape.get();
+  mLastKnownShapeVersion = mLastKnownShape ? mLastKnownShape->getVersion() : 0u;
+
+  if (!mLastKnownShape) {
+    mNativeShape.reset();
+    mNativeAabb = native::Aabb();
+    return;
+  }
+
+  mNativeShape = detail::NativeShapeConversion::create(*mLastKnownShape);
+}
+
+} // namespace collision
+} // namespace dart

--- a/dart/collision/native/NativeCollisionObject.cpp
+++ b/dart/collision/native/NativeCollisionObject.cpp
@@ -35,8 +35,15 @@
 #include "dart/collision/native/detail/NativeShapeConversion.hpp"
 #include "dart/dynamics/Shape.hpp"
 
+#include <limits>
+
 namespace dart {
 namespace collision {
+namespace {
+
+constexpr std::size_t kNoShapeId = std::numeric_limits<std::size_t>::max();
+
+} // namespace
 
 //==============================================================================
 NativeCollisionObject::NativeCollisionObject(
@@ -70,9 +77,10 @@ void NativeCollisionObject::updateEngineData()
 {
   const auto shape = getShape();
   const auto* shapePtr = shape.get();
+  const std::size_t shapeId = shapePtr ? shapePtr->getID() : kNoShapeId;
   const std::size_t shapeVersion = shapePtr ? shapePtr->getVersion() : 0u;
 
-  if (shapePtr != mLastKnownShape || shapeVersion != mLastKnownShapeVersion)
+  if (shapeId != mLastKnownShapeId || shapeVersion != mLastKnownShapeVersion)
     rebuildNativeShape();
 
   mNativeTransform = getTransform();
@@ -88,16 +96,16 @@ void NativeCollisionObject::updateEngineData()
 void NativeCollisionObject::rebuildNativeShape()
 {
   const auto shape = getShape();
-  mLastKnownShape = shape.get();
-  mLastKnownShapeVersion = mLastKnownShape ? mLastKnownShape->getVersion() : 0u;
+  mLastKnownShapeId = shape ? shape->getID() : kNoShapeId;
+  mLastKnownShapeVersion = shape ? shape->getVersion() : 0u;
 
-  if (!mLastKnownShape) {
+  if (!shape) {
     mNativeShape.reset();
     mNativeAabb = native::Aabb();
     return;
   }
 
-  mNativeShape = detail::NativeShapeConversion::create(*mLastKnownShape);
+  mNativeShape = detail::NativeShapeConversion::create(*shape);
 }
 
 } // namespace collision

--- a/dart/collision/native/NativeCollisionObject.hpp
+++ b/dart/collision/native/NativeCollisionObject.hpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_NATIVE_NATIVECOLLISIONOBJECT_HPP_
+#define DART_COLLISION_NATIVE_NATIVECOLLISIONOBJECT_HPP_
+
+#include <dart/collision/CollisionObject.hpp>
+#include <dart/collision/native/aabb.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+
+#include <Eigen/Dense>
+
+#include <memory>
+
+#include <cstddef>
+
+namespace dart {
+namespace dynamics {
+class Shape;
+} // namespace dynamics
+
+namespace collision {
+
+class NativeCollisionDetector;
+class NativeCollisionGroup;
+
+class NativeCollisionObject : public CollisionObject
+{
+public:
+  friend class NativeCollisionDetector;
+  friend class NativeCollisionGroup;
+
+  const native::Shape* getNativeShape() const;
+
+  const Eigen::Isometry3d& getNativeTransform() const;
+
+  const native::Aabb& getNativeAabb() const;
+
+protected:
+  NativeCollisionObject(
+      CollisionDetector* collisionDetector,
+      const dynamics::ShapeFrame* shapeFrame);
+
+  // Documentation inherited
+  void updateEngineData() override;
+
+private:
+  void rebuildNativeShape();
+
+  std::unique_ptr<native::Shape> mNativeShape;
+  Eigen::Isometry3d mNativeTransform{Eigen::Isometry3d::Identity()};
+  native::Aabb mNativeAabb;
+  const dynamics::Shape* mLastKnownShape{nullptr};
+  std::size_t mLastKnownShapeVersion{0u};
+};
+
+} // namespace collision
+} // namespace dart
+
+#endif // DART_COLLISION_NATIVE_NATIVECOLLISIONOBJECT_HPP_

--- a/dart/collision/native/NativeCollisionObject.hpp
+++ b/dart/collision/native/NativeCollisionObject.hpp
@@ -39,15 +39,12 @@
 
 #include <Eigen/Dense>
 
+#include <limits>
 #include <memory>
 
 #include <cstddef>
 
 namespace dart {
-namespace dynamics {
-class Shape;
-} // namespace dynamics
-
 namespace collision {
 
 class NativeCollisionDetector;
@@ -79,7 +76,7 @@ private:
   std::unique_ptr<native::Shape> mNativeShape;
   Eigen::Isometry3d mNativeTransform{Eigen::Isometry3d::Identity()};
   native::Aabb mNativeAabb;
-  const dynamics::Shape* mLastKnownShape{nullptr};
+  std::size_t mLastKnownShapeId{std::numeric_limits<std::size_t>::max()};
   std::size_t mLastKnownShapeVersion{0u};
 };
 

--- a/dart/collision/native/detail/NativeShapeConversion.cpp
+++ b/dart/collision/native/detail/NativeShapeConversion.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/native/detail/NativeShapeConversion.hpp"
+
+#include "dart/collision/native/shapes/shape.hpp"
+#include "dart/common/Console.hpp"
+#include "dart/dynamics/BoxShape.hpp"
+#include "dart/dynamics/Shape.hpp"
+#include "dart/dynamics/SphereShape.hpp"
+
+#include <set>
+#include <string>
+
+namespace dart {
+namespace collision {
+namespace detail {
+
+//==============================================================================
+std::unique_ptr<native::Shape> NativeShapeConversion::create(
+    const dynamics::Shape& shape)
+{
+  const auto& shapeType = shape.getType();
+
+  if (shapeType == dynamics::SphereShape::getStaticType()) {
+    const auto& sphere = static_cast<const dynamics::SphereShape&>(shape);
+    return std::make_unique<native::SphereShape>(sphere.getRadius());
+  }
+
+  if (shapeType == dynamics::BoxShape::getStaticType()) {
+    const auto& box = static_cast<const dynamics::BoxShape&>(shape);
+    return std::make_unique<native::BoxShape>(0.5 * box.getSize());
+  }
+
+  static std::set<std::string> warnedShapeTypes;
+  if (warnedShapeTypes.insert(shapeType).second) {
+    dtwarn << "[NativeShapeConversion] Shape type [" << shapeType
+           << "] is not supported by NativeCollisionDetector yet. This "
+           << "shape will be skipped by the native adapter.\n";
+  }
+
+  return nullptr;
+}
+
+} // namespace detail
+} // namespace collision
+} // namespace dart

--- a/dart/collision/native/detail/NativeShapeConversion.hpp
+++ b/dart/collision/native/detail/NativeShapeConversion.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_NATIVE_DETAIL_NATIVESHAPECONVERSION_HPP_
+#define DART_COLLISION_NATIVE_DETAIL_NATIVESHAPECONVERSION_HPP_
+
+#include <memory>
+
+namespace dart {
+namespace dynamics {
+class Shape;
+} // namespace dynamics
+
+namespace collision {
+namespace native {
+class Shape;
+} // namespace native
+
+namespace detail {
+
+class NativeShapeConversion final
+{
+public:
+  static std::unique_ptr<native::Shape> create(const dynamics::Shape& shape);
+};
+
+} // namespace detail
+} // namespace collision
+} // namespace dart
+
+#endif // DART_COLLISION_NATIVE_DETAIL_NATIVESHAPECONVERSION_HPP_

--- a/tests/integration/test_World.cpp
+++ b/tests/integration/test_World.cpp
@@ -512,6 +512,40 @@ TEST(World, DefaultWorldUsesFclPrimitive)
 }
 
 //==============================================================================
+TEST(World, NativeSkelDetectorFallsBackToFclBeforeRegistration)
+{
+  auto factory = collision::CollisionDetector::getFactory();
+  ASSERT_NE(factory, nullptr);
+
+  if (!factory->canCreate("fcl"))
+    GTEST_SKIP() << "fcl collision detector is not available in this build";
+
+  EXPECT_FALSE(factory->canCreate("native"));
+
+  const std::string skel = R"(
+<skel version="1.0">
+  <world name="world">
+    <physics>
+      <time_step>0.001</time_step>
+      <gravity>0 0 -9.81</gravity>
+      <collision_detector>native</collision_detector>
+    </physics>
+  </world>
+</skel>
+)";
+
+  auto world = utils::SkelParser::readWorldXML(skel);
+  ASSERT_NE(nullptr, world);
+
+  auto fclDetector = std::dynamic_pointer_cast<collision::FCLCollisionDetector>(
+      world->getCollisionDetector());
+  ASSERT_TRUE(fclDetector);
+  EXPECT_EQ(
+      fclDetector->getPrimitiveShapeType(),
+      collision::FCLCollisionDetector::PRIMITIVE);
+}
+
+//==============================================================================
 TEST(World, TypedSetterToFclKeepsPrimitive)
 {
   auto factory = collision::CollisionDetector::getFactory();

--- a/tests/unit/collision/CMakeLists.txt
+++ b/tests/unit/collision/CMakeLists.txt
@@ -1,6 +1,11 @@
 dart_add_test("unit" test_Contact test_Contact.cpp)
 dart_add_test("unit" test_DARTCollisionDetector test_DARTCollisionDetector.cpp)
 dart_add_test("unit" test_FCLCollisionObject test_FCLCollisionObject.cpp)
+dart_add_test(
+  "unit"
+  UNIT_collision_native_detector_adapter
+  test_NativeCollisionDetector.cpp
+)
 
 dart_add_test(
   "unit"

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/CollisionResult.hpp>
+#include <dart/collision/native/NativeCollisionDetector.hpp>
+#include <dart/collision/native/NativeCollisionGroup.hpp>
+#include <dart/collision/native/NativeCollisionObject.hpp>
+#include <dart/collision/native/detail/NativeShapeConversion.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+
+#include <dart/dynamics/BoxShape.hpp>
+#include <dart/dynamics/PlaneShape.hpp>
+#include <dart/dynamics/SimpleFrame.hpp>
+#include <dart/dynamics/SphereShape.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace dart;
+
+namespace {
+
+namespace native = dart::collision::native;
+
+//==============================================================================
+class ExposedNativeCollisionObject final
+  : public collision::NativeCollisionObject
+{
+public:
+  ExposedNativeCollisionObject(
+      collision::CollisionDetector* detector,
+      const dynamics::ShapeFrame* shapeFrame)
+    : NativeCollisionObject(detector, shapeFrame)
+  {
+    // Do nothing
+  }
+
+  using NativeCollisionObject::updateEngineData;
+};
+
+//==============================================================================
+class ExposedNativeCollisionDetector final
+  : public collision::NativeCollisionDetector
+{
+public:
+  ExposedNativeCollisionDetector() = default;
+
+  using collision::CollisionDetector::claimCollisionObject;
+
+private:
+  std::unique_ptr<collision::CollisionObject> createCollisionObject(
+      const dynamics::ShapeFrame* shapeFrame) override
+  {
+    return std::make_unique<ExposedNativeCollisionObject>(this, shapeFrame);
+  }
+};
+
+//==============================================================================
+dynamics::SimpleFramePtr makeFrame(
+    const dynamics::ShapePtr& shape,
+    const Eigen::Vector3d& translation = Eigen::Vector3d::Zero())
+{
+  auto frame = dynamics::SimpleFrame::createShared(dynamics::Frame::World());
+  frame->setShape(shape);
+  frame->setTranslation(translation);
+  return frame;
+}
+
+} // namespace
+
+//==============================================================================
+TEST(NativeCollisionDetector, FactoryKeyRemainsUnregisteredInP3a)
+{
+  auto* factory = collision::CollisionDetector::getFactory();
+  ASSERT_NE(nullptr, factory);
+  EXPECT_FALSE(
+      factory->canCreate(collision::NativeCollisionDetector::getStaticType()));
+  EXPECT_EQ(
+      nullptr,
+      factory->create(collision::NativeCollisionDetector::getStaticType()));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, CreatesDetectorGroupAndStubCollide)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  ASSERT_NE(nullptr, detector);
+  EXPECT_EQ("native", detector->getType());
+
+  auto clone = detector->cloneWithoutCollisionObjects();
+  ASSERT_NE(nullptr, clone);
+  EXPECT_EQ("native", clone->getType());
+
+  auto frame = makeFrame(std::make_shared<dynamics::SphereShape>(0.5));
+  auto group = detector->createCollisionGroup(frame.get());
+  ASSERT_NE(nullptr, group);
+  EXPECT_NE(
+      nullptr, dynamic_cast<collision::NativeCollisionGroup*>(group.get()));
+  EXPECT_EQ(1u, group->getNumShapeFrames());
+
+  collision::CollisionResult result;
+  EXPECT_FALSE(group->collide(collision::CollisionOption(true, 10u), &result));
+  EXPECT_EQ(0u, result.getNumContacts());
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
+{
+  const dynamics::SphereShape sphere(0.75);
+  auto nativeSphere = collision::detail::NativeShapeConversion::create(sphere);
+  ASSERT_NE(nullptr, nativeSphere);
+  ASSERT_EQ(native::ShapeType::Sphere, nativeSphere->getType());
+  EXPECT_DOUBLE_EQ(
+      0.75,
+      static_cast<const native::SphereShape*>(nativeSphere.get())->getRadius());
+
+  const dynamics::BoxShape box(Eigen::Vector3d(2.0, 4.0, 6.0));
+  auto nativeBox = collision::detail::NativeShapeConversion::create(box);
+  ASSERT_NE(nullptr, nativeBox);
+  ASSERT_EQ(native::ShapeType::Box, nativeBox->getType());
+  EXPECT_EQ(
+      Eigen::Vector3d(1.0, 2.0, 3.0),
+      static_cast<const native::BoxShape*>(nativeBox.get())->getHalfExtents());
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, LeavesUnsupportedShapesNull)
+{
+  const dynamics::PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  EXPECT_EQ(nullptr, collision::detail::NativeShapeConversion::create(plane));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, ClaimedObjectTracksNativeAabb)
+{
+  ExposedNativeCollisionDetector detector;
+  auto frame = makeFrame(
+      std::make_shared<dynamics::SphereShape>(0.5),
+      Eigen::Vector3d(1.0, 2.0, 3.0));
+
+  auto object = detector.claimCollisionObject(frame.get());
+  auto* nativeObject
+      = dynamic_cast<ExposedNativeCollisionObject*>(object.get());
+  ASSERT_NE(nullptr, nativeObject);
+  ASSERT_NE(nullptr, nativeObject->getNativeShape());
+  EXPECT_EQ(
+      native::ShapeType::Sphere, nativeObject->getNativeShape()->getType());
+  EXPECT_EQ(
+      Eigen::Vector3d(1.0, 2.0, 3.0),
+      nativeObject->getNativeTransform().translation());
+  EXPECT_EQ(Eigen::Vector3d(0.5, 1.5, 2.5), nativeObject->getNativeAabb().min);
+  EXPECT_EQ(Eigen::Vector3d(1.5, 2.5, 3.5), nativeObject->getNativeAabb().max);
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, ShapeIdentitySwapRebuildsNativeShape)
+{
+  ExposedNativeCollisionDetector detector;
+  auto frame = makeFrame(std::make_shared<dynamics::SphereShape>(0.5));
+
+  auto object = detector.claimCollisionObject(frame.get());
+  auto* nativeObject
+      = dynamic_cast<ExposedNativeCollisionObject*>(object.get());
+  ASSERT_NE(nullptr, nativeObject);
+  ASSERT_NE(nullptr, nativeObject->getNativeShape());
+  EXPECT_EQ(
+      native::ShapeType::Sphere, nativeObject->getNativeShape()->getType());
+
+  frame->setShape(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d(2.0, 4.0, 6.0)));
+  nativeObject->updateEngineData();
+
+  ASSERT_NE(nullptr, nativeObject->getNativeShape());
+  ASSERT_EQ(native::ShapeType::Box, nativeObject->getNativeShape()->getType());
+  EXPECT_EQ(
+      Eigen::Vector3d(-1.0, -2.0, -3.0), nativeObject->getNativeAabb().min);
+  EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), nativeObject->getNativeAabb().max);
+}

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -206,3 +206,32 @@ TEST(NativeCollisionDetector, ShapeIdentitySwapRebuildsNativeShape)
       Eigen::Vector3d(-1.0, -2.0, -3.0), nativeObject->getNativeAabb().min);
   EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), nativeObject->getNativeAabb().max);
 }
+
+//==============================================================================
+TEST(NativeCollisionDetector, SameTypeShapeSwapRebuildsNativeShape)
+{
+  ExposedNativeCollisionDetector detector;
+  auto frame = makeFrame(std::make_shared<dynamics::SphereShape>(0.5));
+
+  auto object = detector.claimCollisionObject(frame.get());
+  auto* nativeObject
+      = dynamic_cast<ExposedNativeCollisionObject*>(object.get());
+  ASSERT_NE(nullptr, nativeObject);
+  ASSERT_NE(nullptr, nativeObject->getNativeShape());
+  ASSERT_EQ(
+      native::ShapeType::Sphere, nativeObject->getNativeShape()->getType());
+  EXPECT_EQ(
+      Eigen::Vector3d(-0.5, -0.5, -0.5), nativeObject->getNativeAabb().min);
+  EXPECT_EQ(Eigen::Vector3d(0.5, 0.5, 0.5), nativeObject->getNativeAabb().max);
+
+  frame->setShape(std::make_shared<dynamics::SphereShape>(1.25));
+  nativeObject->updateEngineData();
+
+  ASSERT_NE(nullptr, nativeObject->getNativeShape());
+  ASSERT_EQ(
+      native::ShapeType::Sphere, nativeObject->getNativeShape()->getType());
+  EXPECT_EQ(
+      Eigen::Vector3d(-1.25, -1.25, -1.25), nativeObject->getNativeAabb().min);
+  EXPECT_EQ(
+      Eigen::Vector3d(1.25, 1.25, 1.25), nativeObject->getNativeAabb().max);
+}


### PR DESCRIPTION
## Summary

- Third phase-2 native collision slice (**P3a**) for the DART 6.20 dependency-minimization lane: add the DART 6 adapter skeleton classes over the already-ported native engine while keeping the detector unregistered and non-default.
- Existing users keep the same FCL default behavior; this PR only makes direct construction of the skeleton possible for the next bridge slice.

## Motivation / Problem

Phase 2 bridges the merged native geometry engine (#3281), BruteForce broadphase (#3303), and reduced narrowphase dispatcher (#3306) into DART 6's `CollisionDetector` / `CollisionGroup` / `CollisionObject` contract. This slice lands the smallest adapter surface first so the DART 6 object/group lifecycle, lazy native-shape conversion, and CMake/test plumbing can be reviewed before P3b makes the `"native"` factory key public and wires real collision translation.

P3a deliberately keeps `collide()` as a stub returning `false` and does **not** register `"native"`; this avoids exposing a factory/SKEL path whose detector cannot yet report contacts.

## Changes / Key Changes

- Add `NativeCollisionDetector`, `NativeCollisionGroup`, and `NativeCollisionObject` in `dart/collision/native/`.
  - Uses DART 6's existing shared collision-object manager.
  - Stores a per-group `native::BruteForceBroadPhase` plus stable object/id maps.
  - Refreshes native object data lazily using shape identity plus shape version, including shape swaps and null shapes.
- Add `detail::NativeShapeConversion` for `SphereShape` and `BoxShape`.
- Add `UNIT_collision_native_detector_adapter` coverage for direct detector/group/object creation, stub collide behavior, converter behavior, unsupported-shape handling, AABB tracking, and shape-identity rebuilds.
- Add a SKEL parser guard proving `<collision_detector>native</collision_detector>` still falls back to FCL before P3b registration.
- CMake: compile the adapter files into the existing core native collision target and register the new unit test.

**Reviewer note:** this directory intentionally contains two namespaces, matching the phase-2 plan in `docs/dev_tasks/dart6_dependency_minimization/07-phase2-adapter-scoping.md`: snake_case files remain the `dart::collision::native` engine, while PascalCase files are the DART 6 `dart::collision` adapter.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Default collision detector | FCL default; no native adapter construction path. | FCL still default; native adapter can be constructed directly but is not factory-registered. |
| `"native"` factory key / SKEL | Unknown key warns and falls back to FCL. | Still unknown and still falls back to FCL; P3b will register it after real collision translation lands. |
| Native shape bridge | No DART 6 shape-to-native adapter object. | Sphere and box convert to native shapes with world AABBs tracked through `NativeCollisionObject`. |
| gz downstream behavior | Existing FCL path only. | Existing FCL path unchanged; `test-gz` remains a non-regression guard for this stub slice. |

## Testing

- `pixi run config`
- `pixi run cmake --build build/default/cpp/Release --target dart UNIT_collision_native_detector_adapter --parallel 8`
- `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native_detector_adapter --output-on-failure`
- Built all native collision unit targets and ran `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native --output-on-failure` — 10/10 pass.
- Built `test_World` and ran `ctest --test-dir build/default/cpp/Release -R test_World --output-on-failure` — 1/1 pass.
- `pixi run cmake --build build/default/cpp/Release --target dart UNIT_collision_native_detector_adapter UNIT_collision_native_aabb UNIT_collision_native_types UNIT_collision_native_shapes UNIT_collision_native_box_box UNIT_collision_native_narrow_phase_dispatch UNIT_collision_native_gjk UNIT_collision_native_gjk_degenerate UNIT_collision_native_sphere_sphere UNIT_collision_native_brute_force test_World --parallel 8 && ctest --test-dir build/default/cpp/Release -R 'UNIT_collision_native|test_World' --output-on-failure` — 11/11 pass.
- `pixi run lint`
- `pixi run check-lint`
- Debug configure/build/test: `pixi run cmake --build build/default/cpp/Debug --target dart UNIT_collision_native_detector_adapter --parallel 8 && ctest --test-dir build/default/cpp/Debug -R UNIT_collision_native_detector_adapter --output-on-failure` — 1/1 pass.
- `pixi run build-tests` — 301/301 targets built.
- `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz` — passed, including gz-sim `INTEGRATION_entity_system` against the source-built DART plugin.
- Portability/scope checks: no `entt`, `EnTT`, `std::span`, or `#include <span>` in touched native/test surfaces; `git diff --check` clean; touched files limited to `dart/collision/native/**`, `tests/unit/collision/**`, and the SKEL fallback guard in `tests/integration/test_World.cpp`.
- Guard matrix: local phase-0 guard driver completed `MATRIX_DONE` under `.omc/artifacts/native-collision-phase2-p3a-20260706T224429Z`. Non-FCL rows matched the frozen packet. FCL/default generated-scene hashes match a clean current-base recapture at `2e11928288c9`; those rows differ from the older packet because the release branch moved after the packet capture, not because of this adapter slice.

## Breaking Changes

- [x] None -- additive, unregistered, and FCL remains default.

## Related Issues / PRs (backports)

- Phase-2 plan: #3302.
- Prior slices: #3303 (P1 broadphase), #3306 (P2 dispatcher).
- Next slice: P3b will implement bridge translation, add `sphere_box`, and register `"native"` after real collision results work.

---

#### Checklist

- [x] Milestone set: DART 6.20.0
- [x] CHANGELOG.md updated if required: N/A, internal unregistered phase slice; no user-visible behavior change.
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, adapter is internal phase work; PR body documents the two-namespace layout.
- [x] Add Python bindings (dartpy) if applicable: N/A, no binding surface.
