### PR TITLE
Fix release Windows zero-duration profile summary

### DIFF
--- a/dart/common/detail/profiler.cpp
+++ b/dart/common/detail/profiler.cpp
@@ -343,6 +343,22 @@ void Profiler::recordCounter(
   counter->last = value;
 }
 
+void Profiler::recordScopeForTesting(
+    std::string_view label,
+    std::string_view file,
+    int line,
+    std::uint64_t durationNs)
+{
+  auto record = threadRecord();
+  auto* node = findOrCreateChild(*record, record->root, label, file, line);
+
+  ++node->callCount;
+  node->inclusiveNs += durationNs;
+  node->selfNs += durationNs;
+  node->minNs = std::min(node->minNs, durationNs);
+  node->maxNs = std::max(node->maxNs, durationNs);
+}
+
 std::uint64_t Profiler::sumInclusiveChildren(const ProfileNode& node)
 {
   std::uint64_t total = 0;
@@ -702,13 +718,15 @@ void Profiler::printSummary(std::ostream& os)
   }
 
   std::uint64_t totalNs = 0;
+  bool anyScopes = false;
   bool anyCounters = false;
   for (const auto& record : threads) {
     totalNs += sumInclusiveChildren(record->root);
+    anyScopes = anyScopes || hasRecordedScopes(record->root);
     anyCounters = anyCounters || hasRecordedCounters(*record);
   }
 
-  if (totalNs == 0 && !anyCounters) {
+  if (!anyScopes && !anyCounters) {
     os << "DART profiler (text): no scoped regions were recorded.\n";
     return;
   }

--- a/dart/common/detail/profiler.hpp
+++ b/dart/common/detail/profiler.hpp
@@ -135,6 +135,11 @@ private:
       std::string_view label,
       std::string_view file,
       int line);
+  void recordScopeForTesting(
+      std::string_view label,
+      std::string_view file,
+      int line,
+      std::uint64_t durationNs);
   static std::string sourceText(const ProfileNode& node);
   static std::string sourceText(const CounterNode& node);
   static std::string padRight(std::string_view text, std::size_t width);

--- a/tests/unit/common/test_Profile.cpp
+++ b/tests/unit/common/test_Profile.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #if DART_BUILD_PROFILE && DART_PROFILE_ENABLE_TEXT
   #include <dart/common/detail/profiler.hpp>
@@ -46,6 +47,20 @@
 
 using dart::common::profile::Profiler;
 using dart::common::profile::ProfileScope;
+
+namespace dart::common::profile {
+
+class ProfilerTestAccess
+{
+public:
+  static void recordZeroDurationScope(std::string_view label)
+  {
+    auto& profiler = Profiler::instance();
+    profiler.recordScopeForTesting(label, __FILE__, __LINE__, 0);
+  }
+};
+
+} // namespace dart::common::profile
 
 namespace {
 
@@ -159,6 +174,17 @@ TEST_F(ProfileTest, ResetReclaimsNodeStorageForNewScopes)
   const auto summary = DART_PROFILE_TEXT_SUMMARY();
   EXPECT_NE(summary.find("after-reset-scope"), std::string::npos);
   EXPECT_EQ(summary.find("prefill-scope-"), std::string::npos);
+}
+
+TEST_F(ProfileTest, ZeroDurationScopesRemainVisibleInSummary)
+{
+  dart::common::profile::ProfilerTestAccess::recordZeroDurationScope(
+      "zero-duration-scope");
+
+  const auto summary = DART_PROFILE_TEXT_SUMMARY();
+  EXPECT_NE(summary.find("zero-duration-scope"), std::string::npos);
+  EXPECT_NE(summary.find("calls        1"), std::string::npos);
+  EXPECT_EQ(summary.find("no scoped regions were recorded"), std::string::npos);
 }
 
 TEST_F(ProfileTest, KeepsDynamicScopeNamesAlive)


### PR DESCRIPTION
## Summary
- Treat recorded profiler scopes as present even when their measured inclusive time is zero
- Keep zero-duration scope rows visible in text summaries instead of reporting that no scoped regions were recorded
- Add a deterministic regression for zero-duration profile scopes

## CI failure addressed
- release-6.20 Windows Release job: https://github.com/dartsim/dart/actions/runs/28909805330/job/85764648992

## Validation
- pixi run config
- cmake --build build/default/cpp/Release --target UNIT_common_Profile --parallel 4
- ctest --test-dir build/default/cpp/Release -R UNIT_common_Profile --output-on-failure
- pixi run check-lint-cpp
- git diff --check