### PR TITLE
Fix MSVC composite data template ownership

### DIFF
--- a/dart/common/composite.cpp
+++ b/dart/common/composite.cpp
@@ -43,6 +43,13 @@
 namespace dart {
 namespace common {
 
+#if DART_OS_WINDOWS
+template class DART_API
+    detail::ComposeData<detail::CompositeState, detail::GetState>;
+template class DART_API
+    detail::ComposeData<detail::CompositeProperties, detail::GetProperties>;
+#endif
+
 //==============================================================================
 /// Type maps are std::map containers which map an object's Type Info to some
 /// instance or trait of that type. For example, an ObjectMap will map an

--- a/dart/common/detail/composite_data.hpp
+++ b/dart/common/detail/composite_data.hpp
@@ -384,6 +384,11 @@ template <typename... Data>
 using MakeCompositeProperties
     = ComposeData<CompositeProperties, GetProperties, Data...>;
 
+#if DART_OS_WINDOWS
+extern template class ComposeData<CompositeState, GetState>;
+extern template class ComposeData<CompositeProperties, GetProperties>;
+#endif
+
 } // namespace detail
 } // namespace common
 } // namespace dart


### PR DESCRIPTION
## Summary
- explicitly instantiate the zero-aspect composite state/properties template bases in the core DLL on Windows
- declare matching extern templates so component DLLs such as dart-io do not emit duplicate MSVC symbols

## Testing
- pixi run check-lint-cpp
- pixi run cmake --build build/default/cpp/Release --target dart-io --parallel