### PR TITLE
WP-PG.31: skip unused shallow-support pass

### DIFF
--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -549,6 +549,19 @@ void World::syncShallowSupportFreeRootVelocityStates()
 }
 
 //==============================================================================
+bool World::hasAnyShallowSupportFreeRootCandidate() const
+{
+  for (const auto& skeleton : mSkeletons) {
+    if (skeleton && skeleton->isMobile()
+        && skeleton->getCachedRootFreeJoint() != nullptr) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+//==============================================================================
 const std::vector<World::FreeRootVelocitySnapshot>&
 World::snapshotFreeRootVelocities()
 {
@@ -1278,18 +1291,28 @@ void World::step(bool _resetCommand)
           });
     }
 
-    const auto& preSolveFreeRootVelocities = snapshotFreeRootVelocities();
+    const bool hasShallowSupportFreeRootCandidate
+        = hasAnyShallowSupportFreeRootCandidate();
+    if (!hasShallowSupportFreeRootCandidate)
+      mPreSolveFreeRootVelocityScratch.clear();
+    const auto& preSolveFreeRootVelocities
+        = hasShallowSupportFreeRootCandidate ? snapshotFreeRootVelocities()
+                                             : mPreSolveFreeRootVelocityScratch;
 
     {
       mConstraintSolver->solve();
     }
 
-    findShallowSupportedFreeRoots(
-        mSkeletons,
-        mConstraintSolver->getLastCollisionResult(),
-        mGravity,
-        mShallowSupportedFreeRootScratch,
-        mSkeletonIndexScratch);
+    if (hasShallowSupportFreeRootCandidate) {
+      findShallowSupportedFreeRoots(
+          mSkeletons,
+          mConstraintSolver->getLastCollisionResult(),
+          mGravity,
+          mShallowSupportedFreeRootScratch,
+          mSkeletonIndexScratch);
+    } else {
+      mShallowSupportedFreeRootScratch.clear();
+    }
     clearUnsupportedShallowSupportFreeRootVelocityStates(
         mShallowSupportedFreeRootScratch, preSolveFreeRootVelocities);
 
@@ -1441,19 +1464,29 @@ void World::step(bool _resetCommand)
         });
   }
 
-  const auto& preSolveFreeRootVelocities = snapshotFreeRootVelocities();
+  const bool hasShallowSupportFreeRootCandidate
+      = hasAnyShallowSupportFreeRootCandidate();
+  if (!hasShallowSupportFreeRootCandidate)
+    mPreSolveFreeRootVelocityScratch.clear();
+  const auto& preSolveFreeRootVelocities
+      = hasShallowSupportFreeRootCandidate ? snapshotFreeRootVelocities()
+                                           : mPreSolveFreeRootVelocityScratch;
 
   // Detect activated constraints and compute constraint impulses
   {
     mConstraintSolver->solve();
   }
 
-  findShallowSupportedFreeRoots(
-      mSkeletons,
-      mConstraintSolver->getLastCollisionResult(),
-      mGravity,
-      mShallowSupportedFreeRootScratch,
-      mSkeletonIndexScratch);
+  if (hasShallowSupportFreeRootCandidate) {
+    findShallowSupportedFreeRoots(
+        mSkeletons,
+        mConstraintSolver->getLastCollisionResult(),
+        mGravity,
+        mShallowSupportedFreeRootScratch,
+        mSkeletonIndexScratch);
+  } else {
+    mShallowSupportedFreeRootScratch.clear();
+  }
   clearUnsupportedShallowSupportFreeRootVelocityStates(
       mShallowSupportedFreeRootScratch, preSolveFreeRootVelocities);
 

--- a/dart/simulation/World.hpp
+++ b/dart/simulation/World.hpp
@@ -504,6 +504,10 @@ protected:
   /// Synchronizes shallow-support velocity state with mSkeletons.
   void syncShallowSupportFreeRootVelocityStates();
 
+  /// Returns true if the shallow-support velocity correction pass can affect
+  /// at least one current skeleton.
+  bool hasAnyShallowSupportFreeRootCandidate() const;
+
   /// Captures free-root velocities immediately before the constraint solve.
   const std::vector<FreeRootVelocitySnapshot>& snapshotFreeRootVelocities();
 

--- a/docs/dev_tasks/dart6_performance_generalization/02-constraint-lcp-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/02-constraint-lcp-lane.md
@@ -17,7 +17,7 @@ final-state hashes on all guard scenes for default-on packets.
 
 #### WP-PG.10 — LCP pipeline instrumentation and island census
 
-- Status: claimed — `wp-pg-10-lcp-profile-census`
+- Status: done — #3339 (`wp-pg-10-lcp-profile-census`)
 - Objective: add missing `DART_PROFILE_*` scopes so assembly vs solve vs
   build split is measurable per island, and emit an island-size histogram
   (bodies, contacts, LCP rows) from `contact_benchmark --profile` runs.

--- a/docs/dev_tasks/dart6_performance_generalization/04-dynamics-batching-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/04-dynamics-batching-lane.md
@@ -47,17 +47,25 @@ the same versions/dirty flags the scalar path does, or sleeping breaks.
 
 #### WP-PG.31 — Scratch retention for shallow-support machinery
 
-- Status: open
-- Objective: reuse member buffers for
-  `findShallowSupportedFreeRoots`' map+vector and
-  `snapshotFreeRootVelocities`' vector, and skip the pass entirely when
-  no skeleton qualifies (using WP-PG.30's classification).
-- Value: removes per-step allocations added by #3227 on every world;
-  zero behavior risk.
-- Scope: `dart/simulation/World.*` cpp + private members.
-- Acceptance evidence: bit-identical everything; allocation-count delta
-  (measure with the WP-PG.32 gate tooling if landed, else heaptrack row).
-- Dependencies: WP-PG.30 (for the skip), else standalone buffer reuse.
+- Status: local verified — `wp-pg-31-shallow-support-scratch`
+- Objective: current `release-6.20` already retains the
+  `findShallowSupportedFreeRoots` and `snapshotFreeRootVelocities` scratch
+  buffers; finish the packet by skipping the shallow-support snapshot/find pass
+  entirely when no mobile root-FreeJoint skeleton can use it.
+- Value: removes unconditional per-step work added by #3227 on articulated or
+  fixed-root worlds while preserving the existing cleanup pass that clears stale
+  shallow-support state after topology/mobile-state changes.
+- Scope: `dart/simulation/World.*` helper and step-path call sites.
+- Acceptance evidence: current-base A/B artifact
+  `/tmp/wp_pg31_ab_20260707T184319` on base `3964108a675` vs branch
+  `21f691311df`: `double_pendulum.world` hashes identical
+  (`0x1db838038acbd960`) with median step time 0.002106 -> 0.001836 ms
+  (DART) and 0.001903 -> 0.001644 ms (ODE); generated 120-object DART/ODE
+  guard hashes identical (`0x3bd9d26da5ea002b`,
+  `0x5576f6244b736aae`); `BM_ContactContainerActive/120/1/{1,16}` ODE medians
+  6588 -> 6433 ms and 6998 -> 6468 ms; base and branch both passed 30/30
+  default 16-thread crash stressors.
+- Dependencies: WP-PG.30.
 
 #### WP-PG.32 — Frame-arena allocation discipline + CI allocation gate
 

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -16,9 +16,9 @@ with the first real SIMD-kernel PR.
 
 | Lane | Owner doc | Packets | Status |
 | --- | --- | --- | --- |
-| WS-A constraint/LCP | 02-constraint-lcp-lane.md | PG.10–PG.15 | active (PG.10 claimed; PG.13 evidence-gated; PG.14 blocked D3; PG.15 blocked D7) |
+| WS-A constraint/LCP | 02-constraint-lcp-lane.md | PG.10–PG.15 | active (PG.10 #3339; PG.13 evidence-gated; PG.14 blocked D3; PG.15 blocked D7) |
 | WS-B ODE backend | 03-ode-backend-lane.md | PG.20–PG.23 | open (PG.20 #3329; PG.21 current-base gate rejected after span-only PG.20; PG.22 local cpp-only route rejected; PG.23 blocked D8; lane re-review at WS-F phase 5) |
-| WS-C dynamics batching | 04-dynamics-batching-lane.md | PG.30–PG.33 | open (PG.33 gated) |
+| WS-C dynamics batching | 04-dynamics-batching-lane.md | PG.30–PG.33 | active (PG.31 claimed; PG.33 gated) |
 | WS-D SIMD enablement | 05-simd-enablement-lane.md | PG.40–PG.42 | active (PG.40 folded into PG.42; PG.41 waits for PG.10 seam evidence) |
 | WS-E infra/evidence | 06-infra-evidence-lane.md | PG.01–PG.04 | open (PG.01 done; PG.02 #3327; PG.03 #3337; PG.04 blocked D4) |
 | WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phase 1 internal math core merged (#3281); no DART 6 detector adapter or phase-4 broadphase SIMD yet |
@@ -31,7 +31,7 @@ with the first real SIMD-kernel PR.
 | WP-PG.02 benchmark matrix | WS-E | done — #3327 | `wp-pg-02-contact-container-matrix` / #3327 | Active rows now cover DART/ODE/FCL/Bullet at 60/120 objects plus 4-thread sweep; bounded DART/ODE deactivation rows are in the dashboard filter; 900 dense-container rows are registered for manual filters but excluded from the default dashboard slice after local budget smoke |
 | WP-PG.03 profiling doc | WS-E | done — #3337 | `wp-pg-03-profiling-doc` / #3337 | Adds `docs/onboarding/profiling.md` for the DART 6.20 text profiler and Tracy workflow, a profile-env `config-tracy` task, and the Tracy callstack compatibility fix required by the packaged dependency; merged 2026-07-07 |
 | WP-PG.04 executor tooling | WS-E | blocked (D4) | — | — |
-| WP-PG.10 LCP instrumentation | WS-A | claimed — local verified | `wp-pg-10-lcp-profile-census` | Adds runtime-gated text-profiler counters for constrained-group island census plus solver/LCP stage scopes. Local profile artifact `/tmp/wp_pg10_profile_20260707T132241`: S1 dense container is solve-proper dominated (primary solve 90.0%, construct 5.69%, one 816-row island); S3 active 3k has 3003 islands / 15015 rows with build 5.44%, construct 0.89%, primary solve 1.02%; S4/S5 generated scenes have 900/90 islands and max 12-row groups. Final local gates passed lint/check-lint, profile smoke, allocation gate, capped `ALL`, and `test-gz` |
+| WP-PG.10 LCP instrumentation | WS-A | done — #3339 | `wp-pg-10-lcp-profile-census` / #3339 | Adds runtime-gated text-profiler counters for constrained-group island census plus solver/LCP stage scopes. Local profile artifact `/tmp/wp_pg10_profile_20260707T132241`: S1 dense container is solve-proper dominated (primary solve 90.0%, construct 5.69%, one 816-row island); S3 active 3k has 3003 islands / 15015 rows with build 5.44%, construct 0.89%, primary solve 1.02%; S4/S5 generated scenes have 900/90 islands and max 12-row groups. Final local gates passed lint/check-lint, profile smoke, allocation gate, capped `ALL`, and `test-gz`; merged 2026-07-08 |
 | WP-PG.11 solver RTTI removal | WS-A | open | — | Local 2026-07-06 cpp-only mining rejected after refreshed current-base A/B on `2e11928288c`: S2 ODE 0.87x, S4 DART 0.93x, S4 Bullet 0.99x, S4 ODE 0.98x medians; guards identical |
 | WP-PG.12 direct assembly | WS-A | deprioritized (PG.01 evidence: assembly ≤ ~8%) | — | — |
 | WP-PG.13 row islanding | WS-A | evidence-gated (PG.10 census) | — | — |
@@ -42,7 +42,7 @@ with the first real SIMD-kernel PR.
 | WP-PG.22 version-gated pose push | WS-B | open | — | Local 2026-07-06 exact-transform fallback rejected by A/B; protected kinematic version blocks cpp-only route |
 | WP-PG.23 ODE manifold reduction | WS-B | blocked (D8) | — | — |
 | WP-PG.30 free-body cache + FD path | WS-C | done — PR #3310 | `wp-pg-30-single-free-body-cache` | A/B: S5 −12.2%, S4 −5.3%, S3 −2.3%, solve-bound rows flat; 8/8 guard hashes bit-identical |
-| WP-PG.31 shallow-support scratch | WS-C | open | — | — |
+| WP-PG.31 shallow-support scratch | WS-C | local verified | `wp-pg-31-shallow-support-scratch` | Current-base A/B artifact `/tmp/wp_pg31_ab_20260707T184319` (`3964108a675` -> `21f691311df`): no-root-FreeJoint `double_pendulum.world` hashes identical and median step time improved 0.002106 -> 0.001836 ms (DART), 0.001903 -> 0.001644 ms (ODE); generated 120-object DART/ODE guard hashes identical; ODE `BM_ContactContainerActive/120/1/{1,16}` medians 6588 -> 6433 ms and 6998 -> 6468 ms; base and branch both passed 30/30 default 16-thread crash stressors |
 | WP-PG.32 frame arena + alloc gate | WS-C | open | — | — |
 | WP-PG.33 SoA integration | WS-C | gated | — | — |
 | WP-PG.40 FP/ISA contracts | WS-D | folded into WP-PG.42 | #3270 closed | maintainer direction: carry D1/D2 evidence with actual SIMD kernel PR |

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -9,23 +9,16 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
 
 ## Next packets
 
-**Current claimed packet: WP-PG.10 — LCP pipeline instrumentation and island
-census** ([02-constraint-lcp-lane.md](02-constraint-lcp-lane.md)). Continue on
-`wp-pg-10-lcp-profile-census` off current `origin/release-6.20`.
+**Current claimed packet: WP-PG.31 — shallow-support scratch retention**
+([04-dynamics-batching-lane.md](04-dynamics-batching-lane.md)). Continue on
+`wp-pg-31-shallow-support-scratch` off current `origin/release-6.20`.
 
-Immediate next step: open the packet PR after maintainer approval. The branch
-adds fixed-label text-profiler counters for constrained-group island census,
-solver/LCP stage scopes, and a runtime profile-recording gate so ordinary
-`World::step()` execution remains allocation-neutral when profiling is compiled
-in but not requested. Local profile artifact
-`/tmp/wp_pg10_profile_20260707T132241` captured S1-S5 native rows; guard
-artifact `/tmp/wp_pg10_guard_20260707T132321` captured S1 120-object dart/ode
-rows and S2-S5 all-detector rows. The FCL generated-scene guard drift (`S4_fcl`,
-`S5_fcl`) reproduces on the unmodified current base, so it is not a WP-PG.10
-regression. Final local verification passed `pixi run lint`,
-`pixi run check-lint`, capped `ALL`, profile smoke, `UNIT_common_Profile`,
-`INTEGRATION_StepAllocation`, and
-`DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz`.
+Immediate next step: run the final local lint/test refresh, then open the PR.
+The old `pr-c-pg31-scratch-retention.patch` was treated as a reference snapshot
+only. Current `release-6.20` already retains the member scratch buffers, so the
+branch implements the remaining no-candidate skip and preserves stale-state
+cleanup. Current-base A/B and the old 16-thread heap-crash gate are recorded in
+the 2026-07-08 session log entry below.
 
 **WP-PG.01 is captured** (branch `wp-pg-01-baseline-evidence`, PR
 pending) — guard rows, profile splits, and prior-art triage are in
@@ -36,9 +29,9 @@ many-islands regime is ~50% integration (WS-C is the lever there).
 
 Claimable now, in priority order:
 
-1. **WP-PG.10** (WS-A — LCP instrumentation and island census; currently
-   claimed).
-2. **WP-PG.31** or **WP-PG.32** only after WP-PG.10 lands or if maintainer
+1. **WP-PG.31** (WS-C — shallow-support scratch retention; locally verified,
+   PR pending).
+2. **WP-PG.32** only after WP-PG.31 lands or if maintainer
    explicitly prioritizes allocation work. WP-PG.20 is #3329; WP-PG.21 failed
    the 2026-07-07 current-base map/pruning gate; WP-PG.22 and WP-PG.11 both
    have local current-base rejection evidence from 2026-07-06.
@@ -152,6 +145,20 @@ decisions.
   Final verification passed lint/check-lint, capped `ALL` (144/144 C++ tests,
   98/98 Python tests), profile smoke, allocation gates, and gz-physics/gz-sim
   compatibility (`test-gz`).
+- 2026-07-08: WP-PG.10 merged as #3339 after Codex review reported no major
+  issues on `d099efa2c9`. WP-PG.31 claimed on
+  `wp-pg-31-shallow-support-scratch`.
+- 2026-07-08: WP-PG.31 implemented as the no-candidate shallow-support skip on
+  current base `3964108a675` (branch `21f691311df`), because current
+  `World.cpp` already retained the scratch buffers from the old preserved
+  patch. A/B artifact `/tmp/wp_pg31_ab_20260707T184319`: no-root-FreeJoint
+  `double_pendulum.world` hashes stayed `0x1db838038acbd960` with median step
+  time 0.002106 -> 0.001836 ms (DART) and 0.001903 -> 0.001644 ms (ODE);
+  generated 120-object DART/ODE guard hashes stayed
+  `0x3bd9d26da5ea002b` and `0x5576f6244b736aae`; ODE
+  `BM_ContactContainerActive/120/1/{1,16}` medians were 6588 -> 6433 ms and
+  6998 -> 6468 ms. Verified binaries passed the historical crash gate: base
+  30/30 and branch 30/30 default 16-thread benchmark stressors returned 0.
 
 ## Session log
 


### PR DESCRIPTION
## Summary

- Skip the shallow-support free-root snapshot and support scan when a world has no mobile root-FreeJoint skeleton that can use that correction path.
- Preserve the existing stale-state cleanup so topology and mobile-state changes still clear shallow-support velocity baselines safely.
- Update the DART 6 performance-generalization tracker with current-base A/B evidence and the historical 16-thread crash stress gate.

## Motivation / Problem

The old WP-PG.31 patch predated the current `World.cpp` allocator and shallow-support layout, so it no longer applied cleanly. On current `release-6.20`, the scratch buffers it wanted are already retained, but `World::step()` still unconditionally snapshots free-root velocities and scans contacts for shallow support even in worlds that cannot have a root-FreeJoint shallow-support correction.

This PR completes the useful remaining part of WP-PG.31 against the current base: skip that work for articulated or fixed-root worlds while keeping the safety cleanup that clears stale shallow-support state.

## Changes / Key Changes

- Add `World::hasAnyShallowSupportFreeRootCandidate()` using the WP-PG.30 cached root-FreeJoint classification.
- In both deactivation-enabled and deactivation-disabled step paths, skip `snapshotFreeRootVelocities()` and `findShallowSupportedFreeRoots()` when no mobile root-FreeJoint candidate exists.
- Keep `clearUnsupportedShallowSupportFreeRootVelocityStates()` on both paths so stale state is still cleared after skeleton topology or mobility changes.
- Record WP-PG.31 status and evidence in `docs/dev_tasks/dart6_performance_generalization/`.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Fixed-root/articulated worlds | Paid the shallow-support free-root snapshot and support scan every step even when no root FreeJoint could use it. | Skips the snapshot/support scan when no mobile root-FreeJoint skeleton is present. |
| Free-root worlds | Ran the existing shallow-support correction path. | Same correction path, with an inexpensive candidate check first. |
| Stale shallow-support state | Cleanup ran after each solve. | Cleanup still runs after each solve, including the no-candidate path. |
| Historical WP-PG.31 crash concern | Old preserved patch had a load-dependent 16-thread heap crash suspicion. | Current implementation passed verified-binary base and branch stress sweeps. |

## Performance / Guard Evidence

Artifact: `/tmp/wp_pg31_ab_20260707T184319`

Current-base A/B:

- Base: `origin/release-6.20` @ `3964108a675`
- Branch: `wp-pg-31-shallow-support-scratch` @ `885824e69f7`

Hash guards:

| Row | Base hash | Branch hash |
| --- | --- | --- |
| `double_pendulum.world`, DART | `0x1db838038acbd960` | `0x1db838038acbd960` |
| `double_pendulum.world`, ODE | `0x1db838038acbd960` | `0x1db838038acbd960` |
| generated 120 objects, DART | `0x3bd9d26da5ea002b` | `0x3bd9d26da5ea002b` |
| generated 120 objects, ODE | `0x5576f6244b736aae` | `0x5576f6244b736aae` |

Timing rows:

| Row | Base | Branch | Ratio |
| --- | ---: | ---: | ---: |
| `double_pendulum.world`, DART median step | 0.002106 ms | 0.001836 ms | 0.87x |
| `double_pendulum.world`, ODE median step | 0.001903 ms | 0.001644 ms | 0.86x |
| `BM_ContactContainerActive/120/1/1`, ODE median | 6588 ms | 6433 ms | 0.98x |
| `BM_ContactContainerActive/120/1/16`, ODE median | 6998 ms | 6468 ms | 0.92x |

Crash stress gate:

| Arm | Command shape | Result |
| --- | --- | --- |
| Base | 30 separate default `BM_ContactContainerActive/120/1/16` processes, 120s timeout each | 30/30 returned 0 |
| Branch | 30 separate default `BM_ContactContainerActive/120/1/16` processes, 120s timeout each | 30/30 returned 0 |

The first branch timing pass in the artifact was discarded for claims because host load was substantially higher; the table above uses the post-base branch rerun while retaining the raw first pass for auditability.

## Testing

- `pixi run lint`
- `pixi run check-lint`
- `pixi run cmake --build build/default/cpp/Release --target contact_benchmark BM_INTEGRATION_contact_container INTEGRATION_StepAllocation test_IslandDeactivation --parallel 8`
- `pixi run ./build/default/cpp/Release/tests/integration/INTEGRATION_StepAllocation` — 31/31 passed; native DART allocation gates reported zero measured operator-new/raw-malloc/base-allocator growth.
- `pixi run ./build/default/cpp/Release/tests/integration/test_IslandDeactivation` — 57/57 passed, 2 disabled.
- Current-base A/B and crash stress commands recorded under `/tmp/wp_pg31_ab_20260707T184319`.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Continues `docs/dev_tasks/dart6_performance_generalization/` on `release-6.20`.
- Builds on WP-PG.30 / #3310 for cached root-FreeJoint classification.
- Follows the performance reporting bar from #3307 and #3329.
- No separate backport PR: this targets `release-6.20` directly.

---

#### Checklist

- [x] Milestone set (DART 6.20.0 for `release-6.20`)
- [x] CHANGELOG.md updated if required (N/A: internal runtime optimization with no public API, dependency, or user workflow change)
- [x] Add unit tests for new functionality (covered by focused existing allocation and island-deactivation tests plus A/B guards)
- [x] Document new methods and classes (N/A: no public methods/classes)
- [x] Add Python bindings (dartpy) if applicable (N/A: no dartpy changes)
