### PR TITLE
Fix MSVC ComposeData template ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,6 +368,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Restored MSVC `dart-io` shared-library builds when parser code uses empty
   `Composite::Properties` data by keeping zero-aspect composite-data template
   members owned by the exported `dart` instantiation.
+  ([#3340](https://github.com/dartsim/dart/pull/3340))
 - Added a `DART_USE_SYSTEM_FMT` CMake option (default ON) that falls back to a
   FetchContent source build of fmt when set OFF, so source and container builds
   keep working when a distro's packaged fmt CMake config is broken; the Alt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,9 @@ compatibility remains on the active DART 6 LTS branch._
 - Fixed DART 7 Windows dartpy wheel links against conda-forge libcurl/libpsl
   metadata by pruning Unix-only `libm` entries from imported MSVC CMake target
   interfaces. ([#3282](https://github.com/dartsim/dart/pull/3282))
+- Restored MSVC `dart-io` shared-library builds when parser code uses empty
+  `Composite::Properties` data by keeping zero-aspect composite-data template
+  members owned by the exported `dart` instantiation.
 - Added a `DART_USE_SYSTEM_FMT` CMake option (default ON) that falls back to a
   FetchContent source build of fmt when set OFF, so source and container builds
   keep working when a distro's packaged fmt CMake config is broken; the Alt

--- a/dart/common/detail/composite_data.hpp
+++ b/dart/common/detail/composite_data.hpp
@@ -187,26 +187,85 @@ template <
 class ComposeData
 {
 public:
-  ComposeData() = default;
+  ComposeData();
 
-  ComposeData(const CompositeType&)
-  {
-    // Do nothing
-  }
+  ComposeData(const ComposeData&);
 
-  virtual ~ComposeData() = default;
+  ComposeData& operator=(const ComposeData&);
 
-  void setFrom(const CompositeType&)
-  {
-    // Do nothing
-  }
+  ComposeData(const CompositeType&);
+
+  virtual ~ComposeData();
+
+  void setFrom(const CompositeType&);
 
 protected:
-  void _addData(CompositeType&) const
-  {
-    // Do nothing
-  }
+  void _addData(CompositeType&) const;
 };
+
+//==============================================================================
+template <
+    class CompositeType,
+    template <class> class GetData,
+    typename... Aspects>
+ComposeData<CompositeType, GetData, Aspects...>::ComposeData() = default;
+
+//==============================================================================
+template <
+    class CompositeType,
+    template <class> class GetData,
+    typename... Aspects>
+ComposeData<CompositeType, GetData, Aspects...>::ComposeData(const ComposeData&)
+    = default;
+
+//==============================================================================
+template <
+    class CompositeType,
+    template <class> class GetData,
+    typename... Aspects>
+ComposeData<CompositeType, GetData, Aspects...>&
+ComposeData<CompositeType, GetData, Aspects...>::operator=(const ComposeData&)
+    = default;
+
+//==============================================================================
+template <
+    class CompositeType,
+    template <class> class GetData,
+    typename... Aspects>
+ComposeData<CompositeType, GetData, Aspects...>::ComposeData(
+    const CompositeType&)
+{
+  // Do nothing
+}
+
+//==============================================================================
+template <
+    class CompositeType,
+    template <class> class GetData,
+    typename... Aspects>
+ComposeData<CompositeType, GetData, Aspects...>::~ComposeData() = default;
+
+//==============================================================================
+template <
+    class CompositeType,
+    template <class> class GetData,
+    typename... Aspects>
+void ComposeData<CompositeType, GetData, Aspects...>::setFrom(
+    const CompositeType&)
+{
+  // Do nothing
+}
+
+//==============================================================================
+template <
+    class CompositeType,
+    template <class> class GetData,
+    typename... Aspects>
+void ComposeData<CompositeType, GetData, Aspects...>::_addData(
+    CompositeType&) const
+{
+  // Do nothing
+}
 
 //==============================================================================
 template <


### PR DESCRIPTION
## Summary

- Restores main-branch MSVC `dart-io` shared-library builds by preventing empty `Composite::Properties` `ComposeData` members from being emitted in parser objects.
- Keeps zero-aspect `ComposeData` special members out of the class body so the existing Windows explicit instantiations own those symbols.

## Motivation / Problem

- `CI Windows / Tests (Release)` failed while linking `dart-io.dll` on `main` with `LNK2005` duplicate `ComposeData<CompositeProperties, GetProperties>` constructor, destructor, and copy-constructor symbols between `dart.lib` and `urdf_parser.obj`.
- The previous explicit-instantiation fix exported the right concrete templates, but the zero-aspect base case still defined its special members inline in the header, so MSVC could emit those members from an importing object as well.

## Changes / Key Changes

- Declares the zero-aspect `ComposeData` special members and no-op helper methods in the class body.
- Defines those members out of line in the template header, matching the repository's existing Windows `extern template` ownership pattern.
- Adds a DART 7 changelog entry for the Windows `dart-io` build fix.

## Testing

- `cmake --build build/default/cpp/Release --target dart-io --parallel 4`
- `pixi run check-lint-cpp`
- `pixi run check-lint-md`
- `pixi run lint`
- Checked the failing job log for https://github.com/dartsim/dart/actions/runs/28893973972/job/85729567365 and confirmed the failure signature was the MSVC duplicate `ComposeData<CompositeProperties, GetProperties>` symbols during `dart-io.dll` link.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3335.
- Fixes the main-branch CI failure in https://github.com/dartsim/dart/actions/runs/28893973972/job/85729567365.
- No DART 6 LTS backport: `release-6.20` uses the DART 6 PascalCase composite files and does not have the Windows zero-aspect `extern template` ownership change that introduced this duplicate-symbol path.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [ ] Add unit tests for new functionality
- [ ] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable

N/A checklist notes: no new runtime behavior, public APIs, documentation-only methods/classes, or dartpy bindings are added.

Changelog decision:

- Mode: finalize
- Base evidence: `origin/main` at `59ba88d8e25`, merged into `fix/main-composedata-msvc-link`
- Scope evidence: PR diff contains `dart/common/detail/composite_data.hpp` and `CHANGELOG.md`; failing Windows job `85729567365` links `dart-io.dll` with duplicate zero-aspect `ComposeData<CompositeProperties, GetProperties>` symbols
- Decision: entry required
- Target section: `CHANGELOG.md` -> DART 7 -> Build, Packaging, and Developer Tooling
- Entry text: Restored MSVC `dart-io` shared-library builds when parser code uses empty `Composite::Properties` data by keeping zero-aspect composite-data template members owned by the exported `dart` instantiation. ([#3340](https://github.com/dartsim/dart/pull/3340))
- PR-body note: `CHANGELOG.md` updated with the PR link.
- Follow-up: none
