### PR TITLE
Polish dart-demos UI layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,6 +448,13 @@
     not look missing from normal camera angles:
     [#3304](https://github.com/dartsim/dart/pull/3304)
 
+  * Polish the `dart-demos` workspace with a more compact toolbar, tabbed
+    scene/inspector/tool panes, a status-and-log bottom panel, clearer
+    simulation/render metrics, a lighter 3D viewport background, a fit-scene
+    view action, and a migrated `hello_world` scene while preserving the
+    standalone first-program example:
+    [#3328](https://github.com/dartsim/dart/pull/3328)
+
   * Add an OSG/ImGui `ssik_ik_gui` example for interactively selecting ssik
     prebuilt IK modules and changing target and solver options online. Every IK
     solution is shown at once as a DART skeleton built from the arm's kinematics

--- a/examples/demos/ContactVisualizer.cpp
+++ b/examples/demos/ContactVisualizer.cpp
@@ -178,8 +178,7 @@ void ContactVisualizer::renderToggle()
     hideFrom(0);
     mLastVisualizedCount = 0;
   }
-  ImGui::SameLine();
-  ImGui::TextDisabled("(capped at %zu arrows)", kMaxArrows);
+  ImGui::TextDisabled("Capped at %zu arrows", kMaxArrows);
 }
 
 } // namespace dart_demos

--- a/examples/demos/DemoHost.cpp
+++ b/examples/demos/DemoHost.cpp
@@ -103,6 +103,32 @@ bool hasLiveRtfStats(
 }
 
 //==============================================================================
+float calcButtonWidth(const char* label)
+{
+  const ImGuiStyle& style = ImGui::GetStyle();
+  return ImGui::CalcTextSize(label).x + 2.0f * style.FramePadding.x;
+}
+
+//==============================================================================
+void sameLineIfEnoughRoom(float nextItemWidth)
+{
+  const ImGuiStyle& style = ImGui::GetStyle();
+  const float windowRight
+      = ImGui::GetWindowPos().x + ImGui::GetContentRegionMax().x;
+  const float nextRight
+      = ImGui::GetItemRectMax().x + style.ItemSpacing.x + nextItemWidth;
+  if (nextRight <= windowRight)
+    ImGui::SameLine();
+}
+
+//==============================================================================
+float clampedItemWidth(float preferred, float minimum)
+{
+  const float avail = std::max(1.0f, ImGui::GetContentRegionAvail().x);
+  return std::clamp(preferred, std::min(minimum, avail), avail);
+}
+
+//==============================================================================
 /// Forwards ImGui rendering to the host; kept alive by ImGuiHandler's own
 /// widget list once registered.
 class HostPanelWidget : public dart::gui::osg::ImGuiWidget
@@ -417,7 +443,7 @@ void DemoHost::ensureViewerConfigured()
   applyModernDarkMetrics();
   mViewer->getImGuiHandler()->setGuiScale(mGuiScale);
 
-  mViewer->getCamera()->setClearColor(::osg::Vec4(0.10f, 0.11f, 0.13f, 1.0f));
+  mViewer->getCamera()->setClearColor(::osg::Vec4(0.58f, 0.62f, 0.65f, 1.0f));
 
   mViewer->getImGuiHandler()->addWidget(
       std::make_shared<HostPanelWidget>(this));
@@ -676,6 +702,14 @@ void DemoHost::applyCameraHome(const CameraHome& home, bool viaManipulator)
   } else {
     mViewer->getCamera()->setViewMatrixAsLookAt(home.eye, home.center, home.up);
   }
+}
+
+//==============================================================================
+void DemoHost::fitCameraToWorld()
+{
+  if (!mCurrentWorld)
+    return;
+  dart::gui::osg::applyDefaultCameraPose(*mViewer, mCurrentWorld);
 }
 
 //==============================================================================
@@ -963,10 +997,10 @@ void DemoHost::renderPanels()
   const float screenW = std::max(1.0f, io.DisplaySize.x);
   const float screenH = std::max(1.0f, io.DisplaySize.y);
 
-  const float toolbarH = std::min(96.0f * scale, screenH * 0.3f);
-  const float bottomH = std::min(190.0f * scale, screenH * 0.35f);
-  const float leftW = std::min(300.0f * scale, screenW * 0.4f);
-  const float rightW = std::min(340.0f * scale, screenW * 0.4f);
+  const float toolbarH = std::min(58.0f * scale, screenH * 0.18f);
+  const float bottomH = std::min(156.0f * scale, screenH * 0.26f);
+  const float leftW = std::min(260.0f * scale, screenW * 0.30f);
+  const float rightW = std::min(360.0f * scale, screenW * 0.34f);
   const float middleH = std::max(1.0f, screenH - toolbarH - bottomH);
 
   constexpr ImGuiWindowFlags kChromeFlags
@@ -1005,17 +1039,27 @@ void DemoHost::renderToolbar()
 {
   const bool hasScene = mWorldNode != nullptr;
   const bool simulating = mViewer->isSimulating();
+  const float scale = static_cast<float>(mGuiScale);
 
+  ImGui::TextColored(ImVec4(0.42f, 0.70f, 1.0f, 1.0f), "DART");
+  ImGui::SameLine();
+  ImGui::TextDisabled("demos");
+  if (!mCurrentSceneTitle.empty()) {
+    sameLineIfEnoughRoom(ImGui::CalcTextSize(mCurrentSceneTitle.c_str()).x);
+    ImGui::TextUnformatted(mCurrentSceneTitle.c_str());
+  }
+
+  sameLineIfEnoughRoom(calcButtonWidth(simulating ? "Pause" : "Play"));
   ImGui::BeginDisabled(!hasScene);
   if (ImGui::Button(simulating ? "Pause" : "Play"))
     mViewer->simulate(!simulating);
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(calcButtonWidth("Step"));
   if (ImGui::Button("Step") && mWorldNode)
     mWorldNode->stepOnce();
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(calcButtonWidth("Rebuild"));
   if (ImGui::Button("Rebuild") && !mCurrentSceneId.empty())
     requestSceneSwitch(mCurrentSceneId);
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(calcButtonWidth("Reset"));
   // Reset restores the scene's initial state by re-running its factory (a
   // fresh World), the same as Rebuild -- see the Rebuild/Reset note in
   // README or the phase-1 report for why world->reset() alone is not enough.
@@ -1023,17 +1067,26 @@ void DemoHost::renderToolbar()
     requestSceneSwitch(mCurrentSceneId);
   ImGui::EndDisabled();
 
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(90.0f * scale);
   ImGui::Text("Time %.2f s", mCurrentWorld ? mCurrentWorld->getTime() : 0.0);
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(72.0f * scale);
+  ImGui::Text("FPS %.0f", static_cast<double>(ImGui::GetIO().Framerate));
+  sameLineIfEnoughRoom(96.0f * scale);
   if (hasLiveRtfStats(mViewer.get(), mWorldNode.get()))
-    ImGui::Text("RTF %.2f", mWorldNode->getSmoothedRealTimeFactor());
+    ImGui::Text("Sim %.2fx", mWorldNode->getSmoothedRealTimeFactor());
   else
-    ImGui::TextUnformatted("RTF --");
+    ImGui::TextUnformatted("Sim --");
+  sameLineIfEnoughRoom(100.0f * scale);
+  ImGui::Text(
+      "Steps/frame %zu",
+      mWorldNode ? mWorldNode->getLastRefreshStepCount() : std::size_t{0});
 
-  ImGui::SetNextItemWidth(220.0f * static_cast<float>(mGuiScale));
+  sameLineIfEnoughRoom(190.0f * scale);
+  ImGui::TextUnformatted("Target");
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(clampedItemWidth(116.0f * scale, 76.0f * scale));
   if (ImGui::SliderFloat(
-          "Target RTF",
+          "##target_rtf",
           &mTargetRtf,
           0.1f,
           4.0f,
@@ -1044,7 +1097,7 @@ void DemoHost::renderToolbar()
     if (mWorldNode)
       mWorldNode->setTargetRealTimeFactor(mTargetRtf);
   }
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(90.0f * scale);
   if (ImGui::Checkbox("Gravity", &mGravityEnabled) && mCurrentWorld) {
     if (mGravityEnabled) {
       mCurrentWorld->setGravity(mSavedGravity);
@@ -1058,10 +1111,12 @@ void DemoHost::renderToolbar()
   // directly to the active world (the same frame-loop thread ImGui renders on,
   // matching the Gravity/Target RTF writes above). NaN input is rejected by
   // keeping the previous value.
+  sameLineIfEnoughRoom(170.0f * scale);
+  ImGui::TextUnformatted("dt");
   ImGui::SameLine();
-  ImGui::SetNextItemWidth(200.0f * static_cast<float>(mGuiScale));
+  ImGui::SetNextItemWidth(clampedItemWidth(120.0f * scale, 86.0f * scale));
   if (ImGui::SliderFloat(
-          "Timestep",
+          "##timestep",
           &mTimeStep,
           1e-5f,
           1e-2f,
@@ -1073,7 +1128,7 @@ void DemoHost::renderToolbar()
       mCurrentWorld->setTimeStep(mTimeStep);
   }
 
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(calcButtonWidth("View"));
   if (ImGui::Button("View"))
     ImGui::OpenPopup("##view_menu_popup");
   if (ImGui::BeginPopup("##view_menu_popup")) {
@@ -1081,12 +1136,22 @@ void DemoHost::renderToolbar()
     ImGui::EndPopup();
   }
 
+  sameLineIfEnoughRoom(120.0f * scale);
   mDragForce.renderToolbarStatus(mGuiScale);
 }
 
 //==============================================================================
 void DemoHost::renderViewMenu()
 {
+  ImGui::BeginDisabled(!mCurrentWorld);
+  if (ImGui::Button("Fit scene"))
+    fitCameraToWorld();
+  ImGui::EndDisabled();
+  ImGui::SameLine();
+  if (ImGui::Button("Reset camera"))
+    mViewer->home();
+
+  ImGui::Separator();
   if (ImGui::Checkbox("Shadows", &mShadowsEnabled))
     applyShadowState();
 
@@ -1146,10 +1211,6 @@ void DemoHost::renderViewMenu()
         = dart::gui::osg::sanitizeGuiScale(std::clamp(guiScale, 0.75f, 2.0f));
     mViewer->getImGuiHandler()->setGuiScale(mGuiScale);
   }
-
-  ImGui::Separator();
-  if (ImGui::Button("Reset camera"))
-    mViewer->home();
 }
 
 //==============================================================================
@@ -1158,10 +1219,15 @@ void DemoHost::renderNavigator()
   ImGui::TextWrapped("%s", mStatusLine.c_str());
   ImGui::Separator();
 
-  ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 60.0f);
+  const float clearW = calcButtonWidth("Clear");
+  const float searchW = std::max(
+      ImGui::GetFontSize() * 5.0f,
+      ImGui::GetContentRegionAvail().x - clearW
+          - ImGui::GetStyle().ItemSpacing.x);
+  ImGui::SetNextItemWidth(searchW);
   ImGui::InputTextWithHint(
       "##search", "Search demos...", mSearchBuf, sizeof(mSearchBuf));
-  ImGui::SameLine();
+  sameLineIfEnoughRoom(clearW);
   if (ImGui::Button("Clear"))
     mSearchBuf[0] = '\0';
 
@@ -1215,8 +1281,13 @@ void DemoHost::renderInspectorSection()
   if (ImGui::CollapsingHeader("Scene Tree", ImGuiTreeNodeFlags_DefaultOpen)) {
     ImGui::BeginChild(
         "##scene_tree_scroll",
-        ImVec2(0.0f, 120.0f * static_cast<float>(mGuiScale)),
-        true);
+        ImVec2(
+            0.0f,
+            std::min(
+                180.0f * static_cast<float>(mGuiScale),
+                ImGui::GetContentRegionAvail().y * 0.45f)),
+        true,
+        ImGuiWindowFlags_HorizontalScrollbar);
     mInspector.renderTree(mCurrentWorld);
     ImGui::EndChild();
   }
@@ -1234,15 +1305,11 @@ void DemoHost::renderInspectorSection()
       }
     }
   }
-
-  ImGui::Separator();
 }
 
 //==============================================================================
-void DemoHost::renderScenePanel()
+void DemoHost::renderSceneControlsSection()
 {
-  renderInspectorSection();
-
   if (mCurrentRenderPanel) {
     try {
       mCurrentRenderPanel();
@@ -1276,6 +1343,45 @@ void DemoHost::renderScenePanel()
 }
 
 //==============================================================================
+void DemoHost::renderToolsSection()
+{
+  if (ImGui::CollapsingHeader(
+          "Contact Visualizer", ImGuiTreeNodeFlags_DefaultOpen)) {
+    mContactVisualizer.renderToggle();
+  }
+
+  if (ImGui::CollapsingHeader("Drag Force", ImGuiTreeNodeFlags_DefaultOpen)) {
+    mDragForce.renderTunables(mGuiScale);
+  }
+
+  if (ImGui::CollapsingHeader("Profiler", ImGuiTreeNodeFlags_DefaultOpen)) {
+    mProfiler.render();
+  }
+}
+
+//==============================================================================
+void DemoHost::renderScenePanel()
+{
+  if (ImGui::BeginTabBar("##scene_panel_tabs")) {
+    if (ImGui::BeginTabItem("Scene")) {
+      renderSceneControlsSection();
+      ImGui::EndTabItem();
+    }
+
+    if (ImGui::BeginTabItem("Inspector")) {
+      renderInspectorSection();
+      ImGui::EndTabItem();
+    }
+
+    if (ImGui::BeginTabItem("Tools")) {
+      renderToolsSection();
+      ImGui::EndTabItem();
+    }
+    ImGui::EndTabBar();
+  }
+}
+
+//==============================================================================
 void DemoHost::renderDiagnostics()
 {
   std::size_t numSkeletons = 0;
@@ -1302,14 +1408,6 @@ void DemoHost::renderDiagnostics()
         "FPS %.0f   RTF min/avg/max -- / -- / --",
         static_cast<double>(ImGui::GetIO().Framerate));
   }
-  ImGui::Text(
-      "Steps %zu   Sim time %.2f s   Skeletons %zu   Bodies %zu   DOFs %zu",
-      mWorldNode ? mWorldNode->getStepCount() : std::size_t{0},
-      mCurrentWorld ? mCurrentWorld->getTime() : 0.0,
-      numSkeletons,
-      numBodies,
-      numDofs);
-
   const std::size_t numContacts
       = mCurrentWorld ? mCurrentWorld->getLastCollisionResult().getNumContacts()
                       : std::size_t{0};
@@ -1318,75 +1416,66 @@ void DemoHost::renderDiagnostics()
             ? mCurrentWorld->getConstraintSolver()->getNumConstraints()
             : std::size_t{0};
   ImGui::Text(
-      "Contacts %zu   Constraints %zu   Steps/refresh %zu   Timestep %.5f s",
-      numContacts,
-      numConstraints,
+      "Steps %zu   Sim %.2f s   Steps/frame %zu   dt %.5f s   Skeletons %zu   "
+      "Bodies %zu   DOFs %zu   Contacts %zu   Constraints %zu",
+      mWorldNode ? mWorldNode->getStepCount() : std::size_t{0},
+      mCurrentWorld ? mCurrentWorld->getTime() : 0.0,
       mWorldNode ? mWorldNode->getLastRefreshStepCount() : std::size_t{0},
-      mCurrentWorld ? mCurrentWorld->getTimeStep() : 0.0);
+      mCurrentWorld ? mCurrentWorld->getTimeStep() : 0.0,
+      numSkeletons,
+      numBodies,
+      numDofs,
+      numContacts,
+      numConstraints);
 
   ImGui::Separator();
-  if (ImGui::CollapsingHeader(
-          "Contact Visualizer", ImGuiTreeNodeFlags_DefaultOpen)) {
-    mContactVisualizer.renderToggle();
-  }
+  renderLogSection(0.0f);
+}
 
-  ImGui::Separator();
-  if (ImGui::CollapsingHeader("Drag Force", ImGuiTreeNodeFlags_DefaultOpen)) {
-    mDragForce.renderTunables(mGuiScale);
-  }
-
-  ImGui::Separator();
-  if (ImGui::CollapsingHeader("Profiler", ImGuiTreeNodeFlags_DefaultOpen)) {
-    mProfiler.render();
-  }
-
-  ImGui::Separator();
-  if (ImGui::CollapsingHeader("Log", ImGuiTreeNodeFlags_DefaultOpen)) {
-    ImGui::Checkbox("Info", &mLogShowInfo);
-    ImGui::SameLine();
-    ImGui::Checkbox("Warning", &mLogShowWarning);
-    ImGui::SameLine();
-    ImGui::Checkbox("Error", &mLogShowError);
-    ImGui::SameLine();
-    ImGui::Checkbox("Autoscroll", &mLogAutoscroll);
-    ImGui::SameLine();
-    if (ImGui::Button("Copy")) {
-      std::string joined;
-      for (const auto& entry : mLog) {
-        if ((entry.level == LogEntry::Level::Info && !mLogShowInfo)
-            || (entry.level == LogEntry::Level::Warning && !mLogShowWarning)
-            || (entry.level == LogEntry::Level::Error && !mLogShowError))
-          continue;
-        joined += entry.message;
-        joined += '\n';
-      }
-      ImGui::SetClipboardText(joined.c_str());
-    }
-
-    ImGui::BeginChild(
-        "##log_scroll",
-        ImVec2(0.0f, 100.0f * static_cast<float>(mGuiScale)),
-        true);
+//==============================================================================
+void DemoHost::renderLogSection(float height)
+{
+  ImGui::Checkbox("Info", &mLogShowInfo);
+  sameLineIfEnoughRoom(95.0f * static_cast<float>(mGuiScale));
+  ImGui::Checkbox("Warning", &mLogShowWarning);
+  sameLineIfEnoughRoom(72.0f * static_cast<float>(mGuiScale));
+  ImGui::Checkbox("Error", &mLogShowError);
+  sameLineIfEnoughRoom(100.0f * static_cast<float>(mGuiScale));
+  ImGui::Checkbox("Autoscroll", &mLogAutoscroll);
+  sameLineIfEnoughRoom(calcButtonWidth("Copy"));
+  if (ImGui::Button("Copy")) {
+    std::string joined;
     for (const auto& entry : mLog) {
       if ((entry.level == LogEntry::Level::Info && !mLogShowInfo)
           || (entry.level == LogEntry::Level::Warning && !mLogShowWarning)
           || (entry.level == LogEntry::Level::Error && !mLogShowError))
         continue;
-
-      ImVec4 color = ImGui::GetStyle().Colors[ImGuiCol_Text];
-      if (entry.level == LogEntry::Level::Error)
-        color = ImVec4(0.95f, 0.35f, 0.35f, 1.0f);
-      else if (entry.level == LogEntry::Level::Warning)
-        color = ImVec4(0.95f, 0.75f, 0.25f, 1.0f);
-
-      ImGui::PushStyleColor(ImGuiCol_Text, color);
-      ImGui::TextWrapped("%s", entry.message.c_str());
-      ImGui::PopStyleColor();
+      joined += entry.message;
+      joined += '\n';
     }
-    if (mLogAutoscroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
-      ImGui::SetScrollHereY(1.0f);
-    ImGui::EndChild();
+    ImGui::SetClipboardText(joined.c_str());
   }
+
+  ImGui::BeginChild("##log_scroll", ImVec2(0.0f, height), true);
+  for (const auto& entry : mLog) {
+    if ((entry.level == LogEntry::Level::Info && !mLogShowInfo)
+        || (entry.level == LogEntry::Level::Warning && !mLogShowWarning)
+        || (entry.level == LogEntry::Level::Error && !mLogShowError))
+      continue;
+
+    ImVec4 color = ImGui::GetStyle().Colors[ImGuiCol_Text];
+    if (entry.level == LogEntry::Level::Error)
+      color = ImVec4(0.95f, 0.35f, 0.35f, 1.0f);
+    else if (entry.level == LogEntry::Level::Warning)
+      color = ImVec4(0.95f, 0.75f, 0.25f, 1.0f);
+
+    ImGui::PushStyleColor(ImGuiCol_Text, color);
+    ImGui::TextWrapped("%s", entry.message.c_str());
+    ImGui::PopStyleColor();
+  }
+  if (mLogAutoscroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
+    ImGui::SetScrollHereY(1.0f);
+  ImGui::EndChild();
 }
 
 } // namespace dart_demos

--- a/examples/demos/DemoHost.cpp
+++ b/examples/demos/DemoHost.cpp
@@ -53,6 +53,9 @@ namespace dart_demos {
 
 namespace {
 
+constexpr int kDefaultWindowWidth = 1600;
+constexpr int kDefaultWindowHeight = 1000;
+
 //==============================================================================
 std::string toLower(const std::string& value)
 {
@@ -391,6 +394,13 @@ void DemoHost::setDebugSelectBodyName(const std::string& name)
 void DemoHost::setDebugRecordProfile(bool on)
 {
   mDebugRecordProfile = on;
+}
+
+//==============================================================================
+void DemoHost::requestScenePanelTab(ScenePanelTab tab)
+{
+  mRequestedScenePanelTab = tab;
+  mHasRequestedScenePanelTab = true;
 }
 
 //==============================================================================
@@ -859,14 +869,18 @@ int DemoHost::runHeadlessShot(
          ++s) {
       found = mCurrentWorld->getSkeleton(s)->getBodyNode(mDebugSelectBodyName);
     }
-    if (found)
+    if (found) {
       mInspector.setSelection(found);
-    else
+      requestScenePanelTab(ScenePanelTab::Inspector);
+    } else {
       std::cerr << "[headless] --debug-select-body '" << mDebugSelectBodyName
                 << "' not found in demo '" << initial << "'.\n";
+    }
   }
-  if (mDebugRecordProfile)
+  if (mDebugRecordProfile) {
     mProfiler.setRecordingForTest(true);
+    requestScenePanelTab(ScenePanelTab::Tools);
+  }
 
   const CameraHome defaultHome{
       ::osg::Vec3d(6.0, 8.0, 4.0),
@@ -915,8 +929,8 @@ int DemoHost::run()
   mViewer->setUpViewInWindow(
       0,
       0,
-      dart::gui::osg::scaleWindowExtent(1280, mGuiScale),
-      dart::gui::osg::scaleWindowExtent(800, mGuiScale));
+      dart::gui::osg::scaleWindowExtent(kDefaultWindowWidth, mGuiScale),
+      dart::gui::osg::scaleWindowExtent(kDefaultWindowHeight, mGuiScale));
 
   const std::string initial = !mInitialSceneId.empty() ? mInitialSceneId
                               : !mScenes.empty()       ? mScenes.front().id
@@ -1362,23 +1376,36 @@ void DemoHost::renderToolsSection()
 //==============================================================================
 void DemoHost::renderScenePanel()
 {
+  const auto tabSelectionFlags = [this](ScenePanelTab tab) {
+    return mHasRequestedScenePanelTab && mRequestedScenePanelTab == tab
+               ? ImGuiTabItemFlags_SetSelected
+               : static_cast<ImGuiTabItemFlags>(0);
+  };
+
   if (ImGui::BeginTabBar("##scene_panel_tabs")) {
-    if (ImGui::BeginTabItem("Scene")) {
+    if (ImGui::BeginTabItem(
+            "Scene", nullptr, tabSelectionFlags(ScenePanelTab::Scene))) {
       renderSceneControlsSection();
       ImGui::EndTabItem();
     }
 
-    if (ImGui::BeginTabItem("Inspector")) {
+    if (ImGui::BeginTabItem(
+            "Inspector",
+            nullptr,
+            tabSelectionFlags(ScenePanelTab::Inspector))) {
       renderInspectorSection();
       ImGui::EndTabItem();
     }
 
-    if (ImGui::BeginTabItem("Tools")) {
+    if (ImGui::BeginTabItem(
+            "Tools", nullptr, tabSelectionFlags(ScenePanelTab::Tools))) {
       renderToolsSection();
       ImGui::EndTabItem();
     }
     ImGui::EndTabBar();
   }
+
+  mHasRequestedScenePanelTab = false;
 }
 
 //==============================================================================

--- a/examples/demos/DemoHost.hpp
+++ b/examples/demos/DemoHost.hpp
@@ -254,9 +254,13 @@ private:
   void renderScenePanel();
   void renderDiagnostics();
   void renderInspectorSection();
+  void renderSceneControlsSection();
+  void renderToolsSection();
+  void renderLogSection(float height);
   void renderViewMenu();
   void invokeKeyAction(KeyAction& action);
   void applyShadowState();
+  void fitCameraToWorld();
 
   std::vector<DemoScene> mScenes;
   std::vector<CategoryGroup> mCategories;

--- a/examples/demos/DemoHost.hpp
+++ b/examples/demos/DemoHost.hpp
@@ -209,6 +209,13 @@ public:
   bool handleKey(int key);
 
 private:
+  enum class ScenePanelTab
+  {
+    Scene,
+    Inspector,
+    Tools
+  };
+
   struct CategoryGroup
   {
     std::string name;
@@ -259,6 +266,7 @@ private:
   void renderLogSection(float height);
   void renderViewMenu();
   void invokeKeyAction(KeyAction& action);
+  void requestScenePanelTab(ScenePanelTab tab);
   void applyShadowState();
   void fitCameraToWorld();
 
@@ -313,6 +321,9 @@ private:
 
   std::string mDebugSelectBodyName;
   bool mDebugRecordProfile = false;
+
+  ScenePanelTab mRequestedScenePanelTab = ScenePanelTab::Scene;
+  bool mHasRequestedScenePanelTab = false;
 };
 
 } // namespace dart_demos

--- a/examples/demos/DragForce.cpp
+++ b/examples/demos/DragForce.cpp
@@ -382,7 +382,9 @@ void DragForce::renderToolbarStatus(double /*guiScale*/) const
 //==============================================================================
 void DragForce::renderTunables(double guiScale)
 {
-  ImGui::SetNextItemWidth(180.0f * static_cast<float>(guiScale));
+  const float width = std::min(
+      180.0f * static_cast<float>(guiScale), ImGui::GetContentRegionAvail().x);
+  ImGui::SetNextItemWidth(width);
   if (ImGui::SliderFloat(
           "Drag coeff",
           &mCoeff,
@@ -392,8 +394,7 @@ void DragForce::renderTunables(double guiScale)
           ImGuiSliderFlags_AlwaysClamp)
       && std::isfinite(mCoeff))
     mCoeff = std::clamp(mCoeff, 1.0f, 2000.0f);
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(180.0f * static_cast<float>(guiScale));
+  ImGui::SetNextItemWidth(width);
   if (ImGui::SliderFloat(
           "Max force",
           &mMaxForce,

--- a/examples/demos/Inspector.cpp
+++ b/examples/demos/Inspector.cpp
@@ -217,12 +217,12 @@ void Inspector::renderJointRow(Joint* joint)
 void Inspector::renderDetail(bool paused, ::osg::Group* worldNode)
 {
   if (!mSelected) {
-    ImGui::TextDisabled("No body selected. Click a body in the tree above.");
+    ImGui::TextWrapped("No body selected. Click a body in the tree above.");
     return;
   }
 
   BodyNode* body = mSelected;
-  ImGui::Text("Body: %s", body->getName().c_str());
+  ImGui::TextWrapped("Body: %s", body->getName().c_str());
 
   const Eigen::Isometry3d worldTf = body->getWorldTransform();
   const Eigen::Isometry3d relTf = body->getRelativeTransform();
@@ -257,7 +257,7 @@ void Inspector::renderDetail(bool paused, ::osg::Group* worldNode)
 
   ImGui::Separator();
   if (auto* joint = body->getParentJoint()) {
-    ImGui::Text(
+    ImGui::TextWrapped(
         "Joint: %s (%s)", joint->getName().c_str(), joint->getType().c_str());
     for (std::size_t i = 0; i < joint->getNumDofs(); ++i) {
       auto* dof = joint->getDof(i);

--- a/examples/demos/Registry.cpp
+++ b/examples/demos/Registry.cpp
@@ -44,6 +44,7 @@ std::vector<DemoScene> makeDemoScenes()
   // docs/dev_tasks/dart6_consolidated_demos/PLAN.md.
   std::vector<DemoScene> scenes;
   scenes.push_back(makeEmptyScene());
+  scenes.push_back(makeHelloWorldScene());
   scenes.push_back(makeSimpleFramesScene());
   scenes.push_back(makeBoxesScene());
   scenes.push_back(makeRigidCubesScene());

--- a/examples/demos/Theme.cpp
+++ b/examples/demos/Theme.cpp
@@ -148,20 +148,20 @@ void applyModernDarkMetrics()
 {
   ImGuiStyle& style = ImGui::GetStyle();
 
-  style.WindowPadding = ImVec2(12.0f, 10.0f);
-  style.FramePadding = ImVec2(8.0f, 5.0f);
-  style.ItemSpacing = ImVec2(9.0f, 7.0f);
-  style.ItemInnerSpacing = ImVec2(6.0f, 5.0f);
-  style.ScrollbarSize = 14.0f;
+  style.WindowPadding = ImVec2(9.0f, 7.0f);
+  style.FramePadding = ImVec2(7.0f, 4.0f);
+  style.ItemSpacing = ImVec2(7.0f, 5.0f);
+  style.ItemInnerSpacing = ImVec2(5.0f, 4.0f);
+  style.ScrollbarSize = 12.0f;
   style.GrabMinSize = 10.0f;
 
-  style.WindowRounding = 7.0f;
-  style.ChildRounding = 5.0f;
-  style.FrameRounding = 5.0f;
-  style.PopupRounding = 5.0f;
-  style.TabRounding = 6.0f;
-  style.ScrollbarRounding = 9.0f;
-  style.GrabRounding = 5.0f;
+  style.WindowRounding = 5.0f;
+  style.ChildRounding = 4.0f;
+  style.FrameRounding = 4.0f;
+  style.PopupRounding = 4.0f;
+  style.TabRounding = 4.0f;
+  style.ScrollbarRounding = 6.0f;
+  style.GrabRounding = 4.0f;
 
   style.WindowBorderSize = 1.0f;
   style.FrameBorderSize = 0.0f;

--- a/examples/demos/main.cpp
+++ b/examples/demos/main.cpp
@@ -45,6 +45,9 @@
 
 namespace {
 
+constexpr int kDefaultWindowWidth = 1600;
+constexpr int kDefaultWindowHeight = 1000;
+
 //==============================================================================
 enum class ParseResult
 {
@@ -64,8 +67,8 @@ struct Options
   std::string shotPath = "dart-demos.png";
   int steps = 150;
   std::string sceneId;
-  int width = 1280;
-  int height = 800;
+  int width = kDefaultWindowWidth;
+  int height = kDefaultWindowHeight;
 
   // Hidden test/debug hooks (undocumented -- not in printUsage()): let a
   // headless --shot capture exercise UI state that normally requires
@@ -95,7 +98,7 @@ void printUsage(const char* prog)
       << "  --steps <n>     Sim steps to settle before the --headless shot "
          "(default 150).\n"
       << "  --width <w> --height <h>  Render/window size (default "
-         "1280x800).\n"
+      << kDefaultWindowWidth << "x" << kDefaultWindowHeight << ").\n"
       << "  --gui-scale <f> Scale the ImGui panels and initial window size "
          "(default 1.0).\n"
       << "  -h, --help      Show this help.\n";

--- a/examples/demos/scenes/AddDeleteSkelsScene.cpp
+++ b/examples/demos/scenes/AddDeleteSkelsScene.cpp
@@ -144,13 +144,12 @@ DemoScene makeAddDeleteSkelsScene()
 
     DemoSceneSetup setup;
     setup.world = world;
-    // Elevated ~49-degree three-quarter view, pulled back far enough that the
-    // whole 4x4 m ground.skel plane (which sits near z = -1) fits as a floor
-    // the cubes drop onto -- the original's low 5,3,3 eye skimmed it nearly
-    // edge-on, and a closer eye pushed the plane's near corner off-screen.
+    // Elevated three-quarter view, pulled back enough for the whole 4x4 m
+    // ground.skel plane and a growing cube pile to remain readable inside the
+    // demo host's center viewport.
     setup.cameraHome = CameraHome{
-        ::osg::Vec3d(4.0, 4.0, 6.0),
-        ::osg::Vec3d(0.0, 0.0, -0.5),
+        ::osg::Vec3d(7.0, 7.0, 8.0),
+        ::osg::Vec3d(0.0, 0.0, 1.0),
         ::osg::Vec3d(0.0, 0.0, 1.0)};
 
     setup.keyActions.push_back(KeyAction{'q', "Spawn cube", [world, state] {

--- a/examples/demos/scenes/HelloWorldScene.cpp
+++ b/examples/demos/scenes/HelloWorldScene.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Mirrored from examples/hello_world: a single free box falling onto a static
+// ground body. The standalone example remains the minimal first-program sample.
+
+#include "Scenes.hpp"
+
+#include <dart/gui/osg/osg.hpp>
+
+#include <dart/dart.hpp>
+
+#include <memory>
+
+namespace dart_demos {
+
+namespace {
+
+//==============================================================================
+dart::dynamics::BodyNode* makeFallingBox(
+    const dart::simulation::WorldPtr& world)
+{
+  auto skeleton = dart::dynamics::Skeleton::create("box");
+  auto pair = skeleton->createJointAndBodyNodePair<dart::dynamics::FreeJoint>();
+  auto* body = pair.second;
+
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() << 0.0, 0.0, 1.0;
+  tf.linear() = dart::math::expMapRot(Eigen::Vector3d::Random());
+  body->getParentJoint()->setTransformFromParentBodyNode(tf);
+
+  auto shapeNode = body->createShapeNodeWith<
+      dart::dynamics::VisualAspect,
+      dart::dynamics::CollisionAspect,
+      dart::dynamics::DynamicsAspect>(
+      std::make_shared<dart::dynamics::BoxShape>(
+          Eigen::Vector3d(0.3, 0.3, 0.3)));
+  body->setInertia(dart::dynamics::Inertia(
+      1.0,
+      Eigen::Vector3d::Zero(),
+      shapeNode->getShape()->computeInertia(1.0)));
+  shapeNode->getVisualAspect()->setColor(dart::Color::Blue());
+
+  world->addSkeleton(skeleton);
+  return body;
+}
+
+//==============================================================================
+void addGround(const dart::simulation::WorldPtr& world)
+{
+  auto ground = dart::dynamics::Skeleton::create("ground");
+  auto* body
+      = ground->createJointAndBodyNodePair<dart::dynamics::WeldJoint>().second;
+  auto shapeNode = body->createShapeNodeWith<
+      dart::dynamics::VisualAspect,
+      dart::dynamics::CollisionAspect,
+      dart::dynamics::DynamicsAspect>(
+      std::make_shared<dart::dynamics::BoxShape>(
+          Eigen::Vector3d(10.0, 10.0, 0.1)));
+  shapeNode->getVisualAspect()->setColor(dart::Color::LightGray());
+
+  world->addSkeleton(ground);
+}
+
+} // namespace
+
+//==============================================================================
+DemoScene makeHelloWorldScene()
+{
+  DemoScene scene;
+  scene.id = "hello_world";
+  scene.title = "Hello World";
+  scene.category = "Getting Started";
+  scene.summary = "A single free box falling onto a static ground body.";
+
+  scene.factory = [] {
+    auto world = dart::simulation::World::create();
+    auto* boxBody = makeFallingBox(world);
+    addGround(world);
+
+    DemoSceneSetup setup;
+    setup.world = world;
+    setup.cameraHome = CameraHome{
+        ::osg::Vec3d(2.57, 3.14, 1.64),
+        ::osg::Vec3d(0.00, 0.00, 0.50),
+        ::osg::Vec3d(-0.24, -0.25, 0.94)};
+
+    setup.renderPanel = [boxBody] {
+      const Eigen::Vector3d p = boxBody->getWorldTransform().translation();
+      ImGui::Text("Box height: %.2f m", p.z());
+      ImGui::Text(
+          "Box velocity: %.2f m/s",
+          boxBody->getSpatialVelocity().tail<3>().z());
+    };
+
+    return setup;
+  };
+
+  return scene;
+}
+
+} // namespace dart_demos

--- a/examples/demos/scenes/Scenes.hpp
+++ b/examples/demos/scenes/Scenes.hpp
@@ -43,6 +43,10 @@ namespace dart_demos {
 /// target, ported from examples/empty.
 [[nodiscard]] DemoScene makeEmptyScene();
 
+/// Getting Started > hello_world: the canonical free-falling box first program,
+/// mirrored from examples/hello_world while keeping that standalone example.
+[[nodiscard]] DemoScene makeHelloWorldScene();
+
 /// Visualization > simple_frames: nested SimpleFrames with ellipsoid markers
 /// and an arrow shape, ported from examples/simple_frames.
 [[nodiscard]] DemoScene makeSimpleFramesScene();


### PR DESCRIPTION
## Summary

- Polish the `dart-demos` host layout so the main 3D viewport has more usable space and side/bottom widgets no longer crowd each other.
- Add compact `DART demos` branding, clearer simulation/render metrics, a lighter 3D viewport background, and a `hello_world` scene in the consolidated catalog.

## Motivation / Problem

The consolidated `dart-demos` host could waste center-view space and let toolbar, inspector, contact visualizer, drag-force, and diagnostics content compete for the same visible area. Some text could overflow narrow widgets, the Add/Delete Skeletons default view did not frame growing piles well, and the top `RTF` label made a catch-up simulation loop look like render-time real-time playback.

The remaining standalone GUI first-program example, `hello_world`, is small enough to mirror inside `dart-demos` while still keeping `examples/hello_world` as the canonical minimal installed-DART consumer sample.

## Changes / Key Changes

- Replace the right-side single scroll panel with `Scene`, `Inspector`, and `Tools` tabs.
- Keep the bottom pane focused on compact diagnostics plus log filtering/log output.
- Make toolbar controls wrap more safely, rename live metrics to `FPS`, `Sim`, and `Steps/frame`, and add a `View > Fit scene` action.
- Tighten ImGui spacing/rounding and wrap/clamp text/widgets that were prone to overflow.
- Use a lighter neutral viewport clear color so the 3D scene area reads separately from the dark UI chrome.
- Broaden the Add/Delete Skeletons default camera view for the full ground plane and growing cube pile.
- Add `hello_world` to the `dart-demos` Getting Started catalog without removing the standalone `examples/hello_world` program.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Main viewport | Left/right/bottom panes consumed more of the first view. | Side panes are narrower, bottom is status/log focused, and the center viewport is larger. |
| Right panel | Inspector, scene controls, and tool widgets stacked together. | `Scene`, `Inspector`, and `Tools` tabs keep frequent controls visible without long collapsible traffic. |
| Bottom panel | Contact visualizer, drag-force, profiler, diagnostics, and log competed for height. | Bottom is compact diagnostics plus a real log region; tools moved to the right-side tab. |
| Top metrics | `RTF` could read as visual playback speed. | `Sim`, `FPS`, and `Steps/frame` separate simulation catch-up from render cadence. |
| GUI example catalog | `hello_world` only existed as a standalone GUI program. | `hello_world` is also browseable from `dart-demos`; standalone first-program sample remains. |

Local visual artifacts inspected:

- `/tmp/dart-demos-default-1600.png`
- `/tmp/dart-demos-debug-inspector.png`
- `/tmp/dart-demos-debug-tools.png`
- `/tmp/dart-demos-pr-hello-world.png`
- `/tmp/dart-demos-pr-add-delete.png`

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run cmake --build build/default/cpp/Release --target dart-demos -j`
- `./build/default/cpp/Release/bin/dart-demos --list-scenes | rg -n "Getting Started|hello_world|Showing"`
- `./build/default/cpp/Release/bin/dart-demos --scene hello_world --headless --shot /tmp/dart-demos-default-1600.png --steps 150` — wrote a `1600 x 1000` PNG using the new default size.
- `./build/default/cpp/Release/bin/dart-demos --scene hello_world --headless --debug-select-body BodyNode --shot /tmp/dart-demos-debug-inspector.png --steps 150` — opened the Inspector tab with the selected body visible.
- `./build/default/cpp/Release/bin/dart-demos --scene hello_world --headless --debug-record-profile --shot /tmp/dart-demos-debug-tools.png --steps 150` — opened the Tools tab with profiler recording visible.
- `./build/default/cpp/Release/bin/dart-demos --scene hello_world --headless --shot /tmp/dart-demos-pr-hello-world.png --steps 150 --width 1280 --height 800`
- `./build/default/cpp/Release/bin/dart-demos --scene add_delete_skels --headless --shot /tmp/dart-demos-pr-add-delete.png --steps 150 --width 1600 --height 1000`
- `./build/default/cpp/Release/bin/dart-demos --cycle-scenes --frames 30` — passed (`32 demo(s) x2`); existing scene warnings about Bullet `PyramidShape` fallback, soft-body fragment normalization, and MJCF inertial inference were printed.
- `git diff --check HEAD`

## Breaking Changes

- [x] None
- UI/example-catalog polish only; no public API, ABI, package component, or dartpy surface change.

## Related Issues / PRs (backports)

- Builds on the consolidated demo host from #3301.
- Follow-up candidate: migrate or extract `examples/contact_benchmark` into the demo surface separately; it is benchmark/CI-load-bearing and not a small catalog registration.

---

#### Checklist

- [x] Milestone set: DART 6.20.0
- [x] CHANGELOG.md updated if required: added DART 6.20.0 entry for #3328.
- [x] Add unit tests for new functionality: N/A, GUI/example behavior verified by headless captures and `--cycle-scenes`.
- [x] Document new methods and classes: N/A, no public API added.
- [x] Add Python bindings (dartpy) if applicable: N/A, no binding changes.
