### PR TITLE
Add native convex foundation pairs

### DIFF
--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -26,7 +26,9 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/face_clip.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/contact_reduction.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_box.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_capsule.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_sphere.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/convex_convex.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_box.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_sphere.hpp
 )
@@ -49,7 +51,9 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/face_clip.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/box_box/contact_reduction.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_box.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_capsule.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_sphere.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/convex_convex.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_box.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_sphere.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/brute_force.cpp

--- a/dart/collision/native/detail/NativeShapeConversion.cpp
+++ b/dart/collision/native/detail/NativeShapeConversion.cpp
@@ -36,7 +36,6 @@
 #include "dart/common/Console.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
-#include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/ConvexMeshShape.hpp"
 #include "dart/dynamics/PyramidShape.hpp"
 #include "dart/dynamics/Shape.hpp"
@@ -46,15 +45,11 @@
 #include <string>
 #include <vector>
 
-#include <cmath>
-
 namespace dart {
 namespace collision {
 namespace detail {
 
 namespace {
-
-constexpr double kPi = 3.141592653589793238462643383279502884;
 
 std::unique_ptr<native::Shape> createConvexOrNull(
     std::vector<Eigen::Vector3d> vertices, const std::string& shapeType)
@@ -70,24 +65,6 @@ std::unique_ptr<native::Shape> createConvexOrNull(
   }
 
   return std::make_unique<native::ConvexShape>(std::move(vertices));
-}
-
-std::vector<Eigen::Vector3d> makeConeVertices(double radius, double height)
-{
-  std::vector<Eigen::Vector3d> vertices;
-  constexpr std::size_t kNumBaseVertices = 16;
-  vertices.reserve(kNumBaseVertices + 1);
-
-  const double baseZ = -0.5 * height;
-  for (std::size_t i = 0; i < kNumBaseVertices; ++i) {
-    const double theta = 2.0 * kPi * static_cast<double>(i)
-                         / static_cast<double>(kNumBaseVertices);
-    vertices.emplace_back(
-        radius * std::cos(theta), radius * std::sin(theta), baseZ);
-  }
-
-  vertices.emplace_back(0.0, 0.0, 0.5 * height);
-  return vertices;
 }
 
 std::vector<Eigen::Vector3d> makePyramidVertices(
@@ -135,12 +112,6 @@ std::unique_ptr<native::Shape> NativeShapeConversion::create(
       return createConvexOrNull({}, shapeType);
     }
     return createConvexOrNull(mesh->getVertices(), shapeType);
-  }
-
-  if (shapeType == dynamics::ConeShape::getStaticType()) {
-    const auto& cone = static_cast<const dynamics::ConeShape&>(shape);
-    return createConvexOrNull(
-        makeConeVertices(cone.getRadius(), cone.getHeight()), shapeType);
   }
 
   if (shapeType == dynamics::PyramidShape::getStaticType()) {

--- a/dart/collision/native/detail/NativeShapeConversion.cpp
+++ b/dart/collision/native/detail/NativeShapeConversion.cpp
@@ -36,15 +36,109 @@
 #include "dart/common/Console.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
+#include "dart/dynamics/ConeShape.hpp"
+#include "dart/dynamics/ConvexMeshShape.hpp"
+#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
+#include "dart/dynamics/PyramidShape.hpp"
 #include "dart/dynamics/Shape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
 
+#include <array>
 #include <set>
 #include <string>
+#include <vector>
+
+#include <cmath>
 
 namespace dart {
 namespace collision {
 namespace detail {
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+
+std::unique_ptr<native::Shape> createConvexOrNull(
+    std::vector<Eigen::Vector3d> vertices, const std::string& shapeType)
+{
+  if (vertices.empty()) {
+    static std::set<std::string> warnedInvalidShapeTypes;
+    if (warnedInvalidShapeTypes.insert(shapeType).second) {
+      dtwarn << "[NativeShapeConversion] Shape type [" << shapeType
+             << "] did not provide convex vertices. This shape will be "
+             << "skipped by the native adapter.\n";
+    }
+    return nullptr;
+  }
+
+  return std::make_unique<native::ConvexShape>(std::move(vertices));
+}
+
+std::vector<Eigen::Vector3d> makeConeVertices(double radius, double height)
+{
+  std::vector<Eigen::Vector3d> vertices;
+  constexpr std::size_t kNumBaseVertices = 16;
+  vertices.reserve(kNumBaseVertices + 1);
+
+  const double baseZ = -0.5 * height;
+  for (std::size_t i = 0; i < kNumBaseVertices; ++i) {
+    const double theta = 2.0 * kPi * static_cast<double>(i)
+                         / static_cast<double>(kNumBaseVertices);
+    vertices.emplace_back(
+        radius * std::cos(theta), radius * std::sin(theta), baseZ);
+  }
+
+  vertices.emplace_back(0.0, 0.0, 0.5 * height);
+  return vertices;
+}
+
+std::vector<Eigen::Vector3d> makePyramidVertices(
+    double baseWidth, double baseDepth, double height)
+{
+  const double halfWidth = 0.5 * baseWidth;
+  const double halfDepth = 0.5 * baseDepth;
+  const double baseZ = -0.5 * height;
+  return {
+      {-halfWidth, -halfDepth, baseZ},
+      {halfWidth, -halfDepth, baseZ},
+      {halfWidth, halfDepth, baseZ},
+      {-halfWidth, halfDepth, baseZ},
+      {0.0, 0.0, 0.5 * height}};
+}
+
+std::vector<Eigen::Vector3d> makeMultiSphereHullVertices(
+    const dynamics::MultiSphereConvexHullShape::Spheres& spheres)
+{
+  static const std::array<Eigen::Vector3d, 14> directions{{
+      Eigen::Vector3d::UnitX(),
+      -Eigen::Vector3d::UnitX(),
+      Eigen::Vector3d::UnitY(),
+      -Eigen::Vector3d::UnitY(),
+      Eigen::Vector3d::UnitZ(),
+      -Eigen::Vector3d::UnitZ(),
+      Eigen::Vector3d(1.0, 1.0, 1.0).normalized(),
+      Eigen::Vector3d(1.0, 1.0, -1.0).normalized(),
+      Eigen::Vector3d(1.0, -1.0, 1.0).normalized(),
+      Eigen::Vector3d(1.0, -1.0, -1.0).normalized(),
+      Eigen::Vector3d(-1.0, 1.0, 1.0).normalized(),
+      Eigen::Vector3d(-1.0, 1.0, -1.0).normalized(),
+      Eigen::Vector3d(-1.0, -1.0, 1.0).normalized(),
+      Eigen::Vector3d(-1.0, -1.0, -1.0).normalized(),
+  }};
+
+  std::vector<Eigen::Vector3d> vertices;
+  vertices.reserve(spheres.size() * directions.size());
+  for (const auto& sphere : spheres) {
+    const double radius = sphere.first;
+    const Eigen::Vector3d& center = sphere.second;
+    for (const auto& direction : directions) {
+      vertices.push_back(center + radius * direction);
+    }
+  }
+  return vertices;
+}
+
+} // namespace
 
 //==============================================================================
 std::unique_ptr<native::Shape> NativeShapeConversion::create(
@@ -66,6 +160,38 @@ std::unique_ptr<native::Shape> NativeShapeConversion::create(
     const auto& capsule = static_cast<const dynamics::CapsuleShape&>(shape);
     return std::make_unique<native::CapsuleShape>(
         capsule.getRadius(), capsule.getHeight());
+  }
+
+  if (shapeType == dynamics::ConvexMeshShape::getStaticType()) {
+    const auto& convex = static_cast<const dynamics::ConvexMeshShape&>(shape);
+    const auto& mesh = convex.getMesh();
+    if (!mesh) {
+      return createConvexOrNull({}, shapeType);
+    }
+    return createConvexOrNull(mesh->getVertices(), shapeType);
+  }
+
+  if (shapeType == dynamics::MultiSphereConvexHullShape::getStaticType()) {
+    const auto& multiSphere
+        = static_cast<const dynamics::MultiSphereConvexHullShape&>(shape);
+    return createConvexOrNull(
+        makeMultiSphereHullVertices(multiSphere.getSpheres()), shapeType);
+  }
+
+  if (shapeType == dynamics::ConeShape::getStaticType()) {
+    const auto& cone = static_cast<const dynamics::ConeShape&>(shape);
+    return createConvexOrNull(
+        makeConeVertices(cone.getRadius(), cone.getHeight()), shapeType);
+  }
+
+  if (shapeType == dynamics::PyramidShape::getStaticType()) {
+    const auto& pyramid = static_cast<const dynamics::PyramidShape&>(shape);
+    return createConvexOrNull(
+        makePyramidVertices(
+            pyramid.getBaseWidth(),
+            pyramid.getBaseDepth(),
+            pyramid.getHeight()),
+        shapeType);
   }
 
   static std::set<std::string> warnedShapeTypes;

--- a/dart/collision/native/detail/NativeShapeConversion.cpp
+++ b/dart/collision/native/detail/NativeShapeConversion.cpp
@@ -38,12 +38,10 @@
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConeShape.hpp"
 #include "dart/dynamics/ConvexMeshShape.hpp"
-#include "dart/dynamics/MultiSphereConvexHullShape.hpp"
 #include "dart/dynamics/PyramidShape.hpp"
 #include "dart/dynamics/Shape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
 
-#include <array>
 #include <set>
 #include <string>
 #include <vector>
@@ -106,38 +104,6 @@ std::vector<Eigen::Vector3d> makePyramidVertices(
       {0.0, 0.0, 0.5 * height}};
 }
 
-std::vector<Eigen::Vector3d> makeMultiSphereHullVertices(
-    const dynamics::MultiSphereConvexHullShape::Spheres& spheres)
-{
-  static const std::array<Eigen::Vector3d, 14> directions{{
-      Eigen::Vector3d::UnitX(),
-      -Eigen::Vector3d::UnitX(),
-      Eigen::Vector3d::UnitY(),
-      -Eigen::Vector3d::UnitY(),
-      Eigen::Vector3d::UnitZ(),
-      -Eigen::Vector3d::UnitZ(),
-      Eigen::Vector3d(1.0, 1.0, 1.0).normalized(),
-      Eigen::Vector3d(1.0, 1.0, -1.0).normalized(),
-      Eigen::Vector3d(1.0, -1.0, 1.0).normalized(),
-      Eigen::Vector3d(1.0, -1.0, -1.0).normalized(),
-      Eigen::Vector3d(-1.0, 1.0, 1.0).normalized(),
-      Eigen::Vector3d(-1.0, 1.0, -1.0).normalized(),
-      Eigen::Vector3d(-1.0, -1.0, 1.0).normalized(),
-      Eigen::Vector3d(-1.0, -1.0, -1.0).normalized(),
-  }};
-
-  std::vector<Eigen::Vector3d> vertices;
-  vertices.reserve(spheres.size() * directions.size());
-  for (const auto& sphere : spheres) {
-    const double radius = sphere.first;
-    const Eigen::Vector3d& center = sphere.second;
-    for (const auto& direction : directions) {
-      vertices.push_back(center + radius * direction);
-    }
-  }
-  return vertices;
-}
-
 } // namespace
 
 //==============================================================================
@@ -169,13 +135,6 @@ std::unique_ptr<native::Shape> NativeShapeConversion::create(
       return createConvexOrNull({}, shapeType);
     }
     return createConvexOrNull(mesh->getVertices(), shapeType);
-  }
-
-  if (shapeType == dynamics::MultiSphereConvexHullShape::getStaticType()) {
-    const auto& multiSphere
-        = static_cast<const dynamics::MultiSphereConvexHullShape&>(shape);
-    return createConvexOrNull(
-        makeMultiSphereHullVertices(multiSphere.getSpheres()), shapeType);
   }
 
   if (shapeType == dynamics::ConeShape::getStaticType()) {

--- a/dart/collision/native/narrow_phase/capsule_capsule.cpp
+++ b/dart/collision/native/narrow_phase/capsule_capsule.cpp
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/capsule_capsule.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+#include <cmath>
+
+namespace dart::collision::native {
+
+namespace {
+
+[[nodiscard]] bool hasIdentityRotation(const Eigen::Isometry3d& transform)
+{
+  const auto& rotation = transform.linear();
+  return rotation(0, 0) == 1.0 && rotation(0, 1) == 0.0 && rotation(0, 2) == 0.0
+         && rotation(1, 0) == 0.0 && rotation(1, 1) == 1.0
+         && rotation(1, 2) == 0.0 && rotation(2, 0) == 0.0
+         && rotation(2, 1) == 0.0 && rotation(2, 2) == 1.0;
+}
+
+struct SegmentClosestPointResult
+{
+  Eigen::Vector3d point1;
+  Eigen::Vector3d point2;
+  double distSquared;
+};
+
+SegmentClosestPointResult closestPointsBetweenSegments(
+    const Eigen::Vector3d& p1,
+    const Eigen::Vector3d& q1,
+    const Eigen::Vector3d& p2,
+    const Eigen::Vector3d& q2)
+{
+  const Eigen::Vector3d d1 = q1 - p1;
+  const Eigen::Vector3d d2 = q2 - p2;
+  const Eigen::Vector3d r = p1 - p2;
+
+  const double a = d1.squaredNorm();
+  const double e = d2.squaredNorm();
+  const double f = d2.dot(r);
+
+  double s = 0.0;
+  double t = 0.0;
+
+  constexpr double epsilon = 1e-10;
+
+  if (a <= epsilon && e <= epsilon) {
+    s = t = 0.0;
+  } else if (a <= epsilon) {
+    s = 0.0;
+    t = std::clamp(f / e, 0.0, 1.0);
+  } else {
+    const double c = d1.dot(r);
+    if (e <= epsilon) {
+      t = 0.0;
+      s = std::clamp(-c / a, 0.0, 1.0);
+    } else {
+      const double b = d1.dot(d2);
+      const double denom = a * e - b * b;
+
+      if (denom != 0.0) {
+        s = std::clamp((b * f - c * e) / denom, 0.0, 1.0);
+      } else {
+        s = 0.0;
+      }
+
+      t = (b * s + f) / e;
+
+      if (t < 0.0) {
+        t = 0.0;
+        s = std::clamp(-c / a, 0.0, 1.0);
+      } else if (t > 1.0) {
+        t = 1.0;
+        s = std::clamp((b - c) / a, 0.0, 1.0);
+      }
+    }
+  }
+
+  SegmentClosestPointResult result;
+  result.point1 = p1 + d1 * s;
+  result.point2 = p2 + d2 * t;
+  result.distSquared = (result.point1 - result.point2).squaredNorm();
+  return result;
+}
+
+bool collideVerticalCapsules(
+    double radius1,
+    double radius2,
+    double halfHeight1,
+    double halfHeight2,
+    const Eigen::Vector3d& translation1,
+    const Eigen::Vector3d& translation2,
+    CollisionResult& result)
+{
+  const double minZ1 = translation1.z() - halfHeight1;
+  const double maxZ1 = translation1.z() + halfHeight1;
+  const double minZ2 = translation2.z() - halfHeight2;
+  const double maxZ2 = translation2.z() + halfHeight2;
+
+  double z1 = minZ1;
+  double z2 = minZ2;
+  if (maxZ1 < minZ2) {
+    z1 = maxZ1;
+    z2 = minZ2;
+  } else if (maxZ2 < minZ1) {
+    z1 = minZ1;
+    z2 = maxZ2;
+  } else {
+    z1 = z2 = std::max(minZ1, minZ2);
+  }
+
+  const double dx = translation1.x() - translation2.x();
+  const double dy = translation1.y() - translation2.y();
+  const double dz = z1 - z2;
+  const double sumRadii = radius1 + radius2;
+
+  if (dy == 0.0 && dz == 0.0) {
+    const double dist = std::abs(dx);
+    if (dist > sumRadii) {
+      return false;
+    }
+
+    const double penetration = sumRadii - dist;
+    if (dist < 1e-10) {
+      result.addContact(
+          translation2.x(),
+          translation2.y(),
+          z2 + radius2 - penetration * 0.5,
+          0.0,
+          0.0,
+          1.0,
+          penetration);
+    } else {
+      const double normalX = dx / dist;
+      result.addContact(
+          translation2.x() + normalX * (radius2 - penetration * 0.5),
+          translation2.y(),
+          z2,
+          normalX,
+          0.0,
+          0.0,
+          penetration);
+    }
+    return true;
+  }
+
+  if (dx == 0.0 && dz == 0.0) {
+    const double dist = std::abs(dy);
+    if (dist > sumRadii) {
+      return false;
+    }
+
+    const double penetration = sumRadii - dist;
+    const double normalY = dy / dist;
+    result.addContact(
+        translation2.x(),
+        translation2.y() + normalY * (radius2 - penetration * 0.5),
+        z2,
+        0.0,
+        normalY,
+        0.0,
+        penetration);
+    return true;
+  }
+
+  const double distSquared = dx * dx + dy * dy + dz * dz;
+  if (distSquared > sumRadii * sumRadii) {
+    return false;
+  }
+
+  const double dist = std::sqrt(distSquared);
+  const double penetration = sumRadii - dist;
+
+  Eigen::Vector3d normal;
+  if (dist < 1e-10) {
+    normal = Eigen::Vector3d::UnitZ();
+  } else {
+    normal = Eigen::Vector3d(dx, dy, dz) / dist;
+  }
+
+  const Eigen::Vector3d contactPoint
+      = Eigen::Vector3d(translation2.x(), translation2.y(), z2)
+        + normal * (radius2 - penetration * 0.5);
+
+  result.addContact(contactPoint, normal, penetration);
+  return true;
+}
+
+bool capsulesOverlap(
+    double radius1,
+    double radius2,
+    double halfHeight1,
+    double halfHeight2,
+    const Eigen::Isometry3d& transform1,
+    const Eigen::Isometry3d& transform2)
+{
+  const Eigen::Vector3d localTop1(0, 0, halfHeight1);
+  const Eigen::Vector3d localBottom1(0, 0, -halfHeight1);
+  const Eigen::Vector3d localTop2(0, 0, halfHeight2);
+  const Eigen::Vector3d localBottom2(0, 0, -halfHeight2);
+
+  const Eigen::Vector3d top1 = transform1 * localTop1;
+  const Eigen::Vector3d bottom1 = transform1 * localBottom1;
+  const Eigen::Vector3d top2 = transform2 * localTop2;
+  const Eigen::Vector3d bottom2 = transform2 * localBottom2;
+
+  const auto closest
+      = closestPointsBetweenSegments(bottom1, top1, bottom2, top2);
+  const double sumRadii = radius1 + radius2;
+  return closest.distSquared <= sumRadii * sumRadii;
+}
+
+} // namespace
+
+bool collideCapsules(
+    const CapsuleShape& capsule1,
+    const Eigen::Isometry3d& transform1,
+    const CapsuleShape& capsule2,
+    const Eigen::Isometry3d& transform2,
+    CollisionResult& result,
+    const CollisionOption& option)
+{
+  if (option.maxNumContacts == 0) {
+    return false;
+  }
+
+  const double radius1 = capsule1.getRadius();
+  const double radius2 = capsule2.getRadius();
+  const double halfHeight1 = capsule1.getHeight() * 0.5;
+  const double halfHeight2 = capsule2.getHeight() * 0.5;
+
+  if (!option.enableContact) {
+    return capsulesOverlap(
+        radius1, radius2, halfHeight1, halfHeight2, transform1, transform2);
+  }
+
+  if (result.numContacts() >= option.maxNumContacts) {
+    return false;
+  }
+
+  if (hasIdentityRotation(transform1) && hasIdentityRotation(transform2)) {
+    return collideVerticalCapsules(
+        radius1,
+        radius2,
+        halfHeight1,
+        halfHeight2,
+        transform1.translation(),
+        transform2.translation(),
+        result);
+  }
+
+  const Eigen::Vector3d localTop1(0, 0, halfHeight1);
+  const Eigen::Vector3d localBottom1(0, 0, -halfHeight1);
+  const Eigen::Vector3d localTop2(0, 0, halfHeight2);
+  const Eigen::Vector3d localBottom2(0, 0, -halfHeight2);
+
+  const Eigen::Vector3d top1 = transform1 * localTop1;
+  const Eigen::Vector3d bottom1 = transform1 * localBottom1;
+  const Eigen::Vector3d top2 = transform2 * localTop2;
+  const Eigen::Vector3d bottom2 = transform2 * localBottom2;
+
+  auto closest = closestPointsBetweenSegments(bottom1, top1, bottom2, top2);
+
+  const double sumRadii = radius1 + radius2;
+  if (closest.distSquared > sumRadii * sumRadii) {
+    return false;
+  }
+
+  const double dist = std::sqrt(closest.distSquared);
+  const double penetration = sumRadii - dist;
+
+  Eigen::Vector3d normal;
+  if (dist < 1e-10) {
+    normal = Eigen::Vector3d::UnitZ();
+  } else {
+    normal = (closest.point1 - closest.point2) / dist;
+  }
+
+  const Eigen::Vector3d contactPoint
+      = closest.point2 + normal * (radius2 - penetration * 0.5);
+
+  ContactPoint contact;
+  contact.position = contactPoint;
+  contact.normal = normal;
+  contact.depth = penetration;
+
+  result.addContact(contact);
+
+  return true;
+}
+
+void collideCapsulesBatch(
+    span<const CapsulePair> pairs,
+    span<CollisionResult> results,
+    const CollisionOption& option)
+{
+  if (results.size() < pairs.size()) {
+    throw std::invalid_argument(
+        "collideCapsulesBatch requires one result for each pair");
+  }
+
+  for (std::size_t i = 0; i < pairs.size(); ++i) {
+    const auto& pair = pairs[i];
+    if (pair.shapeA == nullptr || pair.shapeB == nullptr) {
+      throw std::invalid_argument(
+          "collideCapsulesBatch received a null capsule");
+    }
+
+    [[maybe_unused]] const bool collided = collideCapsules(
+        *pair.shapeA, pair.tfA, *pair.shapeB, pair.tfB, results[i], option);
+  }
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/capsule_capsule.hpp
+++ b/dart/collision/native/narrow_phase/capsule_capsule.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/collision/native/detail/span.hpp>
+#include <dart/collision/native/export.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace dart::collision::native {
+
+class CapsuleShape;
+
+struct DART_COLLISION_NATIVE_API CapsulePair
+{
+  const CapsuleShape* shapeA;
+  const CapsuleShape* shapeB;
+  Eigen::Isometry3d tfA;
+  Eigen::Isometry3d tfB;
+};
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool collideCapsules(
+    const CapsuleShape& capsule1,
+    const Eigen::Isometry3d& transform1,
+    const CapsuleShape& capsule2,
+    const Eigen::Isometry3d& transform2,
+    CollisionResult& result,
+    const CollisionOption& option = CollisionOption());
+
+DART_COLLISION_NATIVE_API void collideCapsulesBatch(
+    span<const CapsulePair> pairs,
+    span<CollisionResult> results,
+    const CollisionOption& option = CollisionOption());
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/convex_convex.cpp
+++ b/dart/collision/native/narrow_phase/convex_convex.cpp
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/convex_convex.hpp>
+#include <dart/collision/native/narrow_phase/mpr.hpp>
+
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include <cmath>
+
+namespace dart::collision::native {
+
+SupportFunction makeConvexSupportFunction(
+    const ConvexShape& shape, const Eigen::Isometry3d& transform)
+{
+  return [&shape, transform](const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+    Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+    Eigen::Vector3d localSupport = shape.support(localDir);
+    return transform * localSupport;
+  };
+}
+
+SupportFunction makeMeshSupportFunction(
+    const MeshShape& shape, const Eigen::Isometry3d& transform)
+{
+  return [&shape, transform](const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+    Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+    Eigen::Vector3d localSupport = shape.support(localDir);
+    return transform * localSupport;
+  };
+}
+
+SupportFunction makeSphereSupportFunction(
+    const SphereShape& shape, const Eigen::Isometry3d& transform)
+{
+  double radius = shape.getRadius();
+  Eigen::Vector3d center = transform.translation();
+  return [radius, center](const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+    double len = dir.norm();
+    if (len < 1e-10) {
+      return center + Eigen::Vector3d(radius, 0, 0);
+    }
+    return Eigen::Vector3d(center + radius * dir / len);
+  };
+}
+
+SupportFunction makeBoxSupportFunction(
+    const BoxShape& shape, const Eigen::Isometry3d& transform)
+{
+  Eigen::Vector3d halfExtents = shape.getHalfExtents();
+  return [halfExtents,
+          transform](const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+    Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+    Eigen::Vector3d localSupport;
+    localSupport.x() = (localDir.x() >= 0) ? halfExtents.x() : -halfExtents.x();
+    localSupport.y() = (localDir.y() >= 0) ? halfExtents.y() : -halfExtents.y();
+    localSupport.z() = (localDir.z() >= 0) ? halfExtents.z() : -halfExtents.z();
+    return transform * localSupport;
+  };
+}
+
+SupportFunction makeCapsuleSupportFunction(
+    const CapsuleShape& shape, const Eigen::Isometry3d& transform)
+{
+  double radius = shape.getRadius();
+  double halfHeight = shape.getHeight() / 2.0;
+  return [radius, halfHeight, transform](
+             const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+    Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+    double len = localDir.norm();
+    if (len < 1e-10) {
+      return transform * Eigen::Vector3d(radius, 0, halfHeight);
+    }
+    Eigen::Vector3d dirNorm = localDir / len;
+    Eigen::Vector3d axisPoint = (dirNorm.z() >= 0)
+                                    ? Eigen::Vector3d(0, 0, halfHeight)
+                                    : Eigen::Vector3d(0, 0, -halfHeight);
+    Eigen::Vector3d localSupport = axisPoint + radius * dirNorm;
+    return transform * localSupport;
+  };
+}
+
+SupportFunction makeCylinderSupportFunction(
+    const CylinderShape& shape, const Eigen::Isometry3d& transform)
+{
+  double radius = shape.getRadius();
+  double halfHeight = shape.getHeight() / 2.0;
+  return [radius, halfHeight, transform](
+             const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+    Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+    Eigen::Vector3d localSupport;
+    double xyLen
+        = std::sqrt(localDir.x() * localDir.x() + localDir.y() * localDir.y());
+    if (xyLen < 1e-10) {
+      localSupport.x() = radius;
+      localSupport.y() = 0;
+    } else {
+      localSupport.x() = radius * localDir.x() / xyLen;
+      localSupport.y() = radius * localDir.y() / xyLen;
+    }
+    localSupport.z() = (localDir.z() >= 0) ? halfHeight : -halfHeight;
+    return transform * localSupport;
+  };
+}
+
+namespace {
+
+SupportFunction makeSupportFunction(
+    const Shape& shape, const Eigen::Isometry3d& transform)
+{
+  switch (shape.getType()) {
+    case ShapeType::Sphere:
+      return makeSphereSupportFunction(
+          static_cast<const SphereShape&>(shape), transform);
+    case ShapeType::Box:
+      return makeBoxSupportFunction(
+          static_cast<const BoxShape&>(shape), transform);
+    case ShapeType::Capsule:
+      return makeCapsuleSupportFunction(
+          static_cast<const CapsuleShape&>(shape), transform);
+    case ShapeType::Cylinder:
+      return makeCylinderSupportFunction(
+          static_cast<const CylinderShape&>(shape), transform);
+    case ShapeType::Convex:
+      return makeConvexSupportFunction(
+          static_cast<const ConvexShape&>(shape), transform);
+    case ShapeType::Mesh:
+      return makeMeshSupportFunction(
+          static_cast<const MeshShape&>(shape), transform);
+    default:
+      return [](const Eigen::Vector3d&) {
+        return Eigen::Vector3d::Zero();
+      };
+  }
+}
+
+Eigen::Vector3d averageVertexPosition(
+    const std::vector<Eigen::Vector3d>& vertices)
+{
+  if (vertices.empty()) {
+    return Eigen::Vector3d::Zero();
+  }
+
+  Eigen::Vector3d sum = Eigen::Vector3d::Zero();
+  for (const auto& v : vertices) {
+    sum += v;
+  }
+  return sum / static_cast<double>(vertices.size());
+}
+
+Eigen::Vector3d computeShapeCenter(
+    const Shape& shape, const Eigen::Isometry3d& transform)
+{
+  switch (shape.getType()) {
+    case ShapeType::Sphere:
+    case ShapeType::Box:
+    case ShapeType::Capsule:
+    case ShapeType::Cylinder:
+      return transform.translation();
+    case ShapeType::Convex: {
+      const auto& convex = static_cast<const ConvexShape&>(shape);
+      return transform * averageVertexPosition(convex.getVertices());
+    }
+    case ShapeType::Mesh: {
+      const auto& mesh = static_cast<const MeshShape&>(shape);
+      return transform * averageVertexPosition(mesh.getVertices());
+    }
+    default:
+      return transform.translation();
+  }
+}
+
+void alignPenetrationWitnesses(
+    double depth,
+    const Eigen::Vector3d& penetrationNormal,
+    Eigen::Vector3d& pointA,
+    Eigen::Vector3d& pointB)
+{
+  if (!(depth > 0.0) || !std::isfinite(depth)) {
+    return;
+  }
+
+  const double witnessDistance = (pointB - pointA).norm();
+  if (std::abs(witnessDistance - depth) <= 1e-6) {
+    return;
+  }
+
+  Eigen::Vector3d normal = penetrationNormal;
+  if (!normal.allFinite() || normal.squaredNorm() < 1e-12) {
+    normal = pointA - pointB;
+  }
+  if (!normal.allFinite() || normal.squaredNorm() < 1e-12) {
+    return;
+  }
+
+  normal.normalize();
+  const Eigen::Vector3d midpoint = 0.5 * (pointA + pointB);
+  pointA = midpoint + 0.5 * depth * normal;
+  pointB = midpoint - 0.5 * depth * normal;
+}
+
+} // namespace
+
+bool collideSupportFunctions(
+    const SupportFunction& supportA,
+    const Eigen::Vector3d& centerA,
+    const SupportFunction& supportB,
+    const Eigen::Vector3d& centerB,
+    CollisionResult& result,
+    const CollisionOption& option)
+{
+  if (option.maxNumContacts == 0) {
+    return false;
+  }
+
+  if (option.enableContact && result.numContacts() >= option.maxNumContacts) {
+    return false;
+  }
+
+  Eigen::Vector3d initialDir = centerB - centerA;
+  if (initialDir.squaredNorm() < 1e-10) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  GjkResult gjkResult = Gjk::query(supportA, supportB, initialDir);
+
+  if (!gjkResult.intersecting) {
+    return false;
+  }
+
+  if (!option.enableContact) {
+    return true;
+  }
+
+  EpaResult epaResult = Epa::penetration(supportA, supportB, gjkResult.simplex);
+  Eigen::Vector3d contactNormal = Eigen::Vector3d::Zero();
+  double penetrationDepth = 0.0;
+  Eigen::Vector3d pointA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d pointB = Eigen::Vector3d::Zero();
+
+  if (epaResult.success) {
+    penetrationDepth = epaResult.depth;
+    contactNormal = -epaResult.normal;
+    pointA = epaResult.pointOnA;
+    pointB = epaResult.pointOnB;
+  } else {
+    MprResult mprResult
+        = Mpr::penetration(supportA, supportB, centerA, centerB);
+    if (mprResult.success) {
+      penetrationDepth = mprResult.depth;
+      contactNormal = -mprResult.normal;
+      pointA = mprResult.pointOnA;
+      pointB = mprResult.pointOnB;
+    }
+  }
+
+  if (contactNormal.squaredNorm() < 1e-12) {
+    contactNormal = Eigen::Vector3d::UnitZ();
+  } else {
+    contactNormal.normalize();
+  }
+
+  if (penetrationDepth < 0.0) {
+    penetrationDepth = -penetrationDepth;
+  }
+
+  ContactPoint contact;
+  contact.depth = penetrationDepth;
+  contact.normal = contactNormal;
+  contact.position = (pointA + pointB) * 0.5;
+
+  result.addContact(contact);
+  return true;
+}
+
+bool collideConvexConvex(
+    const Shape& shape1,
+    const Eigen::Isometry3d& tf1,
+    const Shape& shape2,
+    const Eigen::Isometry3d& tf2,
+    CollisionResult& result,
+    const CollisionOption& option)
+{
+  auto supportA = makeSupportFunction(shape1, tf1);
+  auto supportB = makeSupportFunction(shape2, tf2);
+  const Eigen::Vector3d centerA = computeShapeCenter(shape1, tf1);
+  const Eigen::Vector3d centerB = computeShapeCenter(shape2, tf2);
+  return collideSupportFunctions(
+      supportA, centerA, supportB, centerB, result, option);
+}
+
+void collideConvexConvexBatch(
+    span<const ConvexPair> pairs,
+    span<CollisionResult> results,
+    const CollisionOption& option)
+{
+  if (results.size() < pairs.size()) {
+    throw std::invalid_argument(
+        "collideConvexConvexBatch requires one result for each pair");
+  }
+
+  for (std::size_t i = 0; i < pairs.size(); ++i) {
+    const auto& pair = pairs[i];
+    if (pair.shapeA == nullptr || pair.shapeB == nullptr) {
+      throw std::invalid_argument(
+          "collideConvexConvexBatch received a null shape");
+    }
+
+    [[maybe_unused]] const bool collided = collideConvexConvex(
+        *pair.shapeA, pair.tfA, *pair.shapeB, pair.tfB, results[i], option);
+  }
+}
+
+double distanceConvexConvex(
+    const Shape& shape1,
+    const Eigen::Isometry3d& tf1,
+    const Shape& shape2,
+    const Eigen::Isometry3d& tf2,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  auto supportA = makeSupportFunction(shape1, tf1);
+  auto supportB = makeSupportFunction(shape2, tf2);
+
+  Eigen::Vector3d initialDir = tf2.translation() - tf1.translation();
+  if (initialDir.squaredNorm() < 1e-10) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  GjkResult gjkResult = Gjk::query(supportA, supportB, initialDir);
+
+  if (!gjkResult.intersecting) {
+    if (option.upperBound < gjkResult.distance) {
+      result.distance = std::numeric_limits<double>::max();
+      return std::numeric_limits<double>::max();
+    }
+
+    result.distance = gjkResult.distance;
+    if (option.enableNearestPoints) {
+      result.pointOnObject1 = gjkResult.closestPointA;
+      result.pointOnObject2 = gjkResult.closestPointB;
+      if (gjkResult.distance > 1e-12) {
+        result.normal
+            = (gjkResult.closestPointB - gjkResult.closestPointA).normalized();
+      } else {
+        result.normal = Eigen::Vector3d::UnitX();
+      }
+    }
+    return gjkResult.distance;
+  }
+
+  EpaResult epaResult = Epa::penetration(supportA, supportB, gjkResult.simplex);
+  double depth = 0.0;
+  Eigen::Vector3d pointA = tf1.translation();
+  Eigen::Vector3d pointB = tf2.translation();
+  Eigen::Vector3d normal = Eigen::Vector3d::UnitX();
+  Eigen::Vector3d penetrationNormal = Eigen::Vector3d::UnitX();
+
+  if (epaResult.success) {
+    depth = epaResult.depth;
+    pointA = epaResult.pointOnA;
+    pointB = epaResult.pointOnB;
+    penetrationNormal = epaResult.normal;
+  } else {
+    const Eigen::Vector3d centerA = computeShapeCenter(shape1, tf1);
+    const Eigen::Vector3d centerB = computeShapeCenter(shape2, tf2);
+    MprResult mprResult
+        = Mpr::penetration(supportA, supportB, centerA, centerB);
+    if (mprResult.success) {
+      depth = mprResult.depth;
+      pointA = mprResult.pointOnA;
+      pointB = mprResult.pointOnB;
+      penetrationNormal = mprResult.normal;
+    }
+  }
+
+  alignPenetrationWitnesses(depth, penetrationNormal, pointA, pointB);
+  if ((pointB - pointA).squaredNorm() > 1e-12) {
+    normal = (pointB - pointA).normalized();
+  } else if (penetrationNormal.squaredNorm() > 1e-12) {
+    normal = -penetrationNormal.normalized();
+  }
+
+  result.distance = -depth;
+  if (option.enableNearestPoints) {
+    result.pointOnObject1 = pointA;
+    result.pointOnObject2 = pointB;
+    result.normal = normal;
+  }
+
+  return -depth;
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/convex_convex.hpp
+++ b/dart/collision/native/narrow_phase/convex_convex.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/collision/native/detail/span.hpp>
+#include <dart/collision/native/export.hpp>
+#include <dart/collision/native/narrow_phase/gjk.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <Eigen/Geometry>
+
+namespace dart::collision::native {
+
+struct DART_COLLISION_NATIVE_API ConvexPair
+{
+  const Shape* shapeA;
+  const Shape* shapeB;
+  Eigen::Isometry3d tfA;
+  Eigen::Isometry3d tfB;
+};
+
+DART_COLLISION_NATIVE_API SupportFunction makeConvexSupportFunction(
+    const ConvexShape& shape, const Eigen::Isometry3d& transform);
+
+DART_COLLISION_NATIVE_API SupportFunction makeMeshSupportFunction(
+    const MeshShape& shape, const Eigen::Isometry3d& transform);
+
+DART_COLLISION_NATIVE_API SupportFunction makeSphereSupportFunction(
+    const SphereShape& shape, const Eigen::Isometry3d& transform);
+
+DART_COLLISION_NATIVE_API SupportFunction makeBoxSupportFunction(
+    const BoxShape& shape, const Eigen::Isometry3d& transform);
+
+DART_COLLISION_NATIVE_API SupportFunction makeCapsuleSupportFunction(
+    const CapsuleShape& shape, const Eigen::Isometry3d& transform);
+
+DART_COLLISION_NATIVE_API SupportFunction makeCylinderSupportFunction(
+    const CylinderShape& shape, const Eigen::Isometry3d& transform);
+
+DART_COLLISION_NATIVE_API bool collideSupportFunctions(
+    const SupportFunction& supportA,
+    const Eigen::Vector3d& centerA,
+    const SupportFunction& supportB,
+    const Eigen::Vector3d& centerB,
+    CollisionResult& result,
+    const CollisionOption& option);
+
+DART_COLLISION_NATIVE_API bool collideConvexConvex(
+    const Shape& shape1,
+    const Eigen::Isometry3d& tf1,
+    const Shape& shape2,
+    const Eigen::Isometry3d& tf2,
+    CollisionResult& result,
+    const CollisionOption& option);
+
+DART_COLLISION_NATIVE_API void collideConvexConvexBatch(
+    span<const ConvexPair> pairs,
+    span<CollisionResult> results,
+    const CollisionOption& option = CollisionOption());
+
+DART_COLLISION_NATIVE_API double distanceConvexConvex(
+    const Shape& shape1,
+    const Eigen::Isometry3d& tf1,
+    const Shape& shape2,
+    const Eigen::Isometry3d& tf2,
+    DistanceResult& result,
+    const DistanceOption& option);
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/narrow_phase.cpp
+++ b/dart/collision/native/narrow_phase/narrow_phase.cpp
@@ -32,7 +32,9 @@
 
 #include <dart/collision/native/narrow_phase/box_box.hpp>
 #include <dart/collision/native/narrow_phase/capsule_box.hpp>
+#include <dart/collision/native/narrow_phase/capsule_capsule.hpp>
 #include <dart/collision/native/narrow_phase/capsule_sphere.hpp>
+#include <dart/collision/native/narrow_phase/convex_convex.hpp>
 #include <dart/collision/native/narrow_phase/narrow_phase.hpp>
 #include <dart/collision/native/narrow_phase/sphere_box.hpp>
 #include <dart/collision/native/narrow_phase/sphere_sphere.hpp>
@@ -74,6 +76,12 @@ bool collideWithFlippedNormals(
   }
 
   return true;
+}
+
+bool isP5ConvexFallbackType(ShapeType type)
+{
+  return type == ShapeType::Sphere || type == ShapeType::Box
+         || type == ShapeType::Capsule || type == ShapeType::Convex;
 }
 
 bool collideShapes(
@@ -156,6 +164,17 @@ bool collideShapes(
         [&](CollisionResult& local, const CollisionOption& opt) {
           return collideCapsuleBox(*c, tf2, *b, tf1, local, opt);
         });
+  }
+
+  if (type1 == ShapeType::Capsule && type2 == ShapeType::Capsule) {
+    const auto* c1 = static_cast<const CapsuleShape*>(shape1);
+    const auto* c2 = static_cast<const CapsuleShape*>(shape2);
+    return collideCapsules(*c1, tf1, *c2, tf2, result, option);
+  }
+
+  if ((type1 == ShapeType::Convex || type2 == ShapeType::Convex)
+      && isP5ConvexFallbackType(type1) && isP5ConvexFallbackType(type2)) {
+    return collideConvexConvex(*shape1, tf1, *shape2, tf2, result, option);
   }
 
   return false;
@@ -244,6 +263,13 @@ bool NarrowPhase::isSupported(ShapeType type1, ShapeType type2)
   }
   if ((type1 == ShapeType::Capsule && type2 == ShapeType::Box)
       || (type1 == ShapeType::Box && type2 == ShapeType::Capsule)) {
+    return true;
+  }
+  if (type1 == ShapeType::Capsule && type2 == ShapeType::Capsule) {
+    return true;
+  }
+  if ((type1 == ShapeType::Convex || type2 == ShapeType::Convex)
+      && isP5ConvexFallbackType(type1) && isP5ConvexFallbackType(type2)) {
     return true;
   }
   return false;

--- a/tests/benchmark/unit/bm_native_collision.cpp
+++ b/tests/benchmark/unit/bm_native_collision.cpp
@@ -5,6 +5,8 @@
 #include <Eigen/Geometry>
 #include <benchmark/benchmark.h>
 
+#include <vector>
+
 #include <cstddef>
 
 namespace {
@@ -13,6 +15,7 @@ using dart::collision::native::BoxShape;
 using dart::collision::native::CapsuleShape;
 using dart::collision::native::CollisionOption;
 using dart::collision::native::CollisionResult;
+using dart::collision::native::ConvexShape;
 using dart::collision::native::NarrowPhase;
 using dart::collision::native::Shape;
 using dart::collision::native::SphereShape;
@@ -22,6 +25,17 @@ Eigen::Isometry3d translated(double x, double y, double z)
   Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
   transform.translation() = Eigen::Vector3d(x, y, z);
   return transform;
+}
+
+std::vector<Eigen::Vector3d> makeOctahedronVertices(double scale = 1.0)
+{
+  return {
+      {scale, 0.0, 0.0},
+      {-scale, 0.0, 0.0},
+      {0.0, scale, 0.0},
+      {0.0, -scale, 0.0},
+      {0.0, 0.0, scale},
+      {0.0, 0.0, -scale}};
 }
 
 void runNarrowPhase(
@@ -118,6 +132,32 @@ void BM_NativeCapsuleBox(benchmark::State& state)
       Eigen::Isometry3d::Identity());
 }
 
+void BM_NativeCapsuleCapsule(benchmark::State& state)
+{
+  CapsuleShape capsuleA(0.5, 1.0);
+  CapsuleShape capsuleB(0.5, 1.0);
+
+  runNarrowPhase(
+      state,
+      capsuleA,
+      Eigen::Isometry3d::Identity(),
+      capsuleB,
+      translated(0.75, 0.0, 0.0));
+}
+
+void BM_NativeConvexConvex(benchmark::State& state)
+{
+  ConvexShape convexA(makeOctahedronVertices());
+  ConvexShape convexB(makeOctahedronVertices());
+
+  runNarrowPhase(
+      state,
+      convexA,
+      Eigen::Isometry3d::Identity(),
+      convexB,
+      translated(1.5, 0.0, 0.0));
+}
+
 } // namespace
 
 BENCHMARK(BM_NativeSphereSphere)->Unit(benchmark::kNanosecond);
@@ -125,3 +165,5 @@ BENCHMARK(BM_NativeSphereBox)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeBoxBox)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeCapsuleSphere)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeCapsuleBox)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_NativeCapsuleCapsule)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_NativeConvexConvex)->Unit(benchmark::kNanosecond);

--- a/tests/unit/collision/native/CMakeLists.txt
+++ b/tests/unit/collision/native/CMakeLists.txt
@@ -25,8 +25,18 @@ dart_add_test(
 )
 dart_add_test(
   "unit"
+  UNIT_collision_native_capsule_capsule
+  test_capsule_capsule.cpp
+)
+dart_add_test(
+  "unit"
   UNIT_collision_native_capsule_sphere
   test_capsule_sphere.cpp
+)
+dart_add_test(
+  "unit"
+  UNIT_collision_native_convex_convex
+  test_convex_convex.cpp
 )
 dart_add_test(
   "unit"

--- a/tests/unit/collision/native/test_capsule_capsule.cpp
+++ b/tests/unit/collision/native/test_capsule_capsule.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/capsule_capsule.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace dart::collision::native;
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+
+Eigen::Isometry3d translated(double x, double y, double z)
+{
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(x, y, z);
+  return tf;
+}
+
+Eigen::Isometry3d rotatedTranslated(double x, double y, double z)
+{
+  Eigen::Isometry3d tf = translated(x, y, z);
+  tf.linear() = Eigen::AngleAxisd(0.5 * kPi, Eigen::Vector3d::UnitY())
+                    .toRotationMatrix();
+  return tf;
+}
+
+} // namespace
+
+TEST(CapsuleCapsule, SeparatedReturnsFalse)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  EXPECT_FALSE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(3.0, 0.0, 0.0),
+      result));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(CapsuleCapsule, ParallelOverlapAddsContact)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  ASSERT_TRUE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(0.75, 0.0, 0.0),
+      result));
+
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_TRUE(
+      result.getContact(0).normal.isApprox(-Eigen::Vector3d::UnitX(), 1e-12));
+  EXPECT_NEAR(0.25, result.getContact(0).depth, 1e-12);
+}
+
+TEST(CapsuleCapsule, RotatedOverlapAddsContact)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  ASSERT_TRUE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      rotatedTranslated(0.75, 0.0, 0.0),
+      result));
+
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_GT(result.getContact(0).depth, 0.0);
+}
+
+TEST(CapsuleCapsule, BinaryCheckDoesNotAddContacts)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  EXPECT_TRUE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(0.75, 0.0, 0.0),
+      result,
+      CollisionOption::binaryCheck()));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(CapsuleCapsule, ZeroContactLimitReturnsFalse)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionOption option;
+  option.enableContact = false;
+  option.maxNumContacts = 0;
+
+  CollisionResult result;
+  EXPECT_FALSE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(0.75, 0.0, 0.0),
+      result,
+      option));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(CapsuleCapsuleBatch, RejectsMalformedInputs)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+  const std::vector<CapsulePair> validPairs{
+      {&capsule1,
+       &capsule2,
+       Eigen::Isometry3d::Identity(),
+       translated(0.75, 0.0, 0.0)}};
+
+  std::vector<CollisionResult> emptyResults;
+  EXPECT_THROW(
+      collideCapsulesBatch(validPairs, emptyResults), std::invalid_argument);
+
+  std::vector<CollisionResult> results(1);
+  const std::vector<CapsulePair> nullShapePairs{
+      {nullptr,
+       &capsule2,
+       Eigen::Isometry3d::Identity(),
+       translated(0.75, 0.0, 0.0)}};
+  EXPECT_THROW(
+      collideCapsulesBatch(nullShapePairs, results), std::invalid_argument);
+}

--- a/tests/unit/collision/native/test_capsule_capsule.cpp
+++ b/tests/unit/collision/native/test_capsule_capsule.cpp
@@ -96,6 +96,63 @@ TEST(CapsuleCapsule, ParallelOverlapAddsContact)
   EXPECT_NEAR(0.25, result.getContact(0).depth, 1e-12);
 }
 
+TEST(CapsuleCapsule, ParallelYOffsetUsesYAxisNormal)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  ASSERT_TRUE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(0.0, 0.75, 0.0),
+      result));
+
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_TRUE(
+      result.getContact(0).normal.isApprox(-Eigen::Vector3d::UnitY(), 1e-12));
+  EXPECT_NEAR(0.25, result.getContact(0).depth, 1e-12);
+}
+
+TEST(CapsuleCapsule, AxialEndcapOverlapAddsContact)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  ASSERT_TRUE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(0.0, 0.0, 2.25),
+      result));
+
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_TRUE(
+      result.getContact(0).normal.isApprox(-Eigen::Vector3d::UnitZ(), 1e-12));
+  EXPECT_NEAR(0.75, result.getContact(0).depth, 1e-12);
+}
+
+TEST(CapsuleCapsule, CoincidentAxesUseDeterministicFallbackNormal)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  ASSERT_TRUE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      Eigen::Isometry3d::Identity(),
+      result));
+
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_TRUE(
+      result.getContact(0).normal.isApprox(Eigen::Vector3d::UnitZ(), 1e-12));
+  EXPECT_NEAR(1.0, result.getContact(0).depth, 1e-12);
+}
+
 TEST(CapsuleCapsule, RotatedOverlapAddsContact)
 {
   const CapsuleShape capsule1(0.5, 2.0);
@@ -113,6 +170,21 @@ TEST(CapsuleCapsule, RotatedOverlapAddsContact)
   EXPECT_GT(result.getContact(0).depth, 0.0);
 }
 
+TEST(CapsuleCapsule, RotatedSeparatedReturnsFalse)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  EXPECT_FALSE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      rotatedTranslated(3.0, 0.0, 0.0),
+      result));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
 TEST(CapsuleCapsule, BinaryCheckDoesNotAddContacts)
 {
   const CapsuleShape capsule1(0.5, 2.0);
@@ -126,6 +198,35 @@ TEST(CapsuleCapsule, BinaryCheckDoesNotAddContacts)
       translated(0.75, 0.0, 0.0),
       result,
       CollisionOption::binaryCheck()));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(CapsuleCapsule, NonContactOptionReportsOverlapOnly)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionOption option;
+  option.enableContact = false;
+  option.maxNumContacts = 8;
+
+  CollisionResult result;
+  EXPECT_TRUE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(0.75, 0.0, 0.0),
+      result,
+      option));
+  EXPECT_EQ(0u, result.numContacts());
+
+  EXPECT_FALSE(collideCapsules(
+      capsule1,
+      Eigen::Isometry3d::Identity(),
+      capsule2,
+      translated(3.0, 0.0, 0.0),
+      result,
+      option));
   EXPECT_EQ(0u, result.numContacts());
 }
 
@@ -147,6 +248,27 @@ TEST(CapsuleCapsule, ZeroContactLimitReturnsFalse)
       result,
       option));
   EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(CapsuleCapsuleBatch, CollidesEachPair)
+{
+  const CapsuleShape capsule1(0.5, 2.0);
+  const CapsuleShape capsule2(0.5, 2.0);
+  const std::vector<CapsulePair> pairs{
+      {&capsule1,
+       &capsule2,
+       Eigen::Isometry3d::Identity(),
+       translated(0.75, 0.0, 0.0)},
+      {&capsule1,
+       &capsule2,
+       Eigen::Isometry3d::Identity(),
+       translated(3.0, 0.0, 0.0)}};
+  std::vector<CollisionResult> results(2);
+
+  collideCapsulesBatch(pairs, results);
+
+  EXPECT_EQ(1u, results[0].numContacts());
+  EXPECT_EQ(0u, results[1].numContacts());
 }
 
 TEST(CapsuleCapsuleBatch, RejectsMalformedInputs)

--- a/tests/unit/collision/native/test_convex_convex.cpp
+++ b/tests/unit/collision/native/test_convex_convex.cpp
@@ -36,12 +36,15 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
 using namespace dart::collision::native;
 
 namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
 
 std::vector<Eigen::Vector3d> makeOctahedronVertices(double scale = 1.0)
 {
@@ -61,7 +64,65 @@ Eigen::Isometry3d translated(double x, double y, double z)
   return tf;
 }
 
+Eigen::Isometry3d rotatedTranslated(double x, double y, double z)
+{
+  Eigen::Isometry3d tf = translated(x, y, z);
+  tf.linear() = Eigen::AngleAxisd(0.5 * kPi, Eigen::Vector3d::UnitZ())
+                    .toRotationMatrix();
+  return tf;
+}
+
 } // namespace
+
+TEST(ConvexSupportFunctions, PrimitiveSupportPointsRespectTransforms)
+{
+  const SphereShape sphere(0.5);
+  const auto sphereSupport
+      = makeSphereSupportFunction(sphere, translated(1.0, 2.0, 3.0));
+  EXPECT_TRUE(sphereSupport(Eigen::Vector3d::Zero())
+                  .isApprox(Eigen::Vector3d(1.5, 2.0, 3.0), 1e-12));
+  EXPECT_TRUE(sphereSupport(Eigen::Vector3d::UnitY())
+                  .isApprox(Eigen::Vector3d(1.0, 2.5, 3.0), 1e-12));
+
+  const BoxShape box(Eigen::Vector3d(1.0, 2.0, 3.0));
+  const auto boxSupport
+      = makeBoxSupportFunction(box, rotatedTranslated(0, 0, 0));
+  EXPECT_TRUE(boxSupport(Eigen::Vector3d::UnitX())
+                  .isApprox(Eigen::Vector3d(2.0, 1.0, 3.0), 1e-12));
+
+  const CapsuleShape capsule(0.25, 2.0);
+  const auto capsuleSupport
+      = makeCapsuleSupportFunction(capsule, Eigen::Isometry3d::Identity());
+  EXPECT_TRUE(capsuleSupport(Eigen::Vector3d::Zero())
+                  .isApprox(Eigen::Vector3d(0.25, 0.0, 1.0), 1e-12));
+  EXPECT_TRUE(capsuleSupport(-Eigen::Vector3d::UnitZ())
+                  .isApprox(Eigen::Vector3d(0.0, 0.0, -1.25), 1e-12));
+
+  const CylinderShape cylinder(0.5, 2.0);
+  const auto cylinderSupport
+      = makeCylinderSupportFunction(cylinder, Eigen::Isometry3d::Identity());
+  EXPECT_TRUE(cylinderSupport(Eigen::Vector3d::UnitZ())
+                  .isApprox(Eigen::Vector3d(0.5, 0.0, 1.0), 1e-12));
+  EXPECT_TRUE(cylinderSupport(Eigen::Vector3d::UnitY())
+                  .isApprox(Eigen::Vector3d(0.0, 0.5, 1.0), 1e-12));
+}
+
+TEST(ConvexSupportFunctions, MeshAndConvexSupportUseFurthestVertex)
+{
+  const std::vector<Eigen::Vector3d> vertices = makeOctahedronVertices(2.0);
+  const std::vector<MeshShape::Triangle> triangles{
+      {0, 2, 4}, {2, 1, 4}, {1, 3, 4}, {3, 0, 4}};
+  const MeshShape mesh(vertices, triangles);
+  const auto meshSupport = makeMeshSupportFunction(mesh, translated(1, 0, 0));
+  EXPECT_TRUE(meshSupport(Eigen::Vector3d::UnitX())
+                  .isApprox(Eigen::Vector3d(3.0, 0.0, 0.0), 1e-12));
+
+  const ConvexShape convex(vertices);
+  const auto convexSupport
+      = makeConvexSupportFunction(convex, translated(0, 1, 0));
+  EXPECT_TRUE(convexSupport(Eigen::Vector3d::UnitY())
+                  .isApprox(Eigen::Vector3d(0.0, 3.0, 0.0), 1e-12));
+}
 
 TEST(ConvexConvex, SeparatedReturnsFalse)
 {
@@ -112,6 +173,42 @@ TEST(ConvexConvex, ConvexSphereOverlap)
   EXPECT_EQ(1u, result.numContacts());
 }
 
+TEST(ConvexConvex, PrimitiveShapesUseGenericSupportPath)
+{
+  const BoxShape box(Eigen::Vector3d(0.5, 0.5, 0.5));
+  const CylinderShape cylinder(0.5, 1.0);
+
+  CollisionResult result;
+  EXPECT_TRUE(collideConvexConvex(
+      box,
+      Eigen::Isometry3d::Identity(),
+      cylinder,
+      translated(0.75, 0.0, 0.0),
+      result,
+      CollisionOption()));
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_GT(result.getContact(0).depth, 0.0);
+}
+
+TEST(ConvexConvex, MeshShapeUsesGenericSupportPath)
+{
+  const std::vector<Eigen::Vector3d> vertices = makeOctahedronVertices();
+  const std::vector<MeshShape::Triangle> triangles{
+      {0, 2, 4}, {2, 1, 4}, {1, 3, 4}, {3, 0, 4}};
+  const MeshShape mesh(vertices, triangles);
+  const BoxShape box(Eigen::Vector3d(0.5, 0.5, 0.5));
+
+  CollisionResult result;
+  EXPECT_TRUE(collideConvexConvex(
+      mesh,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.75, 0.0, 0.0),
+      result,
+      CollisionOption()));
+  ASSERT_EQ(1u, result.numContacts());
+}
+
 TEST(ConvexConvex, BinaryCheckDoesNotAddContacts)
 {
   const ConvexShape convex1(makeOctahedronVertices());
@@ -148,6 +245,27 @@ TEST(ConvexConvex, ZeroContactLimitReturnsFalse)
   EXPECT_EQ(0u, result.numContacts());
 }
 
+TEST(ConvexConvexBatch, CollidesEachPair)
+{
+  const ConvexShape convex1(makeOctahedronVertices());
+  const ConvexShape convex2(makeOctahedronVertices());
+  const std::vector<ConvexPair> pairs{
+      {&convex1,
+       &convex2,
+       Eigen::Isometry3d::Identity(),
+       translated(1.5, 0.0, 0.0)},
+      {&convex1,
+       &convex2,
+       Eigen::Isometry3d::Identity(),
+       translated(3.0, 0.0, 0.0)}};
+  std::vector<CollisionResult> results(2);
+
+  collideConvexConvexBatch(pairs, results);
+
+  EXPECT_EQ(1u, results[0].numContacts());
+  EXPECT_EQ(0u, results[1].numContacts());
+}
+
 TEST(ConvexConvexBatch, RejectsMalformedInputs)
 {
   const ConvexShape convex1(makeOctahedronVertices());
@@ -171,4 +289,64 @@ TEST(ConvexConvexBatch, RejectsMalformedInputs)
        translated(1.5, 0.0, 0.0)}};
   EXPECT_THROW(
       collideConvexConvexBatch(nullShapePairs, results), std::invalid_argument);
+}
+
+TEST(ConvexConvexDistance, SeparatedShapesReportPositiveDistance)
+{
+  const BoxShape box1(Eigen::Vector3d(0.5, 0.5, 0.5));
+  const BoxShape box2(Eigen::Vector3d(0.5, 0.5, 0.5));
+
+  DistanceResult result;
+  const double distance = distanceConvexConvex(
+      box1,
+      Eigen::Isometry3d::Identity(),
+      box2,
+      translated(2.0, 0.0, 0.0),
+      result,
+      DistanceOption::unlimited());
+
+  EXPECT_GT(distance, 0.0);
+  EXPECT_TRUE(result.isValid());
+  EXPECT_NEAR(distance, result.distance, 1e-12);
+  EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitX(), 1e-12));
+}
+
+TEST(ConvexConvexDistance, UpperBoundPrunesSeparatedShapes)
+{
+  const BoxShape box1(Eigen::Vector3d(0.5, 0.5, 0.5));
+  const BoxShape box2(Eigen::Vector3d(0.5, 0.5, 0.5));
+
+  DistanceResult result;
+  const double distance = distanceConvexConvex(
+      box1,
+      Eigen::Isometry3d::Identity(),
+      box2,
+      translated(3.0, 0.0, 0.0),
+      result,
+      DistanceOption::withUpperBound(0.25));
+
+  EXPECT_EQ(std::numeric_limits<double>::max(), distance);
+  EXPECT_FALSE(result.isValid());
+}
+
+TEST(ConvexConvexDistance, OverlappingShapesReportNegativeDistance)
+{
+  const SphereShape sphere(0.75);
+  const BoxShape box(Eigen::Vector3d(0.5, 0.5, 0.5));
+
+  DistanceResult result;
+  const double distance = distanceConvexConvex(
+      sphere,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.75, 0.0, 0.0),
+      result,
+      DistanceOption::unlimited());
+
+  EXPECT_LT(distance, 0.0);
+  EXPECT_TRUE(result.isValid());
+  EXPECT_NEAR(distance, result.distance, 1e-12);
+  EXPECT_TRUE(result.pointOnObject1.allFinite());
+  EXPECT_TRUE(result.pointOnObject2.allFinite());
+  EXPECT_TRUE(result.normal.allFinite());
 }

--- a/tests/unit/collision/native/test_convex_convex.cpp
+++ b/tests/unit/collision/native/test_convex_convex.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/convex_convex.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace dart::collision::native;
+
+namespace {
+
+std::vector<Eigen::Vector3d> makeOctahedronVertices(double scale = 1.0)
+{
+  return {
+      {scale, 0.0, 0.0},
+      {-scale, 0.0, 0.0},
+      {0.0, scale, 0.0},
+      {0.0, -scale, 0.0},
+      {0.0, 0.0, scale},
+      {0.0, 0.0, -scale}};
+}
+
+Eigen::Isometry3d translated(double x, double y, double z)
+{
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(x, y, z);
+  return tf;
+}
+
+} // namespace
+
+TEST(ConvexConvex, SeparatedReturnsFalse)
+{
+  const ConvexShape convex1(makeOctahedronVertices());
+  const ConvexShape convex2(makeOctahedronVertices());
+
+  CollisionResult result;
+  EXPECT_FALSE(collideConvexConvex(
+      convex1,
+      Eigen::Isometry3d::Identity(),
+      convex2,
+      translated(3.0, 0.0, 0.0),
+      result,
+      CollisionOption()));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(ConvexConvex, OverlapAddsContact)
+{
+  const ConvexShape convex1(makeOctahedronVertices());
+  const ConvexShape convex2(makeOctahedronVertices());
+
+  CollisionResult result;
+  EXPECT_TRUE(collideConvexConvex(
+      convex1,
+      Eigen::Isometry3d::Identity(),
+      convex2,
+      translated(1.5, 0.0, 0.0),
+      result,
+      CollisionOption()));
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_GT(result.getContact(0).depth, 0.0);
+}
+
+TEST(ConvexConvex, ConvexSphereOverlap)
+{
+  const ConvexShape convex(makeOctahedronVertices());
+  const SphereShape sphere(0.75);
+
+  CollisionResult result;
+  EXPECT_TRUE(collideConvexConvex(
+      convex,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(1.25, 0.0, 0.0),
+      result,
+      CollisionOption()));
+  EXPECT_EQ(1u, result.numContacts());
+}
+
+TEST(ConvexConvex, BinaryCheckDoesNotAddContacts)
+{
+  const ConvexShape convex1(makeOctahedronVertices());
+  const ConvexShape convex2(makeOctahedronVertices());
+
+  CollisionResult result;
+  EXPECT_TRUE(collideConvexConvex(
+      convex1,
+      Eigen::Isometry3d::Identity(),
+      convex2,
+      translated(1.5, 0.0, 0.0),
+      result,
+      CollisionOption::binaryCheck()));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(ConvexConvex, ZeroContactLimitReturnsFalse)
+{
+  const ConvexShape convex1(makeOctahedronVertices());
+  const ConvexShape convex2(makeOctahedronVertices());
+
+  CollisionOption option;
+  option.enableContact = false;
+  option.maxNumContacts = 0;
+
+  CollisionResult result;
+  EXPECT_FALSE(collideConvexConvex(
+      convex1,
+      Eigen::Isometry3d::Identity(),
+      convex2,
+      translated(1.5, 0.0, 0.0),
+      result,
+      option));
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(ConvexConvexBatch, RejectsMalformedInputs)
+{
+  const ConvexShape convex1(makeOctahedronVertices());
+  const ConvexShape convex2(makeOctahedronVertices());
+  const std::vector<ConvexPair> validPairs{
+      {&convex1,
+       &convex2,
+       Eigen::Isometry3d::Identity(),
+       translated(1.5, 0.0, 0.0)}};
+
+  std::vector<CollisionResult> emptyResults;
+  EXPECT_THROW(
+      collideConvexConvexBatch(validPairs, emptyResults),
+      std::invalid_argument);
+
+  std::vector<CollisionResult> results(1);
+  const std::vector<ConvexPair> nullShapePairs{
+      {nullptr,
+       &convex2,
+       Eigen::Isometry3d::Identity(),
+       translated(1.5, 0.0, 0.0)}};
+  EXPECT_THROW(
+      collideConvexConvexBatch(nullShapePairs, results), std::invalid_argument);
+}

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -38,6 +38,7 @@
 
 #include <array>
 #include <stdexcept>
+#include <vector>
 
 using namespace dart::collision::native;
 
@@ -48,6 +49,17 @@ Eigen::Isometry3d translated(double x, double y, double z)
   Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
   tf.translation() = Eigen::Vector3d(x, y, z);
   return tf;
+}
+
+std::vector<Eigen::Vector3d> makeOctahedronVertices(double scale = 1.0)
+{
+  return {
+      {scale, 0.0, 0.0},
+      {-scale, 0.0, 0.0},
+      {0.0, scale, 0.0},
+      {0.0, -scale, 0.0},
+      {0.0, 0.0, scale},
+      {0.0, 0.0, -scale}};
 }
 
 } // namespace
@@ -310,7 +322,7 @@ TEST(NarrowPhaseDispatch, BatchRejectsNullShapes)
       std::invalid_argument);
 }
 
-TEST(NarrowPhaseDispatch, ReportsP4SupportedPairs)
+TEST(NarrowPhaseDispatch, ReportsP5SupportedPairs)
 {
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Sphere));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Box, ShapeType::Box));
@@ -320,11 +332,17 @@ TEST(NarrowPhaseDispatch, ReportsP4SupportedPairs)
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Capsule));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Capsule, ShapeType::Box));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Box, ShapeType::Capsule));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Capsule, ShapeType::Capsule));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Convex, ShapeType::Convex));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Convex, ShapeType::Sphere));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Convex));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Convex, ShapeType::Box));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Capsule, ShapeType::Convex));
 
   EXPECT_FALSE(
-      NarrowPhase::isSupported(ShapeType::Capsule, ShapeType::Capsule));
-  EXPECT_FALSE(
       NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Cylinder));
+  EXPECT_FALSE(
+      NarrowPhase::isSupported(ShapeType::Convex, ShapeType::Cylinder));
 }
 
 TEST(NarrowPhaseDispatch, RoutesCapsuleSphereInBothOrders)
@@ -455,6 +473,110 @@ TEST(NarrowPhaseDispatch, CapsuleBoxBinaryCheckDoesNotAddContacts)
 
   EXPECT_TRUE(boxFirstHit);
   EXPECT_EQ(0u, boxFirstResult.numContacts());
+}
+
+TEST(NarrowPhaseDispatch, RoutesCapsuleCapsule)
+{
+  CapsuleShape capsule1(0.5, 2.0);
+  CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &capsule1,
+      Eigen::Isometry3d::Identity(),
+      &capsule2,
+      translated(0.75, 0.0, 0.0),
+      CollisionOption(),
+      result);
+
+  ASSERT_TRUE(hit);
+  ASSERT_EQ(1u, result.numContacts());
+  EXPECT_TRUE(
+      result.getContact(0).normal.isApprox(-Eigen::Vector3d::UnitX(), 1e-12));
+}
+
+TEST(NarrowPhaseDispatch, CapsuleCapsuleBinaryCheckDoesNotAddContacts)
+{
+  CapsuleShape capsule1(0.5, 2.0);
+  CapsuleShape capsule2(0.5, 2.0);
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &capsule1,
+      Eigen::Isometry3d::Identity(),
+      &capsule2,
+      translated(0.75, 0.0, 0.0),
+      CollisionOption::binaryCheck(),
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(NarrowPhaseDispatch, RoutesConvexFallbackPairs)
+{
+  ConvexShape convex(makeOctahedronVertices());
+  SphereShape sphere(0.75);
+  BoxShape box(Eigen::Vector3d(0.5, 0.5, 0.5));
+  CapsuleShape capsule(0.5, 2.0);
+
+  CollisionResult convexSphere;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      &sphere,
+      translated(1.25, 0.0, 0.0),
+      CollisionOption(),
+      convexSphere));
+  EXPECT_EQ(1u, convexSphere.numContacts());
+
+  CollisionResult sphereConvex;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &sphere,
+      translated(1.25, 0.0, 0.0),
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      sphereConvex));
+  EXPECT_EQ(1u, sphereConvex.numContacts());
+
+  CollisionResult convexBox;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      &box,
+      translated(1.25, 0.0, 0.0),
+      CollisionOption(),
+      convexBox));
+  EXPECT_EQ(1u, convexBox.numContacts());
+
+  CollisionResult convexCapsule;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      &capsule,
+      translated(1.25, 0.0, 0.0),
+      CollisionOption(),
+      convexCapsule));
+  EXPECT_EQ(1u, convexCapsule.numContacts());
+}
+
+TEST(NarrowPhaseDispatch, ConvexFallbackBinaryCheckDoesNotAddContacts)
+{
+  ConvexShape convex(makeOctahedronVertices());
+  SphereShape sphere(0.75);
+
+  CollisionResult result;
+  const bool hit = NarrowPhase::collide(
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      &sphere,
+      translated(1.25, 0.0, 0.0),
+      CollisionOption::binaryCheck(),
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_EQ(0u, result.numContacts());
 }
 
 TEST(NarrowPhaseDispatch, RespectsExhaustedContactBudget)

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -517,19 +517,6 @@ TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
           ->getVertices()
           .size(),
       8u);
-
-  const dynamics::MultiSphereConvexHullShape multiSphere(
-      {{0.25, Eigen::Vector3d::Zero()},
-       {0.25, Eigen::Vector3d(0.5, 0.0, 0.0)}});
-  auto nativeMultiSphere
-      = collision::detail::NativeShapeConversion::create(multiSphere);
-  ASSERT_NE(nullptr, nativeMultiSphere);
-  ASSERT_EQ(native::ShapeType::Convex, nativeMultiSphere->getType());
-  EXPECT_GT(
-      static_cast<const native::ConvexShape*>(nativeMultiSphere.get())
-          ->getVertices()
-          .size(),
-      8u);
 }
 
 //==============================================================================
@@ -537,6 +524,12 @@ TEST(NativeCollisionDetector, LeavesUnsupportedShapesNull)
 {
   const dynamics::PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
   EXPECT_EQ(nullptr, collision::detail::NativeShapeConversion::create(plane));
+
+  const dynamics::MultiSphereConvexHullShape multiSphere(
+      {{0.25, Eigen::Vector3d::Zero()},
+       {0.25, Eigen::Vector3d(0.5, 0.0, 0.0)}});
+  EXPECT_EQ(
+      nullptr, collision::detail::NativeShapeConversion::create(multiSphere));
 }
 
 //==============================================================================

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -40,7 +40,11 @@
 
 #include <dart/dynamics/BoxShape.hpp>
 #include <dart/dynamics/CapsuleShape.hpp>
+#include <dart/dynamics/ConeShape.hpp>
+#include <dart/dynamics/ConvexMeshShape.hpp>
+#include <dart/dynamics/MultiSphereConvexHullShape.hpp>
 #include <dart/dynamics/PlaneShape.hpp>
+#include <dart/dynamics/PyramidShape.hpp>
 #include <dart/dynamics/SimpleFrame.hpp>
 #include <dart/dynamics/SphereShape.hpp>
 
@@ -131,6 +135,39 @@ private:
       std::pair<const dynamics::ShapeFrame*, const dynamics::ShapeFrame*>>
       mIgnoredPairs;
 };
+
+//==============================================================================
+dynamics::ConvexMeshShape::Vertices makeCubeVertices(double halfExtent = 0.5)
+{
+  const double h = halfExtent;
+  return {
+      {-h, -h, -h},
+      {h, -h, -h},
+      {h, h, -h},
+      {-h, h, -h},
+      {-h, -h, h},
+      {h, -h, h},
+      {h, h, h},
+      {-h, h, h}};
+}
+
+//==============================================================================
+dynamics::ConvexMeshShape::Triangles makeCubeTriangles()
+{
+  return {
+      {0, 1, 2},
+      {0, 2, 3},
+      {4, 6, 5},
+      {4, 7, 6},
+      {0, 5, 1},
+      {0, 4, 5},
+      {2, 6, 7},
+      {2, 7, 3},
+      {0, 7, 4},
+      {0, 3, 7},
+      {1, 5, 6},
+      {1, 6, 2}};
+}
 
 } // namespace
 
@@ -339,6 +376,49 @@ TEST(NativeCollisionDetector, CollidesCapsuleBox)
 }
 
 //==============================================================================
+TEST(NativeCollisionDetector, CollidesCapsuleCapsule)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto capsuleFrame1
+      = makeFrame(std::make_shared<dynamics::CapsuleShape>(0.5, 2.0));
+  auto capsuleFrame2 = makeFrame(
+      std::make_shared<dynamics::CapsuleShape>(0.5, 2.0),
+      Eigen::Vector3d(0.75, 0.0, 0.0));
+
+  auto group = detector->createCollisionGroup(
+      capsuleFrame1.get(), capsuleFrame2.get());
+  collision::CollisionResult result;
+  EXPECT_TRUE(group->collide(collision::CollisionOption(true, 10u), &result));
+  ASSERT_EQ(1u, result.getNumContacts());
+
+  const auto& contact = result.getContact(0);
+  EXPECT_EQ(capsuleFrame1.get(), contact.getShapeFrame1());
+  EXPECT_EQ(capsuleFrame2.get(), contact.getShapeFrame2());
+  EXPECT_TRUE(contact.normal.isApprox(-Eigen::Vector3d::UnitX(), 1e-12));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, CollidesSphereConvexMesh)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto convexFrame = makeFrame(std::make_shared<dynamics::ConvexMeshShape>(
+      makeCubeVertices(), makeCubeTriangles()));
+  auto sphereFrame = makeFrame(
+      std::make_shared<dynamics::SphereShape>(0.75),
+      Eigen::Vector3d(1.0, 0.0, 0.0));
+
+  auto group
+      = detector->createCollisionGroup(convexFrame.get(), sphereFrame.get());
+  collision::CollisionResult result;
+  EXPECT_TRUE(group->collide(collision::CollisionOption(true, 10u), &result));
+  ASSERT_EQ(1u, result.getNumContacts());
+
+  const auto& contact = result.getContact(0);
+  EXPECT_EQ(convexFrame.get(), contact.getShapeFrame1());
+  EXPECT_EQ(sphereFrame.get(), contact.getShapeFrame2());
+}
+
+//==============================================================================
 TEST(NativeCollisionDetector, CollidesAcrossGroups)
 {
   auto detector = collision::NativeCollisionDetector::create();
@@ -404,6 +484,52 @@ TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
       1.5,
       static_cast<const native::CapsuleShape*>(nativeCapsule.get())
           ->getHeight());
+
+  const dynamics::ConvexMeshShape convexMesh(
+      makeCubeVertices(), makeCubeTriangles());
+  auto nativeConvexMesh
+      = collision::detail::NativeShapeConversion::create(convexMesh);
+  ASSERT_NE(nullptr, nativeConvexMesh);
+  ASSERT_EQ(native::ShapeType::Convex, nativeConvexMesh->getType());
+  EXPECT_EQ(
+      8u,
+      static_cast<const native::ConvexShape*>(nativeConvexMesh.get())
+          ->getVertices()
+          .size());
+
+  const dynamics::PyramidShape pyramid(1.0, 2.0, 3.0);
+  auto nativePyramid
+      = collision::detail::NativeShapeConversion::create(pyramid);
+  ASSERT_NE(nullptr, nativePyramid);
+  ASSERT_EQ(native::ShapeType::Convex, nativePyramid->getType());
+  EXPECT_EQ(
+      5u,
+      static_cast<const native::ConvexShape*>(nativePyramid.get())
+          ->getVertices()
+          .size());
+
+  const dynamics::ConeShape cone(1.0, 2.0);
+  auto nativeCone = collision::detail::NativeShapeConversion::create(cone);
+  ASSERT_NE(nullptr, nativeCone);
+  ASSERT_EQ(native::ShapeType::Convex, nativeCone->getType());
+  EXPECT_GT(
+      static_cast<const native::ConvexShape*>(nativeCone.get())
+          ->getVertices()
+          .size(),
+      8u);
+
+  const dynamics::MultiSphereConvexHullShape multiSphere(
+      {{0.25, Eigen::Vector3d::Zero()},
+       {0.25, Eigen::Vector3d(0.5, 0.0, 0.0)}});
+  auto nativeMultiSphere
+      = collision::detail::NativeShapeConversion::create(multiSphere);
+  ASSERT_NE(nullptr, nativeMultiSphere);
+  ASSERT_EQ(native::ShapeType::Convex, nativeMultiSphere->getType());
+  EXPECT_GT(
+      static_cast<const native::ConvexShape*>(nativeMultiSphere.get())
+          ->getVertices()
+          .size(),
+      8u);
 }
 
 //==============================================================================

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -522,6 +522,12 @@ TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
 //==============================================================================
 TEST(NativeCollisionDetector, LeavesUnsupportedShapesNull)
 {
+  auto emptyMesh = std::make_shared<dynamics::ConvexMeshShape::TriMeshType>();
+  const dynamics::ConvexMeshShape emptyConvexMesh(emptyMesh);
+  EXPECT_EQ(
+      nullptr,
+      collision::detail::NativeShapeConversion::create(emptyConvexMesh));
+
   const dynamics::PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
   EXPECT_EQ(nullptr, collision::detail::NativeShapeConversion::create(plane));
 

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -507,16 +507,6 @@ TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
       static_cast<const native::ConvexShape*>(nativePyramid.get())
           ->getVertices()
           .size());
-
-  const dynamics::ConeShape cone(1.0, 2.0);
-  auto nativeCone = collision::detail::NativeShapeConversion::create(cone);
-  ASSERT_NE(nullptr, nativeCone);
-  ASSERT_EQ(native::ShapeType::Convex, nativeCone->getType());
-  EXPECT_GT(
-      static_cast<const native::ConvexShape*>(nativeCone.get())
-          ->getVertices()
-          .size(),
-      8u);
 }
 
 //==============================================================================
@@ -530,6 +520,9 @@ TEST(NativeCollisionDetector, LeavesUnsupportedShapesNull)
 
   const dynamics::PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
   EXPECT_EQ(nullptr, collision::detail::NativeShapeConversion::create(plane));
+
+  const dynamics::ConeShape cone(1.0, 2.0);
+  EXPECT_EQ(nullptr, collision::detail::NativeShapeConversion::create(cone));
 
   const dynamics::MultiSphereConvexHullShape multiSphere(
       {{0.25, Eigen::Vector3d::Zero()},


### PR DESCRIPTION
## Summary

- Add native capsule-capsule narrow-phase support on top of #3321.
- Add the convex-convex foundation path, including a DART 6 span shim exemplar.
- Convert exact DART convex-family shapes that already have finite vertex support into native convex support functions.
- Extend dispatch, detector-adapter coverage, and `BM_UNIT_native_collision` benchmark rows for the new pairs.

## Motivation

This continues the dependency-minimization stack by moving the next primitive and exact convex-family collision paths into the opt-in native detector on the 6.20 line.

## Changes

- Adds `capsule_capsule` and `convex_convex` native narrow-phase implementations.
- Wires capsule-capsule direct dispatch and conservative convex fallback dispatch.
- Converts `ConvexMeshShape` and `PyramidShape` into native convex shapes.
- Leaves `ConeShape` and `MultiSphereConvexHullShape` unsupported for now because they need exact native support representations, not sampled vertices.
- Adds direct, dispatch, binary-check, detector-adapter, and benchmark coverage.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Supported native pairs | Native capsule-sphere and capsule-box are available from #3321; capsule-capsule and convex-family pairs are rejected. | Capsule-capsule and exact finite-vertex convex-family pairs route through native implementations. |
| Shape adapter | Convex-family DART shapes are skipped by the native adapter. | `ConvexMeshShape` and `PyramidShape` convert to native convex shapes; cone and multi-sphere hull remain unsupported pending exact support. |
| Binary checks | Existing pairs preserve no-contact binary behavior. | Capsule-capsule and convex-convex preserve the same behavior. |
| Performance evidence | No benchmark rows for the #3322 pairs. | `BM_UNIT_native_collision` includes capsule-capsule and convex-convex rows. |

## Performance Evidence

Benchmark target: `BM_UNIT_native_collision` extended in this PR.

Compared commits:

- Base: `origin/release-6.20` at `279888bc53b` with this PR's benchmark-row extension applied locally so the new rows use identical benchmark code.
- Head: `9e8325575f2`.

Commands:

```bash
cmake --build build/default/cpp/Release --target BM_UNIT_native_collision -j 24
build/default/cpp/Release/bin/BM_UNIT_native_collision \
  --benchmark_filter='BM_Native(CapsuleCapsule|ConvexConvex)$' \
  --benchmark_min_time=1.0s \
  --benchmark_repetitions=9 \
  --benchmark_report_aggregates_only=true \
  --benchmark_out=/tmp/dart-pr3322-native-head-rebased-1.0s.json \
  --benchmark_out_format=json
```

Baseline confirmation used a temporary `origin/release-6.20` worktree at `279888bc53b` with only the benchmark rows applied. Both rows returned `native narrow-phase benchmark case did not collide` before this PR.

Local median CPU time, Release build:

| Row | Base median | Head median | Head CV | Contacts/iter |
| --- | ---: | ---: | ---: | ---: |
| `BM_NativeCapsuleCapsule` | unsupported | 18.4 ns | 2.23% | 1 |
| `BM_NativeConvexConvex` | unsupported | 217 ns | 3.57% | 1 |

Interpretation:

- Both benchmark rows are newly supported by this PR; the release-branch base returned no collision for the same cases.
- This is a narrowphase microbenchmark, not an end-to-end world-step benchmark. DART 6 still defaults to FCL, so these timings apply to users who opt into `"native"`.
- The local host reported CPU scaling enabled, so these numbers should be treated as regression-watch evidence rather than a release-blocking threshold.

## Testing

- `cmake --build build/default/cpp/Release --target BM_UNIT_native_collision UNIT_collision_native_capsule_capsule UNIT_collision_native_convex_convex UNIT_collision_native_detector_adapter -j 24`
- `ctest --test-dir build/default/cpp/Release -R '^(UNIT_collision_native_(capsule_capsule|convex_convex)|UNIT_collision_native_detector_adapter)$' --output-on-failure`
- Temporary baseline worktree at `origin/release-6.20` (`279888bc53b`) with benchmark rows applied locally: `pixi run config`; `cmake --build build/default/cpp/Release --target BM_UNIT_native_collision -j 24`; `BM_UNIT_native_collision --benchmark_filter='BM_Native(CapsuleCapsule|ConvexConvex)$' --benchmark_min_time=0.5s --benchmark_repetitions=7 --benchmark_report_aggregates_only=true`
- `build/default/cpp/Release/bin/BM_UNIT_native_collision --benchmark_filter='BM_Native(CapsuleCapsule|ConvexConvex)$' --benchmark_min_time=1.0s --benchmark_repetitions=9 --benchmark_report_aggregates_only=true --benchmark_out=/tmp/dart-pr3322-native-head-rebased-1.0s.json --benchmark_out_format=json`
- `pixi run lint`
- `pixi run check-lint-quick`

## Related PRs

- Originally stacked on #3321; now based on `release-6.20` after #3321 merged.
- Continues the #3303 / #3306 dependency-minimization stack.
- Follows the phase-2 plan in #3302.

## Breaking Changes

None.

## Checklist

- [x] Focused native collision tests pass locally
- [x] Lint passes locally
- [x] No public API or ABI change intended
