### PR TITLE
WP-PG.03: add DART 6 profiling guide

### DIFF
--- a/dart/common/Profile.hpp
+++ b/dart/common/Profile.hpp
@@ -85,6 +85,12 @@
 
     #include <cstdint>
     #include <cstring>
+
+    #if defined(TRACY_HAS_CALLSTACK) && defined(TRACY_CALLSTACK)
+      #define DART_PROFILE_TRACY_CALLSTACK_ARG , TRACY_CALLSTACK
+    #else
+      #define DART_PROFILE_TRACY_CALLSTACK_ARG
+    #endif
   #endif
 
   // Built-in text backend (readable console summaries)
@@ -148,8 +154,7 @@ public:
         function,
         std::strlen(function),
         name,
-        std::strlen(name),
-        TRACY_CALLSTACK,
+        std::strlen(name) DART_PROFILE_TRACY_CALLSTACK_ARG,
         true),
       m_text(name, file, line)
     #elif DART_PROFILE_HAS_TRACY
@@ -160,8 +165,7 @@ public:
         function,
         std::strlen(function),
         name,
-        std::strlen(name),
-        TRACY_CALLSTACK,
+        std::strlen(name) DART_PROFILE_TRACY_CALLSTACK_ARG,
         true)
     #elif DART_PROFILE_ENABLE_TEXT
     : m_text(name, file, line)
@@ -185,6 +189,10 @@ private:
 };
 
 } // namespace dart::common::profile::detail
+
+    #if DART_PROFILE_HAS_TRACY
+      #undef DART_PROFILE_TRACY_CALLSTACK_ARG
+    #endif
 
   #endif
 

--- a/docs/dev_tasks/dart6_performance_generalization/06-infra-evidence-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/06-infra-evidence-lane.md
@@ -29,7 +29,7 @@ Everything the other lanes need to measure honestly and hand off cleanly.
 
 #### WP-PG.02 — Extend the contact-container benchmark matrix
 
-- Status: claimed — `wp-pg-02-contact-container-matrix`
+- Status: done — PR #3327 (`wp-pg-02-contact-container-matrix`)
 - Objective: extend `BM_INTEGRATION_contact_container` with fcl/bullet
   engines, a 900-object row, deactivation-enabled variants, and a threads
   sweep, keeping the #3230 dashboard schema stable (additive surfaces
@@ -52,7 +52,7 @@ Everything the other lanes need to measure honestly and hand off cleanly.
 
 #### WP-PG.03 — DART 6 profiling documentation + Tracy config task
 
-- Status: open
+- Status: claimed — `wp-pg-03-profiling-doc`
 - Objective: author `docs/onboarding/profiling.md` **for 6.20** (the main
   doc documents DART 7-only APIs): `dart/common/Profile.hpp` text backend
   (`DART_BUILD_PROFILE`, default ON in the pixi config),
@@ -61,7 +61,8 @@ Everything the other lanes need to measure honestly and hand off cleanly.
   (currently manual reconfigure; note `TRACY_NO_EXIT=1` for short runs).
 - Value: every future perf packet starts with a profile; today the
   instructions live in nobody's head but round-1 history.
-- Scope: docs + pixi.toml task; no C++ change.
+- Scope: docs + pixi.toml task; C++ changes only if required to make the Tracy
+  profile backend build with the packaged DART 6.20 Tracy dependency.
 - Acceptance evidence: doc renders; commands verified end-to-end on a
   clean tree; `pixi run lint` (incl. toml/docs linters) green.
 - Dependencies: none.

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -20,7 +20,7 @@ with the first real SIMD-kernel PR.
 | WS-B ODE backend | 03-ode-backend-lane.md | PG.20–PG.23 | open (PG.20 #3329; PG.21 evidence-gated after span-only PG.20; PG.22 local cpp-only route rejected; PG.23 blocked D8; lane re-review at WS-F phase 5) |
 | WS-C dynamics batching | 04-dynamics-batching-lane.md | PG.30–PG.33 | open (PG.33 gated) |
 | WS-D SIMD enablement | 05-simd-enablement-lane.md | PG.40–PG.42 | active (PG.40 folded into PG.42; PG.41 waits for PG.10 seam evidence) |
-| WS-E infra/evidence | 06-infra-evidence-lane.md | PG.01–PG.04 | open (PG.01 done; PG.02/PG.03 next; PG.04 blocked D4) |
+| WS-E infra/evidence | 06-infra-evidence-lane.md | PG.01–PG.04 | open (PG.01 done; PG.02 #3327; PG.03 claimed; PG.04 blocked D4) |
 | WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phase 1 internal math core merged (#3281); no DART 6 detector adapter or phase-4 broadphase SIMD yet |
 
 ## Packet board
@@ -28,8 +28,8 @@ with the first real SIMD-kernel PR.
 | Packet | Lane | Status | Branch / PR | Evidence |
 | --- | --- | --- | --- | --- |
 | WP-PG.01 baseline packet | WS-E | done — PR pending | `wp-pg-01-baseline-evidence` | 01-baseline-evidence.md (S1–S6 guard rows, profile splits, prior-art triage) |
-| WP-PG.02 benchmark matrix | WS-E | claimed — local | `wp-pg-02-contact-container-matrix` | Active rows now cover DART/ODE/FCL/Bullet at 60/120 objects plus 4-thread sweep; bounded DART/ODE deactivation rows are in the dashboard filter; 900 dense-container rows are registered for manual filters but excluded from the default dashboard slice after local budget smoke |
-| WP-PG.03 profiling doc | WS-E | open | — | — |
+| WP-PG.02 benchmark matrix | WS-E | done — #3327 | `wp-pg-02-contact-container-matrix` / #3327 | Active rows now cover DART/ODE/FCL/Bullet at 60/120 objects plus 4-thread sweep; bounded DART/ODE deactivation rows are in the dashboard filter; 900 dense-container rows are registered for manual filters but excluded from the default dashboard slice after local budget smoke |
+| WP-PG.03 profiling doc | WS-E | claimed — local | `wp-pg-03-profiling-doc` | Adds `docs/onboarding/profiling.md` for the DART 6.20 text profiler and Tracy workflow, a profile-env `config-tracy` task, and the Tracy callstack compatibility fix required by the packaged dependency; local verification passed (`pixi run -e profile config-tracy`, profile `contact_benchmark` build + one-step `--profile` smoke, `UNIT_common_Profile`, docs parse smoke, `pixi run lint`, `pixi run check-lint`) |
 | WP-PG.04 executor tooling | WS-E | blocked (D4) | — | — |
 | WP-PG.10 LCP instrumentation | WS-A | open | — | — |
 | WP-PG.11 solver RTTI removal | WS-A | open | — | Local 2026-07-06 cpp-only mining rejected after refreshed current-base A/B on `2e11928288c`: S2 ODE 0.87x, S4 DART 0.93x, S4 Bullet 0.99x, S4 ODE 0.98x medians; guards identical |

--- a/docs/dev_tasks/dart6_performance_generalization/HANDOFF-wp-pg-20.md
+++ b/docs/dev_tasks/dart6_performance_generalization/HANDOFF-wp-pg-20.md
@@ -1,12 +1,15 @@
 # HANDOFF — WP-PG.20 (ODE contact-history perf) + crash-investigation resolution
 
-**Date:** 2026-07-06 · **Branch:** `wp-pg-20-ode-history-spans` (currently
-merged through `origin/release-6.20` tip `90c1d3bfb6b`) · **For:** any fresh AI
-agent (Codex/Claude/other) resuming this lane.
+**Date:** 2026-07-06 · **Status refresh:** 2026-07-07 · **Branch:**
+`wp-pg-20-ode-history-spans` (merged as PR #3329; current
+`origin/release-6.20` includes it) · **For:** any fresh AI agent
+(Codex/Claude/other) resuming this lane.
 
-This branch's WP-PG.20 code is committed and PR #3329 is open; the remaining
-work is review/CI management and any required evidence refresh after base
-advances. Read this top-to-bottom once, then jump to **§7 "How to resume"**.
+This branch's WP-PG.20 code is merged. The gate and crash-investigation notes
+below are retained as audit history for future ODE work, not as an active PR
+checklist. Read [RESUME.md](RESUME.md) and
+[07-orchestration-dashboard.md](07-orchestration-dashboard.md) for the next
+packet.
 
 ---
 
@@ -187,9 +190,8 @@ is in the scratchpad as `groundtruth.sh`; the older gate logic is in
 the commit and used the now-wrong `stash` approach; use the `checkout`-based
 swap above instead.
 
-For the already-open PR #3329, keep the PR body evidence table current after
-base advances, address review comments, and monitor CI. Merge stays with the
-maintainer.
+PR #3329 is merged. Use the evidence table there as the reference format for
+future performance PRs that change runtime behavior.
 
 ---
 
@@ -233,18 +235,15 @@ maintainer.
 
 ## 7. How to resume (checklist)
 
-1. `git checkout wp-pg-20-ode-history-spans && git pull` (branch is pushed).
-2. Confirm you're off `release-6.20` tip; `pixi run config` then
-   `pixi run cmake --build build/default/cpp/Release --target contact_benchmark BM_INTEGRATION_contact_container --parallel 8`. **Verify both binaries exist**
-   (`ls -x build/default/cpp/Release/bin/{contact_benchmark,BM_INTEGRATION_contact_container}`).
-3. Wait for a quiet host (`pgrep -c cc1plus`≈0). Run **Gate A** (determinism,
-   base vs WP-PG.20 — must be bit-identical) → **Gate B** (lint) → **Gate C**
-   (A/B table) → **Gate D** (crash A/B — required, see §5/§3).
-4. If base advances, refresh the PR body with the 3-column benchmark table
-   context and exact head/base SHAs, then shepherd CI/review. Merge =
-   maintainer.
-5. If Gate A fails (hashes differ): WP-PG.20 changed results — a real bug; debug
-   the span-tracking indices / prune set before shipping.
+1. Start from [RESUME.md](RESUME.md), not the merged WP-PG.20 branch.
+2. Claim the next open packet in
+   [07-orchestration-dashboard.md](07-orchestration-dashboard.md) on a fresh
+   branch from current `origin/release-6.20`.
+3. For any runtime performance PR, copy the #3329 evidence shape: recorded
+   baseline, parent/current-base, PR head, exact commands, guard hashes/counts,
+   and explicit unknowns.
+4. If revisiting WP-PG.21, compare against the merged span-only WP-PG.20
+   baseline and require a fresh current-base matrix before claiming the packet.
 
 ---
 

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -9,15 +9,17 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
 
 ## Next packets
 
-**Current claimed packet: WP-PG.02 — Extend the contact-container benchmark
-matrix** ([06-infra-evidence-lane.md](06-infra-evidence-lane.md)). Claim this
-on `wp-pg-02-contact-container-matrix` off current `origin/release-6.20`;
-do not continue the rejected WP-PG.11 solver branch.
+**Current claimed packet: WP-PG.03 — DART 6 profiling documentation + Tracy
+config task** ([06-infra-evidence-lane.md](06-infra-evidence-lane.md)). Continue
+on `wp-pg-03-profiling-doc` off current `origin/release-6.20`.
 
-Immediate next step: finish verification (`pixi run lint`, `pixi run
-check-lint`, benchmark target build, dashboard dry-run, and merge/preview smoke
-over the emitted JSON). Keep any performance claim out of the PR body unless
-backed by a fresh current-base A/B comparison.
+Immediate next step: open the packet PR after maintainer approval, then monitor
+hosted CI. Local verification already passed (`pixi run -e profile
+config-tracy`, profile `contact_benchmark` build + one-step `--profile` smoke,
+`UNIT_common_Profile`, docs parse smoke, `pixi run lint`, and
+`pixi run check-lint`). This packet is docs/config plus the small Tracy
+callstack compatibility fix required to make the new profile task build; do not
+include performance speedup claims.
 
 **WP-PG.01 is captured** (branch `wp-pg-01-baseline-evidence`, PR
 pending) — guard rows, profile splits, and prior-art triage are in
@@ -28,9 +30,8 @@ many-islands regime is ~50% integration (WS-C is the lever there).
 
 Claimable now, in priority order:
 
-1. **WP-PG.02** (WS-E — benchmark matrix coverage for honest future A/B).
-2. **WP-PG.03** (WS-E — profiling doc and Tracy config).
-3. **WP-PG.21** only if a new current-base profile justifies revisiting the
+1. **WP-PG.03** (WS-E — profiling doc and Tracy config; currently claimed).
+2. **WP-PG.21** only if a new current-base profile justifies revisiting the
    ODE active path. WP-PG.20 is #3329 and intentionally stayed span-only
    after the map/pruning variant showed small-row overhead; WP-PG.22 and
    WP-PG.11 both have local current-base rejection evidence from 2026-07-06.
@@ -113,6 +114,16 @@ decisions.
   dashboard slice after local smoke runs exceeded the runtime budget.
   Artifacts: `/tmp/wp_pg02_contact_container_deactivation_rows.json`,
   `/tmp/wp_pg02_contact_container_active_fcl_bullet_smoke.json`.
+- 2026-07-07: WP-PG.02 merged as #3327. WP-PG.03 claimed on
+  `wp-pg-03-profiling-doc` to promote the DART 6.20 profiling workflow into
+  `docs/onboarding/profiling.md` and add the profile-env Tracy configure task.
+  End-to-end profile build exposed an existing `TRACY_CALLSTACK` compatibility
+  bug in `dart/common/Profile.hpp`; the branch fixes it by using Tracy's
+  callstack constructor only when the packaged header exposes the callstack
+  macro. Local verification passed: `pixi run -e profile config-tracy`, profile
+  `contact_benchmark` build + one-step `--profile` smoke,
+  `UNIT_common_Profile`, docs parse smoke, `pixi run lint`, and
+  `pixi run check-lint`.
 
 ## Session log
 

--- a/docs/onboarding/profiling.md
+++ b/docs/onboarding/profiling.md
@@ -1,0 +1,127 @@
+# Profiling DART 6.20
+
+Use profiling to find the hot path before changing performance-sensitive code,
+then use the benchmark and determinism gates to prove the change. Profiling
+output is explanatory evidence; it does not replace a before/after benchmark
+matrix with matching guard hashes.
+
+## Built-in Text Profiler
+
+DART 6.20 has the `dart/common/Profile.hpp` front end. The default Pixi
+configure task builds it in:
+
+```bash
+pixi run config
+```
+
+That task passes `-DDART_BUILD_PROFILE=ON`; the built-in text backend is ON by
+default through `DART_PROFILE_BUILTIN=ON`. When `DART_BUILD_PROFILE=OFF`, the
+`DART_PROFILE_*` macros compile to no-ops.
+
+For contact-workload profiling, build the benchmark target and run it with
+`--profile`:
+
+```bash
+pixi run cmake --build build/default/cpp/Release \
+  --target contact_benchmark --parallel 8
+
+CB=./build/default/cpp/Release/bin/contact_benchmark
+pixi run $CB --generate-container 120 --steps 200 --checkpoint 0 \
+  --collision dart --disable-deactivation --world-threads 1 \
+  --max-contacts 20000 --max-contacts-per-pair 4 --quiet --profile
+```
+
+`--profile` resets the profiler before the measured run and prints the text
+summary at exit. Use the same scene, solver, detector, contact caps, thread
+count, and commit scope as the benchmark row you are investigating.
+
+## Adding Scopes
+
+Use named scopes where the summary would otherwise be ambiguous:
+
+```cpp
+#include <dart/common/Profile.hpp>
+
+void stepSomething()
+{
+  DART_PROFILE_SCOPED_N("stepSomething");
+  // Work to measure.
+}
+```
+
+Use `DART_PROFILE_FRAME` once per simulation frame when frame counts matter.
+For tools that need to control the text backend directly, use:
+
+```cpp
+dart::common::profile::resetProfile();
+dart::common::profile::markProfileFrame();
+dart::common::profile::printProfileSummary(std::cout);
+const auto text = dart::common::profile::getProfileSummaryText();
+```
+
+Keep scopes coarse enough to answer a packet question. If a scope is only
+useful during local diagnosis and would add noise to normal summaries, remove
+it before the PR.
+
+## Tracy
+
+The Tracy backend is opt-in. Configure a Tracy-enabled build from the profile
+environment:
+
+```bash
+pixi run -e profile config-tracy
+pixi run -e profile cmake --build build/profile/cpp/Release \
+  --target contact_benchmark --parallel 8
+```
+
+`config-tracy` enables `DART_BUILD_PROFILE=ON`, keeps the text backend enabled,
+sets `DART_PROFILE_TRACY=ON`, and uses the system Tracy package from the Pixi
+profile environment. The build directory is `build/profile/cpp/Release`.
+
+Start the viewer in a separate terminal:
+
+```bash
+pixi run -e profile tracy
+```
+
+For short-lived command-line runs, keep the process alive long enough for Tracy
+to connect:
+
+```bash
+TRACY_NO_EXIT=1 pixi run -e profile ./build/profile/cpp/Release/bin/contact_benchmark \
+  --generate-container 120 --steps 200 --checkpoint 0 --collision dart \
+  --disable-deactivation --world-threads 1 --max-contacts 20000 \
+  --max-contacts-per-pair 4 --quiet --profile
+```
+
+Use Tracy to locate and understand hot regions. Do not use a Tracy-connected
+run as the acceptance timing for a performance PR; run the normal Release
+before/after matrix separately.
+
+## Reporting
+
+Every performance PR should record:
+
+- exact commit SHAs for the recorded baseline, parent/current base, and PR head;
+- exact configure, build, benchmark, and profile commands;
+- compiler, CPU model, governor/scaling state, Pixi environment, and optional
+  detector availability;
+- profile summary lines that explain the chosen optimization target;
+- the full benchmark evidence table with contacts, pairs, resting counts,
+  cap-hit status, and final-state hashes where applicable.
+
+For `contact_benchmark` rows using ODE, keep `--max-contacts-per-pair 4`; larger
+caps measure a different detector behavior on this branch.
+
+## Troubleshooting
+
+- Empty text summaries usually mean the binary was not rebuilt after enabling
+  `DART_BUILD_PROFILE`, or the tool did not print the summary. For
+  `contact_benchmark`, include `--profile`.
+- If Tracy headers or packages are missing, use the profile environment:
+  `pixi run -e profile config-tracy`.
+- If a short run exits before the Tracy viewer captures it, set
+  `TRACY_NO_EXIT=1`.
+- Reconfigure when switching between default and Tracy builds. They use
+  separate Pixi environment build directories, so stale binaries are easy to
+  spot by path.

--- a/pixi.toml
+++ b/pixi.toml
@@ -1084,6 +1084,25 @@ tracy-profiler-client = ">=0.11.1,<0.12"
 tracy-profiler-gui = ">=0.11.1,<0.12"
 
 [feature.profile.tasks]
+config-tracy = { cmd = """
+    cmake \
+        -G Ninja \
+        -S . \
+        -B build/$PIXI_ENVIRONMENT_NAME/cpp/$BUILD_TYPE \
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+        -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+        -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
+        -DDART_DISABLE_COMPILER_CACHE=$DART_DISABLE_COMPILER_CACHE \
+        -DDART_BUILD_DARTPY=ON \
+        -DDART_BUILD_PROFILE=ON \
+        -DDART_PROFILE_BUILTIN=ON \
+        -DDART_PROFILE_TRACY=ON \
+        -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
+        -DDART_USE_SYSTEM_GOOGLETEST=ON \
+        -DDART_USE_SYSTEM_IMGUI=ON \
+        -DDART_USE_SYSTEM_TRACY=ON \
+        -DDART_VERBOSE=$DART_VERBOSE
+""", env = { DART_VERBOSE = "OFF", BUILD_TYPE = "Release" } }
 tracy = { cmd = "tracy-profiler" }
 
 [feature.profile.target.win-64.tasks]


### PR DESCRIPTION
## Summary

- Add a DART 6.20 profiling guide for the built-in text profiler, `contact_benchmark --profile`, and the opt-in Tracy workflow.
- Add a `pixi run -e profile config-tracy` task so Tracy-enabled local profiling is a one-command configure path.
- Fix the Tracy profile wrapper to build with packaged Tracy headers that do not define `TRACY_CALLSTACK`.
- Reconcile the DART 6 performance-generalization tracker after WP-PG.02 (#3327) and WP-PG.20 (#3329) merged.

## Motivation / Problem

Future DART 6.20 performance packets need a repeatable profile-first workflow before making benchmark claims. The profiling instructions were still scattered across task history, and Tracy required a manual configure command. End-to-end validation of the new Tracy task exposed an existing profile-backend build issue: `dart/common/Profile.hpp` unconditionally passed `TRACY_CALLSTACK`, but the packaged Tracy 0.11 headers only expose that constructor when callstack support is enabled.

This PR is a profiling workflow and build-enablement packet. It does not claim a runtime performance improvement.

## Changes / Key Changes

- Adds `docs/onboarding/profiling.md` with DART 6.20-specific text profiler, scope, Tracy, reporting, and troubleshooting guidance.
- Adds the profile-environment `config-tracy` Pixi task with `DART_PROFILE_TRACY=ON` and the text backend kept enabled.
- Makes `Profile.hpp` use Tracy's callstack constructor only when `TRACY_HAS_CALLSTACK` and `TRACY_CALLSTACK` are both available.
- Marks WP-PG.02 as done via #3327, keeps WP-PG.20 as merged audit history, and marks WP-PG.03 claimed with local verification evidence.

## Before / After

| Surface | Before | After |
| --- | --- | --- |
| DART 6.20 profiling guidance | Lived in dev-task history and local knowledge | Durable onboarding guide at `docs/onboarding/profiling.md` |
| Tracy configure path | Manual CMake flags | `pixi run -e profile config-tracy` |
| Packaged Tracy 0.11 profile build | Failed when `TRACY_CALLSTACK` was not defined | Uses the no-callstack `tracy::ScopedZone` constructor when needed |
| Performance tracker | WP-PG.02 still looked claimed/local; WP-PG.20 handoff still read like an active PR checklist | WP-PG.02/#3327 and WP-PG.20/#3329 are reconciled; WP-PG.03 is the active local packet |

## Testing

- `pixi run lint`
- `pixi run check-lint`
- `pixi run cmake --build build/default/cpp/Release --target UNIT_common_Profile --parallel 8`
- `pixi run ctest --test-dir build/default/cpp/Release -R '^UNIT_common_Profile$' --output-on-failure`
- `pixi run -e profile config-tracy`
- `pixi run -e profile cmake --build build/profile/cpp/Release --target contact_benchmark --parallel 8`
- `pixi run -e profile ./build/profile/cpp/Release/bin/contact_benchmark --generate-objects 1 --steps 1 --warmup 0 --checkpoint 0 --quiet --collision dart --profile`
- Markdown parse smoke for `docs/onboarding/profiling.md`
- `git diff --check`

## Breaking Changes

- [x] None
- Profiling remains opt-in for Tracy and default-enabled only for the existing text backend in the Pixi configure path. No public DART API, ABI, package component, simulation behavior, or dartpy surface changes.

## Related Issues / PRs (backports)

- Part of #3056.
- Follows WP-PG.02 #3327 and WP-PG.20 #3329.
- No separate backport PR: this targets `release-6.20` directly.

---

#### Checklist

- [x] Milestone set: DART 6.20.0
- [x] CHANGELOG.md updated if required (not required: contributor profiling workflow and opt-in profiling-build fix; no public API/package/runtime behavior change)
- [x] Add unit tests for new functionality (covered by existing `UNIT_common_Profile` plus Tracy profile build/smoke)
- [x] Document new methods and classes (N/A: no new public methods/classes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no dartpy changes)
