### PR TITLE
Add native distance and plane pairs

### DIFF
--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -30,7 +30,9 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_sphere.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/convex_convex.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/cylinder_collision.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/distance.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/mesh_mesh.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/plane_sphere.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_box.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_sphere.hpp
 )
@@ -57,7 +59,9 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/capsule_sphere.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/convex_convex.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/cylinder_collision.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/distance.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/mesh_mesh.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/plane_sphere.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_box.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/sphere_sphere.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/brute_force.cpp

--- a/dart/collision/native/narrow_phase/distance.cpp
+++ b/dart/collision/native/narrow_phase/distance.cpp
@@ -623,7 +623,7 @@ bool sampleSdfSurfaceAgainstSdf(
           const Eigen::Vector3d targetGradientUnit
               = targetGradientWorld / targetGradientNorm;
           const double sign = (targetDistance >= 0.0) ? 1.0 : -1.0;
-          normal = targetGradientUnit * sign;
+          normal = -targetGradientUnit * sign;
           targetSurfaceWorld
               = sourceSurfaceWorld - targetGradientUnit * targetDistance;
         }
@@ -709,7 +709,7 @@ double distancePointSetSdf(
     if (gradNorm > 1e-12) {
       const Eigen::Vector3d gradUnit = bestGradient / gradNorm;
       const double sign = (bestDistance >= 0.0) ? 1.0 : -1.0;
-      normal = gradUnit * sign;
+      normal = -gradUnit * sign;
       result.pointOnObject2 = bestPoint - gradUnit * bestDistance;
     } else {
       result.pointOnObject2 = bestPoint;
@@ -789,7 +789,8 @@ double distanceSphereBox(
   Eigen::Vector3d pointOnBoxLocal = closestOnBoxLocal;
   double dist = distToSurface - sphereRadius;
 
-  if (distToSurface > boundaryTolerance) {
+  const bool sphereCenterOutsideBox = distToSurface > boundaryTolerance;
+  if (sphereCenterOutsideBox) {
     normalLocal = diffLocal / distToSurface;
   } else {
     Eigen::Vector3d insideLocalSphereCenter = sphereCenterLocal;
@@ -827,11 +828,13 @@ double distanceSphereBox(
   result.distance = dist;
 
   if (option.enableNearestPoints) {
+    const Eigen::Vector3d resultNormalLocal
+        = sphereCenterOutsideBox ? -normalLocal : normalLocal;
     result.pointOnObject2 = boxTransform * pointOnBoxLocal;
     result.pointOnObject1
         = sphereTransform.translation()
           - (boxTransform.rotation() * normalLocal) * sphereRadius;
-    result.normal = boxTransform.rotation() * normalLocal;
+    result.normal = boxTransform.rotation() * resultNormalLocal;
   }
 
   return dist;
@@ -1098,7 +1101,8 @@ double distanceCapsuleBox(
   Eigen::Vector3d pointOnBoxLocal = bestBoxPoint;
   double dist = minDist - capRadius;
 
-  if (minDist > boundaryTolerance) {
+  const bool capsuleAxisOutsideBox = minDist > boundaryTolerance;
+  if (capsuleAxisOutsideBox) {
     dirLocal /= minDist;
   } else {
     Eigen::Vector3d insideLocalCapsulePoint = bestCapsulePoint;
@@ -1136,10 +1140,12 @@ double distanceCapsuleBox(
   result.distance = dist;
 
   if (option.enableNearestPoints) {
+    const Eigen::Vector3d resultDirLocal
+        = capsuleAxisOutsideBox ? -dirLocal : dirLocal;
     result.pointOnObject2 = boxTransform * pointOnBoxLocal;
     result.pointOnObject1
         = boxTransform * (bestCapsulePoint - dirLocal * capRadius);
-    result.normal = boxTransform.rotation() * dirLocal;
+    result.normal = boxTransform.rotation() * resultDirLocal;
   }
 
   return dist;
@@ -1244,7 +1250,7 @@ double distanceSphereSdf(
       result.pointOnObject2 = center;
       result.pointOnObject1 = center + normal * radius;
     }
-    result.normal = normal;
+    result.normal = -normal;
   }
 
   return dist;
@@ -1341,7 +1347,7 @@ double distanceCapsuleSdf(
       result.pointOnObject2 = best_axis_point;
       result.pointOnObject1 = best_axis_point + normal * radius;
     }
-    result.normal = normal;
+    result.normal = -normal;
   }
 
   return best_dist;
@@ -1445,7 +1451,7 @@ double distanceCylinderSdf(
     if (gradNorm > 1e-12) {
       const Eigen::Vector3d gradUnit = bestGradient / gradNorm;
       const double sign = (bestDistance >= 0.0) ? 1.0 : -1.0;
-      normal = gradUnit * sign;
+      normal = -gradUnit * sign;
       result.pointOnObject2 = bestPoint - gradUnit * bestDistance;
     } else {
       result.pointOnObject2 = bestPoint;

--- a/dart/collision/native/narrow_phase/distance.cpp
+++ b/dart/collision/native/narrow_phase/distance.cpp
@@ -31,10 +31,12 @@
  */
 
 #include <dart/collision/native/detail/span.hpp>
+#include <dart/collision/native/narrow_phase/box_box/sat.hpp>
 #include <dart/collision/native/narrow_phase/distance.hpp>
 #include <dart/collision/native/shapes/shape.hpp>
 
 #include <algorithm>
+#include <array>
 #include <limits>
 
 #include <cmath>
@@ -48,6 +50,12 @@ struct SegmentClosestResult
   Eigen::Vector3d point1;
   Eigen::Vector3d point2;
   double distSq;
+};
+
+struct Segment
+{
+  Eigen::Vector3d start;
+  Eigen::Vector3d end;
 };
 
 struct SdfSdfCandidate
@@ -123,6 +131,148 @@ Eigen::Vector3d closestPointOnBox(
       std::clamp(point.x(), -halfExtents.x(), halfExtents.x()),
       std::clamp(point.y(), -halfExtents.y(), halfExtents.y()),
       std::clamp(point.z(), -halfExtents.z(), halfExtents.z()));
+}
+
+Eigen::Vector3d closestPointOnSegmentInBoxSpace(
+    const Eigen::Vector3d& segmentStart,
+    const Eigen::Vector3d& segmentEnd,
+    const Eigen::Vector3d& halfExtents,
+    Eigen::Vector3d& closestOnSegment)
+{
+  const Eigen::Vector3d segment = segmentEnd - segmentStart;
+  const double segmentLengthSq = segment.squaredNorm();
+
+  if (segmentLengthSq < 1e-10) {
+    closestOnSegment = segmentStart;
+    return closestPointOnBox(segmentStart, halfExtents);
+  }
+
+  double bestDistSq = std::numeric_limits<double>::max();
+  double bestInteriorMargin = -std::numeric_limits<double>::infinity();
+  Eigen::Vector3d bestOnBox = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestOnSegment = segmentStart;
+
+  auto computeInteriorMargin = [&](const Eigen::Vector3d& point) {
+    double margin = std::numeric_limits<double>::infinity();
+    for (int axis = 0; axis < 3; ++axis) {
+      const double axisMargin = halfExtents[axis] - std::abs(point[axis]);
+      if (axisMargin < 0.0) {
+        return -std::numeric_limits<double>::infinity();
+      }
+      margin = std::min(margin, axisMargin);
+    }
+    return margin;
+  };
+
+  auto testCandidate = [&](double t) {
+    const Eigen::Vector3d pointOnSegment = segmentStart + segment * t;
+    const Eigen::Vector3d pointOnBox
+        = closestPointOnBox(pointOnSegment, halfExtents);
+    const double distSq = (pointOnSegment - pointOnBox).squaredNorm();
+    const double interiorMargin = computeInteriorMargin(pointOnSegment);
+
+    if (distSq < bestDistSq - 1e-18
+        || (std::abs(distSq - bestDistSq) <= 1e-18
+            && interiorMargin > bestInteriorMargin)) {
+      bestDistSq = distSq;
+      bestInteriorMargin = interiorMargin;
+      bestOnBox = pointOnBox;
+      bestOnSegment = pointOnSegment;
+    }
+  };
+
+  std::array<double, 8> breakpoints{};
+  std::size_t numBreakpoints = 0;
+  breakpoints[numBreakpoints++] = 0.0;
+  breakpoints[numBreakpoints++] = 1.0;
+
+  constexpr double kAxisEps = 1e-12;
+  for (int axis = 0; axis < 3; ++axis) {
+    if (std::abs(segment[axis]) <= kAxisEps) {
+      continue;
+    }
+
+    for (const double face : {-halfExtents[axis], halfExtents[axis]}) {
+      const double t = (face - segmentStart[axis]) / segment[axis];
+      if (t > 0.0 && t < 1.0) {
+        breakpoints[numBreakpoints++] = t;
+      }
+    }
+  }
+
+  std::sort(breakpoints.begin(), breakpoints.begin() + numBreakpoints);
+
+  std::array<double, 8> uniqueBreakpoints{};
+  std::size_t numUniqueBreakpoints = 0;
+  for (std::size_t i = 0; i < numBreakpoints; ++i) {
+    if (numUniqueBreakpoints == 0
+        || std::abs(
+               breakpoints[i] - uniqueBreakpoints[numUniqueBreakpoints - 1])
+               > kAxisEps) {
+      uniqueBreakpoints[numUniqueBreakpoints++] = breakpoints[i];
+      testCandidate(breakpoints[i]);
+    }
+  }
+
+  for (std::size_t i = 0; i + 1 < numUniqueBreakpoints; ++i) {
+    const double lo = uniqueBreakpoints[i];
+    const double hi = uniqueBreakpoints[i + 1];
+    if (hi - lo <= kAxisEps) {
+      continue;
+    }
+
+    const double mid = 0.5 * (lo + hi);
+    double numerator = 0.0;
+    double denominator = 0.0;
+    for (int axis = 0; axis < 3; ++axis) {
+      const double coord = segmentStart[axis] + segment[axis] * mid;
+      double face = 0.0;
+      if (coord < -halfExtents[axis]) {
+        face = -halfExtents[axis];
+      } else if (coord > halfExtents[axis]) {
+        face = halfExtents[axis];
+      } else {
+        continue;
+      }
+
+      numerator += segment[axis] * (face - segmentStart[axis]);
+      denominator += segment[axis] * segment[axis];
+    }
+
+    if (denominator > kAxisEps) {
+      testCandidate(std::clamp(numerator / denominator, lo, hi));
+    } else {
+      testCandidate(mid);
+    }
+  }
+
+  closestOnSegment = bestOnSegment;
+  return bestOnBox;
+}
+
+std::array<Segment, 12> boxEdges(const Eigen::Vector3d& halfExtents)
+{
+  std::array<Segment, 12> edges;
+  int edgeIndex = 0;
+
+  for (int axis = 0; axis < 3; ++axis) {
+    const int axis1 = (axis + 1) % 3;
+    const int axis2 = (axis + 2) % 3;
+
+    for (const double sign1 : {-1.0, 1.0}) {
+      for (const double sign2 : {-1.0, 1.0}) {
+        Eigen::Vector3d start = Eigen::Vector3d::Zero();
+        Eigen::Vector3d end = Eigen::Vector3d::Zero();
+        start[axis] = -halfExtents[axis];
+        end[axis] = halfExtents[axis];
+        start[axis1] = end[axis1] = sign1 * halfExtents[axis1];
+        start[axis2] = end[axis2] = sign2 * halfExtents[axis2];
+        edges[edgeIndex++] = {start, end};
+      }
+    }
+  }
+
+  return edges;
 }
 
 [[nodiscard]] double computeBoxBoundaryTolerance(
@@ -703,11 +853,53 @@ double distanceBoxBox(
     return result.distance;
   }
 
+  box_box::SatResult sat;
+  const box_box::BoxData boxData1{
+      transform1.translation(), half1, transform1.linear()};
+  const box_box::BoxData boxData2{
+      transform2.translation(), half2, transform2.linear()};
+  if (box_box::computeBoxBoxSat(boxData1, boxData2, sat)) {
+    const double dist = -sat.penetration;
+    result.distance = dist;
+    if (dist > option.upperBound) {
+      return dist;
+    }
+
+    if (option.enableNearestPoints) {
+      Eigen::Vector3d normal = -sat.normal;
+      if (normal.squaredNorm() < 1e-10) {
+        const Eigen::Vector3d centerDiff
+            = transform2.translation() - transform1.translation();
+        normal = centerDiff.squaredNorm() > 1e-10 ? centerDiff.normalized()
+                                                  : Eigen::Vector3d::UnitX();
+      }
+
+      result.normal = normal;
+      result.pointOnObject1 = transform1.translation()
+                              + normal * box_box::projectBox(boxData1, normal);
+      result.pointOnObject2 = transform2.translation()
+                              - normal * box_box::projectBox(boxData2, normal);
+    }
+
+    return dist;
+  }
+
   const Eigen::Isometry3d inv1 = transform1.inverse();
   const Eigen::Isometry3d box2In1 = inv1 * transform2;
 
-  double minDist = std::numeric_limits<double>::max();
-  Eigen::Vector3d bestPoint1Local, bestPoint2Local;
+  double minDistSq = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestPoint1World = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestPoint2World = Eigen::Vector3d::Zero();
+
+  auto updateCandidate
+      = [&](const Eigen::Vector3d& point1, const Eigen::Vector3d& point2) {
+          const double distSq = (point2 - point1).squaredNorm();
+          if (distSq < minDistSq) {
+            minDistSq = distSq;
+            bestPoint1World = point1;
+            bestPoint2World = point2;
+          }
+        };
 
   for (int i = 0; i < 8; ++i) {
     const Eigen::Vector3d corner2Local(
@@ -717,13 +909,7 @@ double distanceBoxBox(
 
     const Eigen::Vector3d corner2In1 = box2In1 * corner2Local;
     const Eigen::Vector3d closest1 = closestPointOnBox(corner2In1, half1);
-    const double d = (corner2In1 - closest1).norm();
-
-    if (d < minDist) {
-      minDist = d;
-      bestPoint1Local = closest1;
-      bestPoint2Local = corner2Local;
-    }
+    updateCandidate(transform1 * closest1, transform2 * corner2Local);
   }
 
   const Eigen::Isometry3d inv2 = transform2.inverse();
@@ -737,15 +923,25 @@ double distanceBoxBox(
 
     const Eigen::Vector3d corner1In2 = box1In2 * corner1Local;
     const Eigen::Vector3d closest2 = closestPointOnBox(corner1In2, half2);
-    const double d = (corner1In2 - closest2).norm();
+    updateCandidate(transform1 * corner1Local, transform2 * closest2);
+  }
 
-    if (d < minDist) {
-      minDist = d;
-      bestPoint1Local = corner1Local;
-      bestPoint2Local = closest2;
+  const auto edges1 = boxEdges(half1);
+  const auto edges2 = boxEdges(half2);
+  for (const auto& edge1 : edges1) {
+    const Eigen::Vector3d edge1Start = transform1 * edge1.start;
+    const Eigen::Vector3d edge1End = transform1 * edge1.end;
+    for (const auto& edge2 : edges2) {
+      const auto closest = closestPointsBetweenSegments(
+          edge1Start,
+          edge1End,
+          transform2 * edge2.start,
+          transform2 * edge2.end);
+      updateCandidate(closest.point1, closest.point2);
     }
   }
 
+  const double minDist = std::sqrt(minDistSq);
   result.distance = minDist;
 
   if (minDist > option.upperBound) {
@@ -753,8 +949,8 @@ double distanceBoxBox(
   }
 
   if (option.enableNearestPoints) {
-    result.pointOnObject1 = transform1 * bestPoint1Local;
-    result.pointOnObject2 = transform2 * bestPoint2Local;
+    result.pointOnObject1 = bestPoint1World;
+    result.pointOnObject2 = bestPoint2World;
 
     const Eigen::Vector3d diff = result.pointOnObject2 - result.pointOnObject1;
     if (diff.squaredNorm() > 1e-10) {
@@ -891,23 +1087,10 @@ double distanceCapsuleBox(
   const Eigen::Vector3d topLocal = boxInv * capTop;
   const Eigen::Vector3d botLocal = boxInv * capBot;
 
-  double minDist = std::numeric_limits<double>::max();
-  Eigen::Vector3d bestCapsulePoint, bestBoxPoint;
-
-  constexpr int numSamples = 5;
-  for (int i = 0; i < numSamples; ++i) {
-    const double t = static_cast<double>(i) / (numSamples - 1);
-    const Eigen::Vector3d axisPointLocal = botLocal + (topLocal - botLocal) * t;
-    const Eigen::Vector3d closestOnBox
-        = closestPointOnBox(axisPointLocal, boxHalf);
-    const double d = (axisPointLocal - closestOnBox).norm();
-
-    if (d < minDist) {
-      minDist = d;
-      bestCapsulePoint = axisPointLocal;
-      bestBoxPoint = closestOnBox;
-    }
-  }
+  Eigen::Vector3d bestCapsulePoint = Eigen::Vector3d::Zero();
+  const Eigen::Vector3d bestBoxPoint = closestPointOnSegmentInBoxSpace(
+      botLocal, topLocal, boxHalf, bestCapsulePoint);
+  const double minDist = (bestCapsulePoint - bestBoxPoint).norm();
 
   const double dist = minDist - capRadius;
 

--- a/dart/collision/native/narrow_phase/distance.cpp
+++ b/dart/collision/native/narrow_phase/distance.cpp
@@ -1,0 +1,1338 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/detail/span.hpp>
+#include <dart/collision/native/narrow_phase/distance.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+
+#include <algorithm>
+#include <limits>
+
+#include <cmath>
+
+namespace dart::collision::native {
+
+namespace {
+
+struct SegmentClosestResult
+{
+  Eigen::Vector3d point1;
+  Eigen::Vector3d point2;
+  double distSq;
+};
+
+struct SdfSdfCandidate
+{
+  double distance = std::numeric_limits<double>::max();
+  Eigen::Vector3d pointOnSource = Eigen::Vector3d::Zero();
+  Eigen::Vector3d pointOnTarget = Eigen::Vector3d::Zero();
+  Eigen::Vector3d normalSourceToTarget = Eigen::Vector3d::UnitX();
+};
+
+SegmentClosestResult closestPointsBetweenSegments(
+    const Eigen::Vector3d& p1,
+    const Eigen::Vector3d& q1,
+    const Eigen::Vector3d& p2,
+    const Eigen::Vector3d& q2)
+{
+  const Eigen::Vector3d d1 = q1 - p1;
+  const Eigen::Vector3d d2 = q2 - p2;
+  const Eigen::Vector3d r = p1 - p2;
+
+  const double a = d1.squaredNorm();
+  const double e = d2.squaredNorm();
+  const double f = d2.dot(r);
+
+  double s = 0.0;
+  double t = 0.0;
+
+  constexpr double eps = 1e-10;
+
+  if (a <= eps && e <= eps) {
+    s = t = 0.0;
+  } else if (a <= eps) {
+    s = 0.0;
+    t = std::clamp(f / e, 0.0, 1.0);
+  } else {
+    const double c = d1.dot(r);
+    if (e <= eps) {
+      t = 0.0;
+      s = std::clamp(-c / a, 0.0, 1.0);
+    } else {
+      const double b = d1.dot(d2);
+      const double denom = a * e - b * b;
+
+      if (denom != 0.0) {
+        s = std::clamp((b * f - c * e) / denom, 0.0, 1.0);
+      } else {
+        s = 0.0;
+      }
+
+      t = (b * s + f) / e;
+
+      if (t < 0.0) {
+        t = 0.0;
+        s = std::clamp(-c / a, 0.0, 1.0);
+      } else if (t > 1.0) {
+        t = 1.0;
+        s = std::clamp((b - c) / a, 0.0, 1.0);
+      }
+    }
+  }
+
+  SegmentClosestResult res;
+  res.point1 = p1 + d1 * s;
+  res.point2 = p2 + d2 * t;
+  res.distSq = (res.point1 - res.point2).squaredNorm();
+  return res;
+}
+
+Eigen::Vector3d closestPointOnBox(
+    const Eigen::Vector3d& point, const Eigen::Vector3d& halfExtents)
+{
+  return Eigen::Vector3d(
+      std::clamp(point.x(), -halfExtents.x(), halfExtents.x()),
+      std::clamp(point.y(), -halfExtents.y(), halfExtents.y()),
+      std::clamp(point.z(), -halfExtents.z(), halfExtents.z()));
+}
+
+[[nodiscard]] double computeBoxBoundaryTolerance(
+    const Eigen::Vector3d& halfExtents, const Eigen::Vector3d& point)
+{
+  const double boundaryScale = std::max(
+      {1.0, halfExtents.cwiseAbs().maxCoeff(), point.cwiseAbs().maxCoeff()});
+  return 64.0 * std::numeric_limits<double>::epsilon() * boundaryScale;
+}
+
+void snapNearBoxBoundary(
+    Eigen::Vector3d& point,
+    const Eigen::Vector3d& halfExtents,
+    double tolerance)
+{
+  for (int axis = 0; axis < 3; ++axis) {
+    const double extent = halfExtents[axis];
+    const double coordinate = point[axis];
+    if (std::abs(std::abs(coordinate) - extent) <= tolerance) {
+      point[axis] = std::copysign(extent, coordinate);
+    }
+  }
+}
+
+bool distanceSameOrientationBoxes(
+    const Eigen::Vector3d& half1,
+    const Eigen::Isometry3d& transform1,
+    const Eigen::Vector3d& half2,
+    const Eigen::Isometry3d& transform2,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const Eigen::Matrix3d relRot
+      = transform1.linear().transpose() * transform2.linear();
+  if (!relRot.isApprox(Eigen::Matrix3d::Identity(), 1e-12)) {
+    return false;
+  }
+
+  const Eigen::Vector3d center2
+      = transform1.linear().transpose()
+        * (transform2.translation() - transform1.translation());
+  const Eigen::Vector3d combinedHalf = half1 + half2;
+  const Eigen::Vector3d axisSeparations = center2.cwiseAbs() - combinedHalf;
+  const bool separated = (axisSeparations.array() > 0.0).any();
+  const double dist = separated ? axisSeparations.cwiseMax(0.0).norm()
+                                : axisSeparations.maxCoeff();
+
+  result.distance = dist;
+  if (dist > option.upperBound) {
+    return true;
+  }
+
+  if (!option.enableNearestPoints) {
+    return true;
+  }
+
+  Eigen::Vector3d point1Local = Eigen::Vector3d::Zero();
+  Eigen::Vector3d point2Local = Eigen::Vector3d::Zero();
+
+  Eigen::Index penetrationAxis = 0;
+  if (!separated) {
+    axisSeparations.maxCoeff(&penetrationAxis);
+  }
+
+  for (int axis = 0; axis < 3; ++axis) {
+    if (!separated && axis == penetrationAxis) {
+      const double direction = (center2[axis] >= 0.0) ? 1.0 : -1.0;
+      point1Local[axis] = direction * half1[axis];
+      point2Local[axis] = -direction * half2[axis];
+    } else if (center2[axis] > combinedHalf[axis]) {
+      point1Local[axis] = half1[axis];
+      point2Local[axis] = -half2[axis];
+    } else if (center2[axis] < -combinedHalf[axis]) {
+      point1Local[axis] = -half1[axis];
+      point2Local[axis] = half2[axis];
+    } else {
+      const double overlapMin
+          = std::max(-half1[axis], center2[axis] - half2[axis]);
+      const double overlapMax
+          = std::min(half1[axis], center2[axis] + half2[axis]);
+      point1Local[axis] = 0.5 * (overlapMin + overlapMax);
+      point2Local[axis] = point1Local[axis] - center2[axis];
+    }
+  }
+
+  result.pointOnObject1 = transform1 * point1Local;
+  result.pointOnObject2 = transform2 * point2Local;
+
+  if (!separated) {
+    const double direction = (center2[penetrationAxis] >= 0.0) ? 1.0 : -1.0;
+    result.normal = direction * transform1.linear().col(penetrationAxis);
+  } else {
+    const Eigen::Vector3d diff = result.pointOnObject2 - result.pointOnObject1;
+    if (diff.squaredNorm() > 1e-10) {
+      result.normal = diff.normalized();
+    } else {
+      result.normal = Eigen::Vector3d::UnitX();
+    }
+  }
+
+  return true;
+}
+
+constexpr double kSupportEps = 1e-12;
+constexpr double kPi = 3.141592653589793238462643383279502884;
+
+bool supportPointOnShape(
+    const Shape& shape,
+    const Eigen::Isometry3d& transform,
+    const Eigen::Vector3d& directionWorld,
+    Eigen::Vector3d& supportWorld)
+{
+  Eigen::Vector3d dir = directionWorld;
+  if (dir.squaredNorm() < kSupportEps) {
+    dir = Eigen::Vector3d::UnitX();
+  }
+
+  switch (shape.getType()) {
+    case ShapeType::Sphere: {
+      const auto& sphere = static_cast<const SphereShape&>(shape);
+      supportWorld
+          = transform.translation() + sphere.getRadius() * dir.normalized();
+      return true;
+    }
+    case ShapeType::Box: {
+      const auto& box = static_cast<const BoxShape&>(shape);
+      const Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+      Eigen::Vector3d localSupport;
+      const Eigen::Vector3d& halfExtents = box.getHalfExtents();
+      localSupport.x()
+          = (localDir.x() >= 0.0) ? halfExtents.x() : -halfExtents.x();
+      localSupport.y()
+          = (localDir.y() >= 0.0) ? halfExtents.y() : -halfExtents.y();
+      localSupport.z()
+          = (localDir.z() >= 0.0) ? halfExtents.z() : -halfExtents.z();
+      supportWorld = transform * localSupport;
+      return true;
+    }
+    case ShapeType::Capsule: {
+      const auto& capsule = static_cast<const CapsuleShape&>(shape);
+      const double radius = capsule.getRadius();
+      const double halfHeight = capsule.getHeight() * 0.5;
+      Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+      if (localDir.squaredNorm() < kSupportEps) {
+        localDir = Eigen::Vector3d::UnitX();
+      }
+      const Eigen::Vector3d dirNorm = localDir.normalized();
+      const Eigen::Vector3d axisPoint
+          = (dirNorm.z() >= 0.0) ? Eigen::Vector3d(0, 0, halfHeight)
+                                 : Eigen::Vector3d(0, 0, -halfHeight);
+      supportWorld = transform * (axisPoint + radius * dirNorm);
+      return true;
+    }
+    case ShapeType::Cylinder: {
+      const auto& cylinder = static_cast<const CylinderShape&>(shape);
+      const double radius = cylinder.getRadius();
+      const double halfHeight = cylinder.getHeight() * 0.5;
+      const Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+      const double xyLen = std::sqrt(
+          localDir.x() * localDir.x() + localDir.y() * localDir.y());
+      Eigen::Vector3d localSupport;
+      if (xyLen < kSupportEps) {
+        localSupport.x() = radius;
+        localSupport.y() = 0.0;
+      } else {
+        localSupport.x() = radius * localDir.x() / xyLen;
+        localSupport.y() = radius * localDir.y() / xyLen;
+      }
+      localSupport.z() = (localDir.z() >= 0.0) ? halfHeight : -halfHeight;
+      supportWorld = transform * localSupport;
+      return true;
+    }
+    case ShapeType::Convex: {
+      const auto& convex = static_cast<const ConvexShape&>(shape);
+      Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+      if (localDir.squaredNorm() < kSupportEps) {
+        localDir = Eigen::Vector3d::UnitX();
+      }
+      supportWorld = transform * convex.support(localDir);
+      return true;
+    }
+    case ShapeType::Mesh: {
+      const auto& mesh = static_cast<const MeshShape&>(shape);
+      Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+      if (localDir.squaredNorm() < kSupportEps) {
+        localDir = Eigen::Vector3d::UnitX();
+      }
+      supportWorld = transform * mesh.support(localDir);
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+bool querySdfDistanceAndGradient(
+    const SignedDistanceField* field,
+    const Eigen::Isometry3d& sdfInverse,
+    const Eigen::Matrix3d& sdfRotation,
+    const Eigen::Vector3d& pointWorld,
+    const SdfQueryOptions& options,
+    double* distance,
+    Eigen::Vector3d* gradientWorld)
+{
+  if (!field) {
+    return false;
+  }
+
+  Eigen::Vector3d gradientField = Eigen::Vector3d::Zero();
+  const Eigen::Vector3d pointField = sdfInverse * pointWorld;
+  if (!field->distanceAndGradient(
+          pointField, distance, &gradientField, options)) {
+    return false;
+  }
+
+  *gradientWorld = sdfRotation * gradientField;
+  return true;
+}
+
+double boundedSdfQueryDistance(double upperBound, double margin)
+{
+  if (!std::isfinite(upperBound)) {
+    return std::numeric_limits<double>::max();
+  }
+  if (upperBound > std::numeric_limits<double>::max() - margin) {
+    return std::numeric_limits<double>::max();
+  }
+  return upperBound + margin;
+}
+
+int sdfAxisSampleCount(double extent, double voxelSize)
+{
+  if (!std::isfinite(extent) || extent <= 0.0) {
+    return 2;
+  }
+
+  return std::clamp(static_cast<int>(std::ceil(extent / voxelSize)) + 1, 2, 64);
+}
+
+bool isValidAabb(const Aabb& aabb)
+{
+  return aabb.min.allFinite() && aabb.max.allFinite()
+         && (aabb.max.array() >= aabb.min.array()).all();
+}
+
+bool sampleSdfSurfaceAgainstSdf(
+    const SignedDistanceField* sourceField,
+    const Eigen::Isometry3d& sourceTransform,
+    const SignedDistanceField* targetField,
+    const Eigen::Isometry3d& targetTransform,
+    double shellThickness,
+    const DistanceOption& option,
+    SdfSdfCandidate& best)
+{
+  if (!sourceField || !targetField) {
+    return false;
+  }
+
+  const Aabb sourceAabb = sourceField->localAabb();
+  if (!isValidAabb(sourceAabb)) {
+    return false;
+  }
+
+  const double sourceVoxelSize = std::max(sourceField->voxelSize(), 1e-6);
+  const Eigen::Vector3d extents = sourceAabb.extents();
+  const Eigen::Vector3i samples(
+      sdfAxisSampleCount(extents.x(), sourceVoxelSize),
+      sdfAxisSampleCount(extents.y(), sourceVoxelSize),
+      sdfAxisSampleCount(extents.z(), sourceVoxelSize));
+
+  SdfQueryOptions sourceOptions;
+  sourceOptions.maxDistance = shellThickness;
+
+  SdfQueryOptions targetOptions;
+  targetOptions.maxDistance
+      = boundedSdfQueryDistance(option.upperBound, shellThickness);
+
+  const Eigen::Isometry3d targetInverse = targetTransform.inverse();
+  const Eigen::Matrix3d targetRotation = targetTransform.rotation();
+
+  bool found = false;
+
+  for (int z = 0; z < samples.z(); ++z) {
+    const double zAlpha
+        = (samples.z() == 1)
+              ? 0.5
+              : static_cast<double>(z) / static_cast<double>(samples.z() - 1);
+    for (int y = 0; y < samples.y(); ++y) {
+      const double yAlpha
+          = (samples.y() == 1)
+                ? 0.5
+                : static_cast<double>(y) / static_cast<double>(samples.y() - 1);
+      for (int x = 0; x < samples.x(); ++x) {
+        const double xAlpha = (samples.x() == 1)
+                                  ? 0.5
+                                  : static_cast<double>(x)
+                                        / static_cast<double>(samples.x() - 1);
+
+        const Eigen::Vector3d sourcePointLocal(
+            sourceAabb.min.x() + extents.x() * xAlpha,
+            sourceAabb.min.y() + extents.y() * yAlpha,
+            sourceAabb.min.z() + extents.z() * zAlpha);
+
+        double sourceDistance = 0.0;
+        Eigen::Vector3d sourceGradient = Eigen::Vector3d::Zero();
+        if (!sourceField->distanceAndGradient(
+                sourcePointLocal,
+                &sourceDistance,
+                &sourceGradient,
+                sourceOptions)) {
+          continue;
+        }
+        if (std::abs(sourceDistance) > shellThickness) {
+          continue;
+        }
+
+        Eigen::Vector3d sourceSurfaceLocal = sourcePointLocal;
+        const double sourceGradientNorm = sourceGradient.norm();
+        if (sourceGradientNorm > 1e-12) {
+          sourceSurfaceLocal
+              -= (sourceGradient / sourceGradientNorm) * sourceDistance;
+        }
+
+        const Eigen::Vector3d sourceSurfaceWorld
+            = sourceTransform * sourceSurfaceLocal;
+
+        double targetDistance = 0.0;
+        Eigen::Vector3d targetGradientWorld = Eigen::Vector3d::Zero();
+        if (!querySdfDistanceAndGradient(
+                targetField,
+                targetInverse,
+                targetRotation,
+                sourceSurfaceWorld,
+                targetOptions,
+                &targetDistance,
+                &targetGradientWorld)) {
+          continue;
+        }
+
+        if (targetDistance >= best.distance) {
+          continue;
+        }
+
+        Eigen::Vector3d normal = Eigen::Vector3d::UnitX();
+        Eigen::Vector3d targetSurfaceWorld = sourceSurfaceWorld;
+        const double targetGradientNorm = targetGradientWorld.norm();
+        if (targetGradientNorm > 1e-12) {
+          const Eigen::Vector3d targetGradientUnit
+              = targetGradientWorld / targetGradientNorm;
+          const double sign = (targetDistance >= 0.0) ? 1.0 : -1.0;
+          normal = targetGradientUnit * sign;
+          targetSurfaceWorld
+              = sourceSurfaceWorld - targetGradientUnit * targetDistance;
+        }
+
+        best.distance = targetDistance;
+        best.pointOnSource = sourceSurfaceWorld;
+        best.pointOnTarget = targetSurfaceWorld;
+        best.normalSourceToTarget = normal;
+        found = true;
+      }
+    }
+  }
+
+  return found;
+}
+
+double distancePointSetSdf(
+    span<const Eigen::Vector3d> pointsLocal,
+    const Eigen::Isometry3d& pointSetTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  if (pointsLocal.empty()) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const SignedDistanceField* field = sdf.getField();
+  if (!field) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const Eigen::Isometry3d sdfInverse = sdfTransform.inverse();
+  const Eigen::Matrix3d sdfRotation = sdfTransform.rotation();
+
+  SdfQueryOptions queryOptions;
+  queryOptions.maxDistance = boundedSdfQueryDistance(option.upperBound, 0.0);
+
+  bool found = false;
+  double bestDistance = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestPoint = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestGradient = Eigen::Vector3d::Zero();
+
+  for (const auto& pointLocal : pointsLocal) {
+    const Eigen::Vector3d pointWorld = pointSetTransform * pointLocal;
+    double fieldDistance = 0.0;
+    Eigen::Vector3d gradientWorld = Eigen::Vector3d::Zero();
+    if (!querySdfDistanceAndGradient(
+            field,
+            sdfInverse,
+            sdfRotation,
+            pointWorld,
+            queryOptions,
+            &fieldDistance,
+            &gradientWorld)) {
+      continue;
+    }
+
+    if (fieldDistance < bestDistance) {
+      bestDistance = fieldDistance;
+      bestPoint = pointWorld;
+      bestGradient = gradientWorld;
+      found = true;
+    }
+  }
+
+  if (!found) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  result.distance = bestDistance;
+  if (bestDistance > option.upperBound) {
+    return bestDistance;
+  }
+
+  if (option.enableNearestPoints) {
+    Eigen::Vector3d normal = Eigen::Vector3d::UnitX();
+    const double gradNorm = bestGradient.norm();
+    if (gradNorm > 1e-12) {
+      const Eigen::Vector3d gradUnit = bestGradient / gradNorm;
+      const double sign = (bestDistance >= 0.0) ? 1.0 : -1.0;
+      normal = gradUnit * sign;
+      result.pointOnObject2 = bestPoint - gradUnit * bestDistance;
+    } else {
+      result.pointOnObject2 = bestPoint;
+    }
+    result.pointOnObject1 = bestPoint;
+    result.normal = normal;
+  }
+
+  return bestDistance;
+}
+
+} // namespace
+
+double distanceSphereSphere(
+    const SphereShape& sphere1,
+    const Eigen::Isometry3d& transform1,
+    const SphereShape& sphere2,
+    const Eigen::Isometry3d& transform2,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const Eigen::Vector3d center1 = transform1.translation();
+  const Eigen::Vector3d center2 = transform2.translation();
+  const double r1 = sphere1.getRadius();
+  const double r2 = sphere2.getRadius();
+
+  const Eigen::Vector3d diff = center2 - center1;
+  const double centerDist = diff.norm();
+  const double dist = centerDist - r1 - r2;
+
+  if (dist > option.upperBound) {
+    result.distance = dist;
+    return dist;
+  }
+
+  result.distance = dist;
+
+  if (option.enableNearestPoints) {
+    if (centerDist > 1e-10) {
+      const Eigen::Vector3d dir = diff / centerDist;
+      result.pointOnObject1 = center1 + dir * r1;
+      result.pointOnObject2 = center2 - dir * r2;
+      result.normal = dir;
+    } else {
+      result.pointOnObject1 = center1 + Eigen::Vector3d(r1, 0, 0);
+      result.pointOnObject2 = center2 - Eigen::Vector3d(r2, 0, 0);
+      result.normal = Eigen::Vector3d::UnitX();
+    }
+  }
+
+  return dist;
+}
+
+double distanceSphereBox(
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const double sphereRadius = sphere.getRadius();
+  const Eigen::Vector3d& boxHalf = box.getHalfExtents();
+
+  const Eigen::Isometry3d boxInv = boxTransform.inverse();
+  const Eigen::Vector3d sphereCenterLocal
+      = boxInv * sphereTransform.translation();
+
+  const Eigen::Vector3d closestOnBoxLocal
+      = closestPointOnBox(sphereCenterLocal, boxHalf);
+  const Eigen::Vector3d diffLocal = sphereCenterLocal - closestOnBoxLocal;
+  const double distToSurface = diffLocal.norm();
+  const double boundaryTolerance
+      = computeBoxBoundaryTolerance(boxHalf, sphereCenterLocal);
+
+  Eigen::Vector3d normalLocal;
+  Eigen::Vector3d pointOnBoxLocal = closestOnBoxLocal;
+  double dist = distToSurface - sphereRadius;
+
+  if (distToSurface > boundaryTolerance) {
+    normalLocal = diffLocal / distToSurface;
+  } else {
+    Eigen::Vector3d insideLocalSphereCenter = sphereCenterLocal;
+    snapNearBoxBoundary(insideLocalSphereCenter, boxHalf, boundaryTolerance);
+
+    double minDist = boxHalf.x() - std::abs(insideLocalSphereCenter.x());
+    int minAxis = 0;
+
+    const double distY = boxHalf.y() - std::abs(insideLocalSphereCenter.y());
+    if (distY < minDist) {
+      minDist = distY;
+      minAxis = 1;
+    }
+
+    const double distZ = boxHalf.z() - std::abs(insideLocalSphereCenter.z());
+    if (distZ < minDist) {
+      minDist = distZ;
+      minAxis = 2;
+    }
+
+    normalLocal = Eigen::Vector3d::Zero();
+    normalLocal[minAxis]
+        = (insideLocalSphereCenter[minAxis] >= 0.0) ? 1.0 : -1.0;
+    pointOnBoxLocal = insideLocalSphereCenter;
+    pointOnBoxLocal[minAxis]
+        = normalLocal[minAxis] > 0.0 ? boxHalf[minAxis] : -boxHalf[minAxis];
+    dist = -(sphereRadius + minDist);
+  }
+
+  if (dist > option.upperBound) {
+    result.distance = dist;
+    return dist;
+  }
+
+  result.distance = dist;
+
+  if (option.enableNearestPoints) {
+    result.pointOnObject2 = boxTransform * pointOnBoxLocal;
+    result.pointOnObject1
+        = sphereTransform.translation()
+          - (boxTransform.rotation() * normalLocal) * sphereRadius;
+    result.normal = boxTransform.rotation() * normalLocal;
+  }
+
+  return dist;
+}
+
+double distanceBoxBox(
+    const BoxShape& box1,
+    const Eigen::Isometry3d& transform1,
+    const BoxShape& box2,
+    const Eigen::Isometry3d& transform2,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const Eigen::Vector3d& half1 = box1.getHalfExtents();
+  const Eigen::Vector3d& half2 = box2.getHalfExtents();
+
+  if (distanceSameOrientationBoxes(
+          half1, transform1, half2, transform2, result, option)) {
+    return result.distance;
+  }
+
+  const Eigen::Isometry3d inv1 = transform1.inverse();
+  const Eigen::Isometry3d box2In1 = inv1 * transform2;
+
+  double minDist = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestPoint1Local, bestPoint2Local;
+
+  for (int i = 0; i < 8; ++i) {
+    const Eigen::Vector3d corner2Local(
+        (i & 1) ? half2.x() : -half2.x(),
+        (i & 2) ? half2.y() : -half2.y(),
+        (i & 4) ? half2.z() : -half2.z());
+
+    const Eigen::Vector3d corner2In1 = box2In1 * corner2Local;
+    const Eigen::Vector3d closest1 = closestPointOnBox(corner2In1, half1);
+    const double d = (corner2In1 - closest1).norm();
+
+    if (d < minDist) {
+      minDist = d;
+      bestPoint1Local = closest1;
+      bestPoint2Local = corner2Local;
+    }
+  }
+
+  const Eigen::Isometry3d inv2 = transform2.inverse();
+  const Eigen::Isometry3d box1In2 = inv2 * transform1;
+
+  for (int i = 0; i < 8; ++i) {
+    const Eigen::Vector3d corner1Local(
+        (i & 1) ? half1.x() : -half1.x(),
+        (i & 2) ? half1.y() : -half1.y(),
+        (i & 4) ? half1.z() : -half1.z());
+
+    const Eigen::Vector3d corner1In2 = box1In2 * corner1Local;
+    const Eigen::Vector3d closest2 = closestPointOnBox(corner1In2, half2);
+    const double d = (corner1In2 - closest2).norm();
+
+    if (d < minDist) {
+      minDist = d;
+      bestPoint1Local = corner1Local;
+      bestPoint2Local = closest2;
+    }
+  }
+
+  result.distance = minDist;
+
+  if (minDist > option.upperBound) {
+    return minDist;
+  }
+
+  if (option.enableNearestPoints) {
+    result.pointOnObject1 = transform1 * bestPoint1Local;
+    result.pointOnObject2 = transform2 * bestPoint2Local;
+
+    const Eigen::Vector3d diff = result.pointOnObject2 - result.pointOnObject1;
+    if (diff.squaredNorm() > 1e-10) {
+      result.normal = diff.normalized();
+    } else {
+      result.normal = Eigen::Vector3d::UnitX();
+    }
+  }
+
+  return minDist;
+}
+
+double distanceCapsuleCapsule(
+    const CapsuleShape& capsule1,
+    const Eigen::Isometry3d& transform1,
+    const CapsuleShape& capsule2,
+    const Eigen::Isometry3d& transform2,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const double r1 = capsule1.getRadius();
+  const double h1 = capsule1.getHeight() * 0.5;
+  const double r2 = capsule2.getRadius();
+  const double h2 = capsule2.getHeight() * 0.5;
+
+  const Eigen::Vector3d axis1 = transform1.rotation().col(2);
+  const Eigen::Vector3d axis2 = transform2.rotation().col(2);
+  const Eigen::Vector3d center1 = transform1.translation();
+  const Eigen::Vector3d center2 = transform2.translation();
+
+  const Eigen::Vector3d top1 = center1 + axis1 * h1;
+  const Eigen::Vector3d bot1 = center1 - axis1 * h1;
+  const Eigen::Vector3d top2 = center2 + axis2 * h2;
+  const Eigen::Vector3d bot2 = center2 - axis2 * h2;
+
+  auto closest = closestPointsBetweenSegments(bot1, top1, bot2, top2);
+
+  const double axisDist = std::sqrt(closest.distSq);
+  const double dist = axisDist - r1 - r2;
+
+  if (dist > option.upperBound) {
+    result.distance = dist;
+    return dist;
+  }
+
+  result.distance = dist;
+
+  if (option.enableNearestPoints) {
+    Eigen::Vector3d dir;
+    if (axisDist > 1e-10) {
+      dir = (closest.point2 - closest.point1) / axisDist;
+    } else {
+      dir = axis1.cross(axis2);
+      if (dir.squaredNorm() < 1e-10) {
+        dir = Eigen::Vector3d::UnitX();
+      }
+      dir.normalize();
+    }
+
+    result.pointOnObject1 = closest.point1 + dir * r1;
+    result.pointOnObject2 = closest.point2 - dir * r2;
+    result.normal = dir;
+  }
+
+  return dist;
+}
+
+double distanceCapsuleSphere(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const double capRadius = capsule.getRadius();
+  const double capHalfHeight = capsule.getHeight() * 0.5;
+  const double sphereRadius = sphere.getRadius();
+
+  const Eigen::Vector3d capAxis = capsuleTransform.rotation().col(2);
+  const Eigen::Vector3d capCenter = capsuleTransform.translation();
+  const Eigen::Vector3d sphereCenter = sphereTransform.translation();
+
+  const Eigen::Vector3d toSphere = sphereCenter - capCenter;
+  const double proj = toSphere.dot(capAxis);
+  const double clampedProj = std::clamp(proj, -capHalfHeight, capHalfHeight);
+  const Eigen::Vector3d closestOnAxis = capCenter + capAxis * clampedProj;
+
+  const Eigen::Vector3d diff = sphereCenter - closestOnAxis;
+  const double axisDist = diff.norm();
+  const double dist = axisDist - capRadius - sphereRadius;
+
+  if (dist > option.upperBound) {
+    result.distance = dist;
+    return dist;
+  }
+
+  result.distance = dist;
+
+  if (option.enableNearestPoints) {
+    Eigen::Vector3d dir;
+    if (axisDist > 1e-10) {
+      dir = diff / axisDist;
+    } else {
+      dir = Eigen::Vector3d::UnitX();
+    }
+
+    result.pointOnObject1 = closestOnAxis + dir * capRadius;
+    result.pointOnObject2 = sphereCenter - dir * sphereRadius;
+    result.normal = dir;
+  }
+
+  return dist;
+}
+
+double distanceCapsuleBox(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const double capRadius = capsule.getRadius();
+  const double capHalfHeight = capsule.getHeight() * 0.5;
+  const Eigen::Vector3d& boxHalf = box.getHalfExtents();
+
+  const Eigen::Vector3d capAxis = capsuleTransform.rotation().col(2);
+  const Eigen::Vector3d capCenter = capsuleTransform.translation();
+  const Eigen::Vector3d capTop = capCenter + capAxis * capHalfHeight;
+  const Eigen::Vector3d capBot = capCenter - capAxis * capHalfHeight;
+
+  const Eigen::Isometry3d boxInv = boxTransform.inverse();
+  const Eigen::Vector3d topLocal = boxInv * capTop;
+  const Eigen::Vector3d botLocal = boxInv * capBot;
+
+  double minDist = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestCapsulePoint, bestBoxPoint;
+
+  constexpr int numSamples = 5;
+  for (int i = 0; i < numSamples; ++i) {
+    const double t = static_cast<double>(i) / (numSamples - 1);
+    const Eigen::Vector3d axisPointLocal = botLocal + (topLocal - botLocal) * t;
+    const Eigen::Vector3d closestOnBox
+        = closestPointOnBox(axisPointLocal, boxHalf);
+    const double d = (axisPointLocal - closestOnBox).norm();
+
+    if (d < minDist) {
+      minDist = d;
+      bestCapsulePoint = axisPointLocal;
+      bestBoxPoint = closestOnBox;
+    }
+  }
+
+  const double dist = minDist - capRadius;
+
+  if (dist > option.upperBound) {
+    result.distance = dist;
+    return dist;
+  }
+
+  result.distance = dist;
+
+  if (option.enableNearestPoints) {
+    Eigen::Vector3d dirLocal = bestCapsulePoint - bestBoxPoint;
+    if (dirLocal.squaredNorm() > 1e-10) {
+      dirLocal.normalize();
+    } else {
+      dirLocal = Eigen::Vector3d::UnitX();
+    }
+
+    result.pointOnObject2 = boxTransform * bestBoxPoint;
+    result.pointOnObject1
+        = boxTransform * (bestCapsulePoint - dirLocal * capRadius);
+    result.normal = boxTransform.rotation() * dirLocal;
+  }
+
+  return dist;
+}
+
+double distancePlaneShape(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const Shape& shape,
+    const Eigen::Isometry3d& shapeTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const Eigen::Vector3d worldNormal
+      = planeTransform.rotation() * plane.getNormal();
+  const Eigen::Vector3d planePoint
+      = planeTransform.translation() + worldNormal * plane.getOffset();
+
+  Eigen::Vector3d supportPoint = Eigen::Vector3d::Zero();
+  if (!supportPointOnShape(shape, shapeTransform, -worldNormal, supportPoint)) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const double signedDist = worldNormal.dot(supportPoint - planePoint);
+  if (signedDist > option.upperBound) {
+    result.distance = signedDist;
+    return signedDist;
+  }
+
+  result.distance = signedDist;
+
+  if (option.enableNearestPoints) {
+    result.pointOnObject2 = supportPoint;
+    result.pointOnObject1 = supportPoint - worldNormal * signedDist;
+    const Eigen::Vector3d delta = result.pointOnObject2 - result.pointOnObject1;
+    if (delta.squaredNorm() > kSupportEps) {
+      result.normal = delta.normalized();
+    } else {
+      result.normal = worldNormal;
+    }
+  }
+
+  return signedDist;
+}
+
+double distanceSphereSdf(
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const Eigen::Vector3d center = sphereTransform.translation();
+  const double radius = sphere.getRadius();
+
+  const SignedDistanceField* field = sdf.getField();
+  if (!field) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const Eigen::Isometry3d sdf_inverse = sdfTransform.inverse();
+  const Eigen::Matrix3d sdf_rotation = sdfTransform.rotation();
+
+  SdfQueryOptions query_options;
+  query_options.maxDistance = option.upperBound + radius;
+
+  double field_distance = 0.0;
+  Eigen::Vector3d gradientWorld = Eigen::Vector3d::Zero();
+  if (!querySdfDistanceAndGradient(
+          field,
+          sdf_inverse,
+          sdf_rotation,
+          center,
+          query_options,
+          &field_distance,
+          &gradientWorld)) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const double dist = field_distance - radius;
+  result.distance = dist;
+
+  if (dist > option.upperBound) {
+    return dist;
+  }
+
+  if (option.enableNearestPoints) {
+    Eigen::Vector3d normal = Eigen::Vector3d::UnitX();
+    const double grad_norm = gradientWorld.norm();
+    if (grad_norm > 1e-12) {
+      const Eigen::Vector3d grad_unit = gradientWorld / grad_norm;
+      const double sign = (field_distance >= 0.0) ? 1.0 : -1.0;
+      normal = grad_unit * sign;
+
+      result.pointOnObject2 = center - grad_unit * field_distance;
+      result.pointOnObject1 = center + normal * radius;
+    } else {
+      result.pointOnObject2 = center;
+      result.pointOnObject1 = center + normal * radius;
+    }
+    result.normal = normal;
+  }
+
+  return dist;
+}
+
+double distanceCapsuleSdf(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const double radius = capsule.getRadius();
+  const double halfHeight = capsule.getHeight() * 0.5;
+
+  const Eigen::Vector3d axis = capsuleTransform.rotation().col(2);
+  const Eigen::Vector3d center = capsuleTransform.translation();
+  const Eigen::Vector3d top = center + axis * halfHeight;
+  const Eigen::Vector3d bottom = center - axis * halfHeight;
+
+  const SignedDistanceField* field = sdf.getField();
+  if (!field) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const Eigen::Isometry3d sdf_inverse = sdfTransform.inverse();
+  const Eigen::Matrix3d sdf_rotation = sdfTransform.rotation();
+
+  SdfQueryOptions query_options;
+  query_options.maxDistance = option.upperBound + radius;
+
+  const double voxel_size = std::max(field->voxelSize(), 1e-6);
+  const int raw_samples
+      = static_cast<int>(std::ceil(capsule.getHeight() / voxel_size)) + 1;
+  const int num_samples = std::clamp(raw_samples, 2, 32);
+
+  bool found = false;
+  double best_dist = std::numeric_limits<double>::max();
+  double best_field_distance = 0.0;
+  Eigen::Vector3d best_axis_point = Eigen::Vector3d::Zero();
+  Eigen::Vector3d best_gradient = Eigen::Vector3d::Zero();
+
+  for (int i = 0; i < num_samples; ++i) {
+    const double t
+        = (num_samples == 1) ? 0.5 : static_cast<double>(i) / (num_samples - 1);
+    const Eigen::Vector3d axis_point = bottom + (top - bottom) * t;
+
+    double field_distance = 0.0;
+    Eigen::Vector3d gradientWorld = Eigen::Vector3d::Zero();
+    if (!querySdfDistanceAndGradient(
+            field,
+            sdf_inverse,
+            sdf_rotation,
+            axis_point,
+            query_options,
+            &field_distance,
+            &gradientWorld)) {
+      continue;
+    }
+
+    const double dist = field_distance - radius;
+    if (dist < best_dist) {
+      best_dist = dist;
+      best_field_distance = field_distance;
+      best_axis_point = axis_point;
+      best_gradient = gradientWorld;
+      found = true;
+    }
+  }
+
+  if (!found) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  result.distance = best_dist;
+  if (best_dist > option.upperBound) {
+    return best_dist;
+  }
+
+  if (option.enableNearestPoints) {
+    Eigen::Vector3d normal = Eigen::Vector3d::UnitX();
+    const double grad_norm = best_gradient.norm();
+    if (grad_norm > 1e-12) {
+      const Eigen::Vector3d grad_unit = best_gradient / grad_norm;
+      const double sign = (best_field_distance >= 0.0) ? 1.0 : -1.0;
+      normal = grad_unit * sign;
+
+      result.pointOnObject2 = best_axis_point - grad_unit * best_field_distance;
+      result.pointOnObject1 = best_axis_point + normal * radius;
+    } else {
+      result.pointOnObject2 = best_axis_point;
+      result.pointOnObject1 = best_axis_point + normal * radius;
+    }
+    result.normal = normal;
+  }
+
+  return best_dist;
+}
+
+double distanceCylinderSdf(
+    const CylinderShape& cylinder,
+    const Eigen::Isometry3d& cylinderTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const SignedDistanceField* field = sdf.getField();
+  if (!field) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const double radius = cylinder.getRadius();
+  const double halfHeight = cylinder.getHeight() * 0.5;
+  const double voxelSize = std::max(field->voxelSize(), 1e-6);
+  const int axialSamples = std::clamp(
+      static_cast<int>(std::ceil(cylinder.getHeight() / voxelSize)) + 1, 2, 32);
+  const int radialSamples
+      = std::clamp(static_cast<int>(std::ceil(radius / voxelSize)) + 1, 2, 16);
+  const int angularSamples = std::clamp(
+      static_cast<int>(std::ceil(2.0 * kPi * radius / voxelSize)), 16, 64);
+
+  const Eigen::Isometry3d sdfInverse = sdfTransform.inverse();
+  const Eigen::Matrix3d sdfRotation = sdfTransform.rotation();
+
+  SdfQueryOptions queryOptions;
+  const double boundingRadius
+      = std::sqrt(radius * radius + halfHeight * halfHeight);
+  queryOptions.maxDistance
+      = boundedSdfQueryDistance(option.upperBound, boundingRadius);
+
+  bool found = false;
+  double bestDistance = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestPoint = Eigen::Vector3d::Zero();
+  Eigen::Vector3d bestGradient = Eigen::Vector3d::Zero();
+
+  const auto querySample = [&](const Eigen::Vector3d& pointLocal) {
+    const Eigen::Vector3d pointWorld = cylinderTransform * pointLocal;
+    double fieldDistance = 0.0;
+    Eigen::Vector3d gradientWorld = Eigen::Vector3d::Zero();
+    if (!querySdfDistanceAndGradient(
+            field,
+            sdfInverse,
+            sdfRotation,
+            pointWorld,
+            queryOptions,
+            &fieldDistance,
+            &gradientWorld)) {
+      return;
+    }
+
+    if (fieldDistance < bestDistance) {
+      bestDistance = fieldDistance;
+      bestPoint = pointWorld;
+      bestGradient = gradientWorld;
+      found = true;
+    }
+  };
+
+  for (int zIndex = 0; zIndex < axialSamples; ++zIndex) {
+    const double zAlpha = (axialSamples == 1)
+                              ? 0.5
+                              : static_cast<double>(zIndex)
+                                    / static_cast<double>(axialSamples - 1);
+    const double z = -halfHeight + 2.0 * halfHeight * zAlpha;
+
+    querySample(Eigen::Vector3d(0.0, 0.0, z));
+
+    for (int rIndex = 1; rIndex < radialSamples; ++rIndex) {
+      const double r = radius * static_cast<double>(rIndex)
+                       / static_cast<double>(radialSamples - 1);
+      for (int angleIndex = 0; angleIndex < angularSamples; ++angleIndex) {
+        const double theta = 2.0 * kPi * static_cast<double>(angleIndex)
+                             / static_cast<double>(angularSamples);
+        querySample(
+            Eigen::Vector3d(r * std::cos(theta), r * std::sin(theta), z));
+      }
+    }
+  }
+
+  if (!found) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  result.distance = bestDistance;
+  if (bestDistance > option.upperBound) {
+    return bestDistance;
+  }
+
+  if (option.enableNearestPoints) {
+    Eigen::Vector3d normal = Eigen::Vector3d::UnitX();
+    const double gradNorm = bestGradient.norm();
+    if (gradNorm > 1e-12) {
+      const Eigen::Vector3d gradUnit = bestGradient / gradNorm;
+      const double sign = (bestDistance >= 0.0) ? 1.0 : -1.0;
+      normal = gradUnit * sign;
+      result.pointOnObject2 = bestPoint - gradUnit * bestDistance;
+    } else {
+      result.pointOnObject2 = bestPoint;
+    }
+    result.pointOnObject1 = bestPoint;
+    result.normal = normal;
+  }
+
+  return bestDistance;
+}
+
+double distanceConvexSdf(
+    const ConvexShape& convex,
+    const Eigen::Isometry3d& convexTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  return distancePointSetSdf(
+      convex.getVertices(), convexTransform, sdf, sdfTransform, result, option);
+}
+
+double distanceMeshSdf(
+    const MeshShape& mesh,
+    const Eigen::Isometry3d& meshTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  return distancePointSetSdf(
+      mesh.getVertices(), meshTransform, sdf, sdfTransform, result, option);
+}
+
+double distanceSdfSdf(
+    const SdfShape& sdf1,
+    const Eigen::Isometry3d& sdf1Transform,
+    const SdfShape& sdf2,
+    const Eigen::Isometry3d& sdf2Transform,
+    DistanceResult& result,
+    const DistanceOption& option)
+{
+  const SignedDistanceField* field1 = sdf1.getField();
+  const SignedDistanceField* field2 = sdf2.getField();
+  if (!field1 || !field2) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  const double shellThickness
+      = 1.5 * std::max({field1->voxelSize(), field2->voxelSize(), 1e-6});
+
+  SdfSdfCandidate best;
+  bool found = sampleSdfSurfaceAgainstSdf(
+      field1,
+      sdf1Transform,
+      field2,
+      sdf2Transform,
+      shellThickness,
+      option,
+      best);
+
+  SdfSdfCandidate reverseBest;
+  if (sampleSdfSurfaceAgainstSdf(
+          field2,
+          sdf2Transform,
+          field1,
+          sdf1Transform,
+          shellThickness,
+          option,
+          reverseBest)
+      && reverseBest.distance < best.distance) {
+    best.distance = reverseBest.distance;
+    best.pointOnSource = reverseBest.pointOnTarget;
+    best.pointOnTarget = reverseBest.pointOnSource;
+    best.normalSourceToTarget = -reverseBest.normalSourceToTarget;
+    found = true;
+  }
+
+  if (!found) {
+    result.distance = std::numeric_limits<double>::max();
+    return result.distance;
+  }
+
+  result.distance = best.distance;
+  if (best.distance > option.upperBound) {
+    return best.distance;
+  }
+
+  if (option.enableNearestPoints) {
+    result.pointOnObject1 = best.pointOnSource;
+    result.pointOnObject2 = best.pointOnTarget;
+    result.normal = best.normalSourceToTarget;
+  }
+
+  return best.distance;
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/distance.cpp
+++ b/dart/collision/native/narrow_phase/distance.cpp
@@ -1091,8 +1091,42 @@ double distanceCapsuleBox(
   const Eigen::Vector3d bestBoxPoint = closestPointOnSegmentInBoxSpace(
       botLocal, topLocal, boxHalf, bestCapsulePoint);
   const double minDist = (bestCapsulePoint - bestBoxPoint).norm();
+  const double boundaryTolerance
+      = computeBoxBoundaryTolerance(boxHalf, bestCapsulePoint);
 
-  const double dist = minDist - capRadius;
+  Eigen::Vector3d dirLocal = bestCapsulePoint - bestBoxPoint;
+  Eigen::Vector3d pointOnBoxLocal = bestBoxPoint;
+  double dist = minDist - capRadius;
+
+  if (minDist > boundaryTolerance) {
+    dirLocal /= minDist;
+  } else {
+    Eigen::Vector3d insideLocalCapsulePoint = bestCapsulePoint;
+    snapNearBoxBoundary(insideLocalCapsulePoint, boxHalf, boundaryTolerance);
+
+    double minFaceDist = boxHalf.x() - std::abs(insideLocalCapsulePoint.x());
+    int minAxis = 0;
+
+    const double distY = boxHalf.y() - std::abs(insideLocalCapsulePoint.y());
+    if (distY < minFaceDist) {
+      minFaceDist = distY;
+      minAxis = 1;
+    }
+
+    const double distZ = boxHalf.z() - std::abs(insideLocalCapsulePoint.z());
+    if (distZ < minFaceDist) {
+      minFaceDist = distZ;
+      minAxis = 2;
+    }
+
+    minFaceDist = std::max(0.0, minFaceDist);
+    dirLocal = Eigen::Vector3d::Zero();
+    dirLocal[minAxis] = (insideLocalCapsulePoint[minAxis] >= 0.0) ? 1.0 : -1.0;
+    pointOnBoxLocal = insideLocalCapsulePoint;
+    pointOnBoxLocal[minAxis]
+        = dirLocal[minAxis] > 0.0 ? boxHalf[minAxis] : -boxHalf[minAxis];
+    dist = -(capRadius + minFaceDist);
+  }
 
   if (dist > option.upperBound) {
     result.distance = dist;
@@ -1102,14 +1136,7 @@ double distanceCapsuleBox(
   result.distance = dist;
 
   if (option.enableNearestPoints) {
-    Eigen::Vector3d dirLocal = bestCapsulePoint - bestBoxPoint;
-    if (dirLocal.squaredNorm() > 1e-10) {
-      dirLocal.normalize();
-    } else {
-      dirLocal = Eigen::Vector3d::UnitX();
-    }
-
-    result.pointOnObject2 = boxTransform * bestBoxPoint;
+    result.pointOnObject2 = boxTransform * pointOnBoxLocal;
     result.pointOnObject1
         = boxTransform * (bestCapsulePoint - dirLocal * capRadius);
     result.normal = boxTransform.rotation() * dirLocal;

--- a/dart/collision/native/narrow_phase/distance.cpp
+++ b/dart/collision/native/narrow_phase/distance.cpp
@@ -1239,7 +1239,7 @@ double distanceSphereSdf(
       normal = grad_unit * sign;
 
       result.pointOnObject2 = center - grad_unit * field_distance;
-      result.pointOnObject1 = center + normal * radius;
+      result.pointOnObject1 = center - normal * radius;
     } else {
       result.pointOnObject2 = center;
       result.pointOnObject1 = center + normal * radius;
@@ -1336,7 +1336,7 @@ double distanceCapsuleSdf(
       normal = grad_unit * sign;
 
       result.pointOnObject2 = best_axis_point - grad_unit * best_field_distance;
-      result.pointOnObject1 = best_axis_point + normal * radius;
+      result.pointOnObject1 = best_axis_point - normal * radius;
     } else {
       result.pointOnObject2 = best_axis_point;
       result.pointOnObject1 = best_axis_point + normal * radius;

--- a/dart/collision/native/narrow_phase/distance.hpp
+++ b/dart/collision/native/narrow_phase/distance.hpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/collision/native/export.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace dart::collision::native {
+
+class BoxShape;
+class CapsuleShape;
+class ConvexShape;
+class CylinderShape;
+class MeshShape;
+class PlaneShape;
+class Shape;
+class SphereShape;
+class SdfShape;
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceSphereSphere(
+    const SphereShape& sphere1,
+    const Eigen::Isometry3d& transform1,
+    const SphereShape& sphere2,
+    const Eigen::Isometry3d& transform2,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceSphereBox(
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceBoxBox(
+    const BoxShape& box1,
+    const Eigen::Isometry3d& transform1,
+    const BoxShape& box2,
+    const Eigen::Isometry3d& transform2,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceCapsuleCapsule(
+    const CapsuleShape& capsule1,
+    const Eigen::Isometry3d& transform1,
+    const CapsuleShape& capsule2,
+    const Eigen::Isometry3d& transform2,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceCapsuleSphere(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceCapsuleBox(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distancePlaneShape(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const Shape& shape,
+    const Eigen::Isometry3d& shapeTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceSphereSdf(
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceCapsuleSdf(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceCylinderSdf(
+    const CylinderShape& cylinder,
+    const Eigen::Isometry3d& cylinderTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceConvexSdf(
+    const ConvexShape& convex,
+    const Eigen::Isometry3d& convexTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceMeshSdf(
+    const MeshShape& mesh,
+    const Eigen::Isometry3d& meshTransform,
+    const SdfShape& sdf,
+    const Eigen::Isometry3d& sdfTransform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API double distanceSdfSdf(
+    const SdfShape& sdf1,
+    const Eigen::Isometry3d& sdf1Transform,
+    const SdfShape& sdf2,
+    const Eigen::Isometry3d& sdf2Transform,
+    DistanceResult& result,
+    const DistanceOption& option = DistanceOption());
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/narrow_phase.cpp
+++ b/dart/collision/native/narrow_phase/narrow_phase.cpp
@@ -38,6 +38,7 @@
 #include <dart/collision/native/narrow_phase/cylinder_collision.hpp>
 #include <dart/collision/native/narrow_phase/mesh_mesh.hpp>
 #include <dart/collision/native/narrow_phase/narrow_phase.hpp>
+#include <dart/collision/native/narrow_phase/plane_sphere.hpp>
 #include <dart/collision/native/narrow_phase/sphere_box.hpp>
 #include <dart/collision/native/narrow_phase/sphere_sphere.hpp>
 #include <dart/collision/native/shapes/shape.hpp>
@@ -130,6 +131,74 @@ bool collideShapes(
     const auto* b1 = static_cast<const BoxShape*>(shape1);
     const auto* b2 = static_cast<const BoxShape*>(shape2);
     return collideBoxes(*b1, tf1, *b2, tf2, result, option);
+  }
+
+  if (type1 == ShapeType::Plane && type2 == ShapeType::Sphere) {
+    const auto* p = static_cast<const PlaneShape*>(shape1);
+    const auto* s = static_cast<const SphereShape*>(shape2);
+    return collideWithFlippedNormals(
+        result,
+        option,
+        [&](CollisionResult& local, const CollisionOption& opt) {
+          return collidePlaneSphere(*p, tf1, *s, tf2, local, opt);
+        });
+  }
+
+  if (type1 == ShapeType::Sphere && type2 == ShapeType::Plane) {
+    const auto* s = static_cast<const SphereShape*>(shape1);
+    const auto* p = static_cast<const PlaneShape*>(shape2);
+    return collidePlaneSphere(*p, tf2, *s, tf1, result, option);
+  }
+
+  if (type1 == ShapeType::Plane && type2 == ShapeType::Box) {
+    const auto* p = static_cast<const PlaneShape*>(shape1);
+    const auto* b = static_cast<const BoxShape*>(shape2);
+    return collideWithFlippedNormals(
+        result,
+        option,
+        [&](CollisionResult& local, const CollisionOption& opt) {
+          return collidePlaneBox(*p, tf1, *b, tf2, local, opt);
+        });
+  }
+
+  if (type1 == ShapeType::Box && type2 == ShapeType::Plane) {
+    const auto* b = static_cast<const BoxShape*>(shape1);
+    const auto* p = static_cast<const PlaneShape*>(shape2);
+    return collidePlaneBox(*p, tf2, *b, tf1, result, option);
+  }
+
+  if (type1 == ShapeType::Plane && type2 == ShapeType::Capsule) {
+    const auto* p = static_cast<const PlaneShape*>(shape1);
+    const auto* c = static_cast<const CapsuleShape*>(shape2);
+    return collideWithFlippedNormals(
+        result,
+        option,
+        [&](CollisionResult& local, const CollisionOption& opt) {
+          return collidePlaneCapsule(*p, tf1, *c, tf2, local, opt);
+        });
+  }
+
+  if (type1 == ShapeType::Capsule && type2 == ShapeType::Plane) {
+    const auto* c = static_cast<const CapsuleShape*>(shape1);
+    const auto* p = static_cast<const PlaneShape*>(shape2);
+    return collidePlaneCapsule(*p, tf2, *c, tf1, result, option);
+  }
+
+  if (type1 == ShapeType::Plane && type2 == ShapeType::Convex) {
+    const auto* p = static_cast<const PlaneShape*>(shape1);
+    const auto* c = static_cast<const ConvexShape*>(shape2);
+    return collideWithFlippedNormals(
+        result,
+        option,
+        [&](CollisionResult& local, const CollisionOption& opt) {
+          return collidePlaneConvex(*p, tf1, *c, tf2, local, opt);
+        });
+  }
+
+  if (type1 == ShapeType::Convex && type2 == ShapeType::Plane) {
+    const auto* c = static_cast<const ConvexShape*>(shape1);
+    const auto* p = static_cast<const PlaneShape*>(shape2);
+    return collidePlaneConvex(*p, tf2, *c, tf1, result, option);
   }
 
   if (type1 == ShapeType::Sphere && type2 == ShapeType::Box) {
@@ -380,6 +449,16 @@ bool NarrowPhase::isSupported(ShapeType type1, ShapeType type2)
     return true;
   }
   if (type1 == ShapeType::Box && type2 == ShapeType::Box) {
+    return true;
+  }
+  if ((type1 == ShapeType::Plane && type2 == ShapeType::Sphere)
+      || (type1 == ShapeType::Sphere && type2 == ShapeType::Plane)
+      || (type1 == ShapeType::Plane && type2 == ShapeType::Box)
+      || (type1 == ShapeType::Box && type2 == ShapeType::Plane)
+      || (type1 == ShapeType::Plane && type2 == ShapeType::Capsule)
+      || (type1 == ShapeType::Capsule && type2 == ShapeType::Plane)
+      || (type1 == ShapeType::Plane && type2 == ShapeType::Convex)
+      || (type1 == ShapeType::Convex && type2 == ShapeType::Plane)) {
     return true;
   }
   if ((type1 == ShapeType::Sphere && type2 == ShapeType::Box)

--- a/dart/collision/native/narrow_phase/plane_sphere.cpp
+++ b/dart/collision/native/narrow_phase/plane_sphere.cpp
@@ -53,6 +53,11 @@ bool contactBudgetPrecludesDetection(
   return option.enableContact && result.numContacts() >= option.maxNumContacts;
 }
 
+double contactTieTolerance(double scale)
+{
+  return 64.0 * std::numeric_limits<double>::epsilon() * std::max(1.0, scale);
+}
+
 } // namespace
 
 bool collidePlaneSphere(
@@ -118,7 +123,6 @@ bool collidePlaneBox(
   const Eigen::Vector3d& halfExtents = box.getHalfExtents();
 
   double minDist = std::numeric_limits<double>::max();
-  Eigen::Vector3d deepestCorner;
 
   for (int i = 0; i < 8; ++i) {
     const Eigen::Vector3d localCorner(
@@ -131,7 +135,6 @@ bool collidePlaneBox(
 
     if (signedDist < minDist) {
       minDist = signedDist;
-      deepestCorner = worldCorner;
     }
   }
 
@@ -144,8 +147,31 @@ bool collidePlaneBox(
   }
 
   const double penetration = -minDist;
+  const double tieTolerance = contactTieTolerance(std::max(
+      {halfExtents.cwiseAbs().maxCoeff(),
+       boxTransform.translation().cwiseAbs().maxCoeff(),
+       planePoint.cwiseAbs().maxCoeff(),
+       std::abs(minDist)}));
+  Eigen::Vector3d deepestCentroid = Eigen::Vector3d::Zero();
+  int numDeepestCorners = 0;
+
+  for (int i = 0; i < 8; ++i) {
+    const Eigen::Vector3d localCorner(
+        (i & 1) ? halfExtents.x() : -halfExtents.x(),
+        (i & 2) ? halfExtents.y() : -halfExtents.y(),
+        (i & 4) ? halfExtents.z() : -halfExtents.z());
+
+    const Eigen::Vector3d worldCorner = boxTransform * localCorner;
+    const double signedDist = worldNormal.dot(worldCorner - planePoint);
+    if (signedDist <= minDist + tieTolerance) {
+      deepestCentroid += worldCorner;
+      ++numDeepestCorners;
+    }
+  }
+  deepestCentroid /= static_cast<double>(numDeepestCorners);
+
   const Eigen::Vector3d contactPoint
-      = deepestCorner + worldNormal * (penetration * 0.5);
+      = deepestCentroid + worldNormal * (penetration * 0.5);
 
   ContactPoint contact;
   contact.position = contactPoint;
@@ -186,13 +212,23 @@ bool collidePlaneCapsule(
   const double distTop = worldNormal.dot(worldTop - planePoint);
   const double distBottom = worldNormal.dot(worldBottom - planePoint);
 
-  const Eigen::Vector3d* closestEndpoint;
+  const double tieTolerance = contactTieTolerance(std::max(
+      {std::abs(distTop),
+       std::abs(distBottom),
+       radius,
+       halfHeight,
+       capsuleTransform.translation().cwiseAbs().maxCoeff(),
+       planePoint.cwiseAbs().maxCoeff()}));
+  Eigen::Vector3d closestAxisPoint;
   double minDist;
-  if (distTop < distBottom) {
-    closestEndpoint = &worldTop;
+  if (std::abs(distTop - distBottom) <= tieTolerance) {
+    closestAxisPoint = 0.5 * (worldTop + worldBottom);
+    minDist = 0.5 * (distTop + distBottom);
+  } else if (distTop < distBottom) {
+    closestAxisPoint = worldTop;
     minDist = distTop;
   } else {
-    closestEndpoint = &worldBottom;
+    closestAxisPoint = worldBottom;
     minDist = distBottom;
   }
 
@@ -206,7 +242,7 @@ bool collidePlaneCapsule(
 
   const double penetration = radius - minDist;
   const Eigen::Vector3d contactPoint
-      = *closestEndpoint - worldNormal * (0.5 * (radius + minDist));
+      = closestAxisPoint - worldNormal * (0.5 * (radius + minDist));
 
   ContactPoint contact;
   contact.position = contactPoint;

--- a/dart/collision/native/narrow_phase/plane_sphere.cpp
+++ b/dart/collision/native/narrow_phase/plane_sphere.cpp
@@ -41,6 +41,20 @@
 
 namespace dart::collision::native {
 
+namespace {
+
+bool contactBudgetPrecludesDetection(
+    const CollisionResult& result, const CollisionOption& option)
+{
+  if (option.maxNumContacts == 0) {
+    return true;
+  }
+
+  return option.enableContact && result.numContacts() >= option.maxNumContacts;
+}
+
+} // namespace
+
 bool collidePlaneSphere(
     const PlaneShape& plane,
     const Eigen::Isometry3d& planeTransform,
@@ -49,7 +63,7 @@ bool collidePlaneSphere(
     CollisionResult& result,
     const CollisionOption& option)
 {
-  if (result.numContacts() >= option.maxNumContacts) {
+  if (contactBudgetPrecludesDetection(result, option)) {
     return false;
   }
 
@@ -92,7 +106,7 @@ bool collidePlaneBox(
     CollisionResult& result,
     const CollisionOption& option)
 {
-  if (result.numContacts() >= option.maxNumContacts) {
+  if (contactBudgetPrecludesDetection(result, option)) {
     return false;
   }
 
@@ -151,7 +165,7 @@ bool collidePlaneCapsule(
     CollisionResult& result,
     const CollisionOption& option)
 {
-  if (result.numContacts() >= option.maxNumContacts) {
+  if (contactBudgetPrecludesDetection(result, option)) {
     return false;
   }
 
@@ -212,7 +226,7 @@ bool collidePlaneConvex(
     CollisionResult& result,
     const CollisionOption& option)
 {
-  if (result.numContacts() >= option.maxNumContacts) {
+  if (contactBudgetPrecludesDetection(result, option)) {
     return false;
   }
 

--- a/dart/collision/native/narrow_phase/plane_sphere.cpp
+++ b/dart/collision/native/narrow_phase/plane_sphere.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/distance.hpp>
+#include <dart/collision/native/narrow_phase/plane_sphere.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+
+#include <algorithm>
+#include <limits>
+
+#include <cmath>
+
+namespace dart::collision::native {
+
+bool collidePlaneSphere(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    CollisionResult& result,
+    const CollisionOption& option)
+{
+  if (result.numContacts() >= option.maxNumContacts) {
+    return false;
+  }
+
+  const Eigen::Vector3d worldNormal
+      = planeTransform.rotation() * plane.getNormal();
+  const Eigen::Vector3d planePoint
+      = planeTransform.translation() + worldNormal * plane.getOffset();
+
+  const Eigen::Vector3d sphereCenter = sphereTransform.translation();
+  const double radius = sphere.getRadius();
+
+  const double signedDist = worldNormal.dot(sphereCenter - planePoint);
+
+  if (signedDist > radius) {
+    return false;
+  }
+
+  if (!option.enableContact) {
+    return true;
+  }
+
+  const double penetration = radius - signedDist;
+  const Eigen::Vector3d contactPoint = sphereCenter - worldNormal * signedDist;
+
+  ContactPoint contact;
+  contact.position = contactPoint;
+  contact.normal = worldNormal;
+  contact.depth = penetration;
+
+  result.addContact(contact);
+
+  return true;
+}
+
+bool collidePlaneBox(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    CollisionResult& result,
+    const CollisionOption& option)
+{
+  if (result.numContacts() >= option.maxNumContacts) {
+    return false;
+  }
+
+  const Eigen::Vector3d worldNormal
+      = planeTransform.rotation() * plane.getNormal();
+  const Eigen::Vector3d planePoint
+      = planeTransform.translation() + worldNormal * plane.getOffset();
+
+  const Eigen::Vector3d& halfExtents = box.getHalfExtents();
+
+  double minDist = std::numeric_limits<double>::max();
+  Eigen::Vector3d deepestCorner;
+
+  for (int i = 0; i < 8; ++i) {
+    const Eigen::Vector3d localCorner(
+        (i & 1) ? halfExtents.x() : -halfExtents.x(),
+        (i & 2) ? halfExtents.y() : -halfExtents.y(),
+        (i & 4) ? halfExtents.z() : -halfExtents.z());
+
+    const Eigen::Vector3d worldCorner = boxTransform * localCorner;
+    const double signedDist = worldNormal.dot(worldCorner - planePoint);
+
+    if (signedDist < minDist) {
+      minDist = signedDist;
+      deepestCorner = worldCorner;
+    }
+  }
+
+  if (minDist > 0.0) {
+    return false;
+  }
+
+  if (!option.enableContact) {
+    return true;
+  }
+
+  const double penetration = -minDist;
+  const Eigen::Vector3d contactPoint
+      = deepestCorner + worldNormal * (penetration * 0.5);
+
+  ContactPoint contact;
+  contact.position = contactPoint;
+  contact.normal = worldNormal;
+  contact.depth = penetration;
+
+  result.addContact(contact);
+
+  return true;
+}
+
+bool collidePlaneCapsule(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    CollisionResult& result,
+    const CollisionOption& option)
+{
+  if (result.numContacts() >= option.maxNumContacts) {
+    return false;
+  }
+
+  const Eigen::Vector3d worldNormal
+      = planeTransform.rotation() * plane.getNormal();
+  const Eigen::Vector3d planePoint
+      = planeTransform.translation() + worldNormal * plane.getOffset();
+
+  const double radius = capsule.getRadius();
+  const double halfHeight = capsule.getHeight() * 0.5;
+
+  const Eigen::Vector3d localTop(0, 0, halfHeight);
+  const Eigen::Vector3d localBottom(0, 0, -halfHeight);
+
+  const Eigen::Vector3d worldTop = capsuleTransform * localTop;
+  const Eigen::Vector3d worldBottom = capsuleTransform * localBottom;
+
+  const double distTop = worldNormal.dot(worldTop - planePoint);
+  const double distBottom = worldNormal.dot(worldBottom - planePoint);
+
+  const Eigen::Vector3d* closestEndpoint;
+  double minDist;
+  if (distTop < distBottom) {
+    closestEndpoint = &worldTop;
+    minDist = distTop;
+  } else {
+    closestEndpoint = &worldBottom;
+    minDist = distBottom;
+  }
+
+  if (minDist > radius) {
+    return false;
+  }
+
+  if (!option.enableContact) {
+    return true;
+  }
+
+  const double penetration = radius - minDist;
+  const Eigen::Vector3d contactPoint
+      = *closestEndpoint - worldNormal * (minDist - penetration * 0.5);
+
+  ContactPoint contact;
+  contact.position = contactPoint;
+  contact.normal = worldNormal;
+  contact.depth = penetration;
+
+  result.addContact(contact);
+
+  return true;
+}
+
+bool collidePlaneConvex(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const ConvexShape& convex,
+    const Eigen::Isometry3d& convexTransform,
+    CollisionResult& result,
+    const CollisionOption& option)
+{
+  if (result.numContacts() >= option.maxNumContacts) {
+    return false;
+  }
+
+  DistanceResult distanceResult;
+  const double signedDist = distancePlaneShape(
+      plane,
+      planeTransform,
+      convex,
+      convexTransform,
+      distanceResult,
+      DistanceOption::unlimited());
+
+  if (!std::isfinite(signedDist) || signedDist > 0.0) {
+    return false;
+  }
+
+  if (!option.enableContact) {
+    return true;
+  }
+
+  const Eigen::Vector3d worldNormal
+      = planeTransform.rotation() * plane.getNormal();
+  const double penetration = -signedDist;
+  const Eigen::Vector3d contactPoint
+      = distanceResult.pointOnObject2 + worldNormal * (penetration * 0.5);
+
+  ContactPoint contact;
+  contact.position = contactPoint;
+  contact.normal = worldNormal;
+  contact.depth = penetration;
+
+  result.addContact(contact);
+  return true;
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/plane_sphere.cpp
+++ b/dart/collision/native/narrow_phase/plane_sphere.cpp
@@ -192,7 +192,7 @@ bool collidePlaneCapsule(
 
   const double penetration = radius - minDist;
   const Eigen::Vector3d contactPoint
-      = *closestEndpoint - worldNormal * (minDist - penetration * 0.5);
+      = *closestEndpoint - worldNormal * (0.5 * (radius + minDist));
 
   ContactPoint contact;
   contact.position = contactPoint;

--- a/dart/collision/native/narrow_phase/plane_sphere.hpp
+++ b/dart/collision/native/narrow_phase/plane_sphere.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/collision/native/export.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace dart::collision::native {
+
+class PlaneShape;
+class SphereShape;
+class BoxShape;
+class CapsuleShape;
+class ConvexShape;
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool collidePlaneSphere(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    CollisionResult& result,
+    const CollisionOption& option = CollisionOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool collidePlaneBox(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    CollisionResult& result,
+    const CollisionOption& option = CollisionOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool collidePlaneCapsule(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    CollisionResult& result,
+    const CollisionOption& option = CollisionOption());
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool collidePlaneConvex(
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const ConvexShape& convex,
+    const Eigen::Isometry3d& convexTransform,
+    CollisionResult& result,
+    const CollisionOption& option = CollisionOption());
+
+} // namespace dart::collision::native

--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -12,7 +12,7 @@
 >   names (a project convention; see the naming note in
 >   `02-default-environment-split.md`).
 >
-> _Last updated: 2026-07-07._
+> _Last updated: 2026-07-08._
 
 ## Lanes & owners
 
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271) + phase 1 (#3281) merged; phase 2 in progress: P1 (#3303), P2 (#3306), and P3a (#3318) merged; P3b (#3319) open |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271) + phase 1 (#3281) merged; phase 2 in progress: P1-P7 merged through mesh (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325); P8/P9 active on `feature/native-distance-plane` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -81,6 +81,15 @@
   2026-07-06).
 - **#3318** phase-2 P3a adapter skeleton + sphere/box conversion, intentionally
   unregistered (merged 2026-07-07).
+- **#3319** phase-2 P3b bridge translation, `"native"` registration, `sphere_box`,
+  and parity coverage (merged 2026-07-07).
+- **#3321** phase-2 P4 capsule primitive pairs (merged 2026-07-07).
+- **#3322** phase-2 P5 convex foundation and capsule-capsule (merged
+  2026-07-07).
+- **#3324** phase-2 P6 cylinder collision pairs (merged 2026-07-07).
+- **#3325** phase-2 P7 mesh collision pairs (merged 2026-07-08).
+- **#3283** main-branch dual for the native sphere-sphere binary-check fix
+  (merged 2026-07-07).
 
 ### ✅ Merged — former monitoring queue (all landed by 2026-07-04)
 
@@ -93,19 +102,17 @@
   **#3239** release-branch AI enforcement stack · **#3245** MSVC SIMD fix ·
   **#3233** release CI concurrency fix.
 
-### 🔄 Open — monitoring (checked 2026-07-07)
+### 🔄 Open — monitoring (checked 2026-07-08)
 
-- **#3317** `docs/phase2-handoff` — handoff/dashboard synchronization for the
-  phase-2 native-collision stack. Review fixes are applied; hosted CI is queued.
-- **#3319** `feature/native-detector-bridge` — phase-2 P3b bridge translation +
-  delayed `"native"` factory registration. Codex review is clean; hosted CI is
-  queued/running.
-- **#3321 / #3322 / #3324 / #3325** — stacked phase-2 pair-coverage PRs
-  (capsule primitives, convex foundation, cylinder, mesh). Hosted CI is queued
-  or running; #3325 has follow-up review fixes pushed.
-- **#3283** `fix/native-sphere-binary-check` — main-branch dual of merged
-  release-6.20 #3298.
-- The perf lane's WP-PG.01 baseline packet **#3263** merged 2026-07-06.
+- **P8/P9** `feature/native-distance-plane` — active local slice for the
+  distance module and plane primitive/convex coverage. Keep it one PR to reduce
+  CI overhead.
+- **#3341** is the only current open `release-6.20` PR seen during this refresh;
+  it belongs to the separate performance-generalization lane, not this native
+  collision port lane.
+- The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
+  #3324, and #3325 are merged. The perf lane's WP-PG.01 baseline packet
+  **#3263** also merged.
 
 Related remote heads still visible: `feature/native-occupancy-grid`,
 `task/native-collision-performance-exec`, and six `perf/dart6-*` round-1
@@ -118,12 +125,10 @@ before treating it as an open/active PR.)_
 
 ### 🛠️ Native-collision-port lane (the largest dependency lever — FCL/Bullet/ODE)
 - **Current state:** DART 6.20 now contains #3281's internal native math core,
-  phase-2 P1/P2, and the P3a adapter skeleton, but it has no registered
-  `"native"` factory key and no FCL-optional default.
+  phase-2 P1-P7, the DART 6 adapter, and the opt-in `"native"` factory key,
+  but it has no FCL-optional default.
   `release-6.20` still uses FCL as the default detector — created in *both*
-  `ConstraintSolver` constructors (`dart/constraint/ConstraintSolver.cpp:336`
-  and `:353` at `1e6a8332a730`; the `:322`/`:342` refs in `03` predate recent
-  merges).
+  `ConstraintSolver` constructors.
 - **Phase 0 (captured 2026-07-04, recaptured 2026-07-05):** all
   evidence-harness prerequisites merged (#3209 container workload, #3230
   dashboard capture path); the baseline packet is recorded in
@@ -134,12 +139,12 @@ before treating it as an open/active PR.)_
   sequencing. For the phase-6 tolerance gate, retrieve JSONL dumps matching
   the recorded SHA-256 digests or recapture dumps on the flip PR's parent
   and compare within that same recapture.
-- **Phase 2 status:** P1 broadphase (#3303), P2 dispatcher (#3306), and P3a
-  adapter skeleton (#3318) are merged. **Next merge target is P3b (#3319):**
-  bridge `collide()` translation, `sphere_box`, normal calibration, and delayed
-  `"native"` factory registration after real contacts work. P4-P7 pair coverage
-  is open as stacked PRs (#3321/#3322/#3324/#3325). P8/P9 distance+plane work is
-  being kept consolidated to avoid extra CI waves.
+- **Phase 2 status:** P1-P7 are merged: broadphase, dispatcher, adapter bridge,
+  `"native"` registration, sphere/box/capsule/convex/cylinder/mesh coverage, and
+  associated parity tests. **Current slice is P8/P9:** distance module +
+  plane-sphere/box/capsule/convex routes, kept consolidated to avoid another CI
+  wave. P10 remains optional mixed-scene fcl/dart/native parity coverage after
+  P9.
 - **Default flip:** still late-phase only. Do not flip defaults until `03`'s full
   A/B packet and gz gate pass.
 - _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
@@ -151,8 +156,8 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `634c20d1b9a1bb9e009535e7d7c523d6c4dde12f`; `origin/main` =
-     `82372aa6fed623bd6ba1e16045fce683bcb52ba7`.
+     `44645974b3570b35db11c6c251117cc4d8dea624`; `origin/main` =
+     `a1128c429223622790bf128c4a57f1e5d2c40b9b`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
    - All remote mutations are owned by the maintainer.
@@ -189,9 +194,10 @@ before treating it as an open/active PR.)_
 - **Just landed (2026-06-22):** legacy `dart/integration` dead-code removal (#3122);
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
-- **Open queue (2026-07-07):** #3317, #3319, #3321, #3322, #3324, #3325, and
-  main-branch dual #3283. The former #3263/#3271/#3281/#3302/#3303/#3306/#3318
-  lane milestones are merged.
+- **Open queue (2026-07-08):** no open native-collision release PRs remain after
+  #3325. P8/P9 is active locally on `feature/native-distance-plane`; the former
+  #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319/#3321/#3322/#3324/#3325
+  lane milestones and main-branch dual #3283 are merged.
 - **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE
   optional and eventually drops `fcl` from core. The DART 7 native engine is
   only partially ported to DART 6.20; default-flip is still a late-phase

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -1,6 +1,6 @@
 # HANDOFF — DART 6.20 dependency minimization (native collision port)
 
-> Session handoff, 2026-07-06. Read [README.md](README.md) (overall SSOT),
+> Session handoff, refreshed 2026-07-08. Read [README.md](README.md) (overall SSOT),
 > then [03-native-collision-port-scoping.md](03-native-collision-port-scoping.md)
 > (plan of record for the remaining work), then
 > [07-phase2-adapter-scoping.md](07-phase2-adapter-scoping.md) (phase-2 execution
@@ -40,7 +40,7 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 - **#3281** phase-1 native math core → `dart/collision/native/` (internal-only,
   FCL default). Includes `06-phase1-port-packet.md`.
 - **#3298** fix: `maxNumContacts == 0` short-circuit in native sphere-sphere
-  (release-6.20). Its main-branch dual is **#3283 (still OPEN — see §5)**.
+  (release-6.20). Its main-branch dual **#3283** is also merged.
 - **#3302** phase-2 execution plan (`07-phase2-adapter-scoping.md`) + this RESUME.
 - **#3303** phase-2 **P1**: native BruteForce broadphase (internal-only).
 - **#3306** phase-2 **P2**: narrowphase dispatcher (sphere/box only) →
@@ -48,8 +48,14 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 - **#3318** phase-2 **P3a**: adapter skeleton + sphere/box conversion,
   intentionally unregistered. The `"native"` factory key still does not exist
   until P3b.
+- **#3319** phase-2 **P3b**: bridge translation, `"native"` factory
+  registration, `sphere_box`, and native-vs-fcl/dart parity.
+- **#3321** phase-2 **P4**: capsule primitive pairs.
+- **#3322** phase-2 **P5**: convex foundation and capsule-capsule.
+- **#3324** phase-2 **P6**: cylinder collision pairs.
+- **#3325** phase-2 **P7**: mesh collision pairs.
 
-`origin/release-6.20` tip at this refresh: `634c20d1b9a1` (moves as the
+`origin/release-6.20` tip at this refresh: `44645974b35` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
 ## 4. Phase 2 — the active work (plan: `07`, PR slices P1–P9 + P10)
@@ -64,28 +70,32 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **P1** | BroadPhase base + BruteForce (pure engine) | ✅ **merged (#3303)** |
 | **P2** | Narrowphase dispatcher, sphere/box only (bespoke §2.1 trim) | ✅ **merged (#3306)** |
 | **P3a** | Adapter skeleton + `NativeShapeConversion`(sphere,box), intentionally **unregistered**; `collide()` is a documented **stub** | ✅ **merged (#3318)** |
-| **P3b** | Bridge `collide()` translation + `"native"` factory registration + `sphere_box` collider + normal calibration (R1) + parity vs **fcl and dart** | 🔄 **open (#3319)** |
-| **P4** | `capsule_sphere`, `capsule_box` (no-span primitives) | 🔄 **open (#3321)** |
-| **P5** | `convex_convex` (keystone) + `capsule_capsule` (first span pair) | 🔄 **open (#3322)** |
-| **P6** | `cylinder_collision` (needs convex_convex) | 🔄 **open (#3324)** |
-| **P7** | `mesh_mesh` (needs convex_convex; largest file) | 🔄 **open (#3325)** |
-| **P8** | `distance` module (engine-only; needs span shim) | local combined with P9; unpublished |
-| **P9** | `plane_sphere` (needs `distance`) → completes primitive+convex+mesh+plane | local combined with P8; unpublished |
+| **P3b** | Bridge `collide()` translation + `"native"` factory registration + `sphere_box` collider + normal calibration (R1) + parity vs **fcl and dart** | ✅ **merged (#3319)** |
+| **P4** | `capsule_sphere`, `capsule_box` (no-span primitives) | ✅ **merged (#3321)** |
+| **P5** | `convex_convex` (keystone) + `capsule_capsule` (first span pair) | ✅ **merged (#3322)** |
+| **P6** | `cylinder_collision` (needs convex_convex) | ✅ **merged (#3324)** |
+| **P7** | `mesh_mesh` (needs convex_convex; largest file) | ✅ **merged (#3325)** |
+| **P8** | `distance` module (engine-only; needs span shim) | 🔄 active on `feature/native-distance-plane`, combined with P9 |
+| **P9** | `plane_sphere` (needs `distance`) → completes primitive+convex+mesh+plane | 🔄 active on `feature/native-distance-plane`, combined with P8 |
 | **P10** | (optional) mixed-scene fcl/dart/native parity integration test | after P9 |
 
-### Exact next step: execute P3b
+### Exact next step: execute P8/P9
 
-1. Continue with **#3319** (`feature/native-detector-bridge`), after merging
-   the latest `origin/release-6.20` into the PR branch before any push.
-2. Implement/verify per `07` **§1.5** (bridge `collide()` translation,
-   pair-only result mode, global/per-pair caps, normal orientation) and
-   **§1.6** (delayed `"native"` factory registration; **no**
-   `CollisionDetectorType::Native` enum), and the **P3b row in §3**.
-3. Proof gates specific to P3b: `EXPECT_TRUE(getFactory()->canCreate("native"))`
-   after the bridge produces real contacts; SKEL `"native"` resolves to the
-   new detector; parity vs both **fcl** and **dart** on sphere-sphere, box-box,
-   and sphere-box.
-4. Gates for **every** phase-2 PR (see `07` §3 — note the corrected commands):
+1. Continue with the consolidated **P8/P9** branch
+   `feature/native-distance-plane`, based on the current
+   `origin/release-6.20`.
+2. Keep it as one PR to avoid another CI wave: port `distance.{hpp,cpp}`,
+   `plane_sphere.{hpp,cpp}`, dispatcher plane routes, and focused distance /
+   plane-pair tests. `NativeCollisionDetector::distance()` remains stubbed in
+   phase 2; this slice only provides the engine distance helpers needed by the
+   plane pair implementation.
+3. Include performance evidence for the newly routed plane rows. Baseline
+   `origin/release-6.20` plus benchmark rows should report unsupported; PR head
+   should report median CPU time, CV, and contacts/iter for
+   `BM_NativePlane{Sphere,Box,Capsule,Convex}`.
+4. After P8/P9 merges, phase 2 is functionally complete except for optional
+   **P10** mixed-scene fcl/dart/native parity coverage.
+5. Gates for **every** phase-2 PR (see `07` §3 — note the corrected commands):
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
    UNIT_collision_native --output-on-failure` (`pixi run test-all` only *builds*);
@@ -96,19 +106,13 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 
 ## 5. Open PRs / loose ends
 
-- **#3319 (P3b bridge)** — OPEN; next phase-2 merge target after #3318.
-- **#3321 (P4 capsule primitives)** — OPEN; stacked after #3319.
-- **#3322 (P5 convex foundation)** — OPEN; stacked after #3321.
-- **#3324 (P6 cylinder collision)** — OPEN; stacked after #3322.
-- **#3325 (P7 mesh collision)** — OPEN; stacked after #3324; review fixes for
-  mesh dispatch and mesh-mesh contracts have been pushed.
-- **P8/P9 distance + plane work** — kept as one local unpublished branch to
-  avoid another CI wave until the stack is ready for it.
-- **#3283 (main sphere-sphere `enableContact` fix)** — OPEN; the **main-branch
-  dual** of the merged release-6.20 #3298. It was **reverted to the squared
-  overlap predicate** (commit `afb1ea58959`) after review — see the lesson in
-  §7. It still needs to merge so `main` and `release-6.20` stay consistent for
-  the eventual phase-6 diff. Re-review was requested.
+- **P8/P9 distance + plane work** — active on `feature/native-distance-plane`
+  as one PR-sized slice to minimize CI overhead.
+- **#3283 (main sphere-sphere `enableContact` fix)** — MERGED; main and
+  `release-6.20` now agree on the squared binary predicate for the eventual
+  phase-6 diff.
+- **#3341** is the only current open `release-6.20` PR seen during this
+  refresh, and it belongs to the separate performance-generalization lane.
 
 ## 6. Load-bearing invariants (do not violate)
 
@@ -160,12 +164,10 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 
 ## 8. Worktrees at handoff (cleanup)
 
-- `.claude/worktrees/phase2-p1` — P1 (#3303, merged), removable after confirming
-  no unpushed local-only evidence is needed.
-- `.claude/worktrees/phase2-p2` — P2 (**merged**), **removable now**; holds the
-  untracked `08-p2-dispatcher-packet.md` working spec (disposable — the
-  dispatcher approach is captured in `07` §2.1) and a symlinked `.pixi` env.
-- `.claude/worktrees/dart7-sphere-fix` — #3283 (main), keep until it merges.
+- `.claude/worktrees/phase2-p2` — P2 merged; retained only because it has
+  untracked local notes.
+- `.claude/worktrees/phase2-p4` — dirty local performance-generalization work;
+  not part of this lane's next code slice.
 - `task_1_pr3239` — pre-existing, not this lane's.
 
 ## 9. Evidence artifacts (for phase 6)

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -19,13 +19,13 @@ This task is for the DART 6.20 support lane.
 Evidence was first collected on 2026-06-19 after fetching `origin/main`,
 `origin/release-6.20`, and `origin/release-6.19`. The native-collision port
 evidence in `03-native-collision-port-scoping.md` and the dashboard state in
-`04-orchestration-dashboard.md` were refreshed on 2026-07-03 after fetching
-`origin/main` and `origin/release-6.20`.
+`04-orchestration-dashboard.md` were refreshed on 2026-07-08 after fetching
+`origin/main` and `origin/release-6.20`, and after phase-2 P7 merged.
 
 ## Current Branch State
 
 - `origin/release-6.20` currently points at
-  `849f22245b7ef11299fa73074c77d6c50b8dda01`.
+  `44645974b3570b35db11c6c251117cc4d8dea624`.
 - `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x
   package version (`6.19.3` in the current CMake configure output).
 - DART 6.20 intentionally uses the release lane while package version metadata

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -35,9 +35,9 @@ the recorded SHA-256 digests or recapture dumps on the flip PR's parent
 and compare within that same recapture.
 
 **Phases 0 and 1 are merged** (#3271 phase-0 packet, #3281 phase-1 native
-math core — C++17, no EnTT, internal-only; FCL stays default). A follow-up
-fixed the `maxNumContacts==0` contract in native sphere-sphere (#3283 on
-main, #3298 on release-6.20).
+math core — C++17, no EnTT, internal-only; FCL stays default). Follow-ups
+fixed the `maxNumContacts==0` contract in native sphere-sphere on both
+release-6.20 (#3298) and main (#3283).
 
 **Phase 2 is in progress.** The execution plan (merged, #3302) is
 [07-phase2-adapter-scoping.md](07-phase2-adapter-scoping.md): add an
@@ -55,18 +55,23 @@ scope-diff-guarded.
   (`dart/collision/native/narrow_phase/narrow_phase.{hpp,cpp}` now on
   `release-6.20`).
 - **P3a** (adapter skeleton + sphere/box shape conversion, intentionally
-  unregistered): **#3318** — **merged**. The `"native"` factory key is still
-  unknown by design.
+  unregistered): **#3318** — **merged**.
+- **P3b** (bridge translation + `"native"` registration + `sphere_box` +
+  parity): **#3319** — **merged**.
+- **P4** (capsule primitive pairs): **#3321** — **merged**.
+- **P5** (convex foundation + capsule-capsule): **#3322** — **merged**.
+- **P6** (cylinder collision pairs): **#3324** — **merged**.
+- **P7** (mesh collision pairs): **#3325** — **merged**.
 
-**Next: P3b — bridge translation + `"native"` factory registration +
-`sphere_box` + parity** (#3319), per plan §1.5/§1.6 and the P3b row in §3.
-Then P4–P9 (pair coverage), then phases 3–7. **Do not** add a
+**Next: P8/P9 — distance module + plane primitive/convex coverage** on
+`feature/native-distance-plane`. Keep this as one PR to minimize CI overhead:
+add `distance.{hpp,cpp}`, `plane_sphere.{hpp,cpp}`, dispatcher plane routes,
+focused distance/plane tests, and native plane benchmark rows. **Do not** add a
 `CollisionDetectorType::Native` enum or touch `World`/`ConstraintSolver`/
-`WorldConfig` — selection becomes the factory pointer
-(`getFactory()->create("native")`) only after P3b.
+`WorldConfig`; FCL remains the default until phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
-PRs, worktrees, gotchas, exact P3b next steps).
+PRs, worktrees, gotchas, and exact P8/P9 next steps).
 
 ## Standing constraints
 

--- a/tests/benchmark/unit/bm_native_collision.cpp
+++ b/tests/benchmark/unit/bm_native_collision.cpp
@@ -262,6 +262,62 @@ void BM_NativeCylinderPlane(benchmark::State& state)
       Eigen::Isometry3d::Identity());
 }
 
+void BM_NativePlaneSphere(benchmark::State& state)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SphereShape sphere(1.0);
+
+  runNarrowPhase(
+      state,
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 0.5));
+}
+
+void BM_NativePlaneBox(benchmark::State& state)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  BoxShape box(Eigen::Vector3d::Constant(1.0));
+
+  runNarrowPhase(
+      state,
+      plane,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.0, 0.0, 0.5));
+}
+
+void BM_NativePlaneCapsule(benchmark::State& state)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  CapsuleShape capsule(0.5, 2.0);
+
+  runNarrowPhase(
+      state,
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, 1.3));
+}
+
+void BM_NativePlaneConvex(benchmark::State& state)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.0, 0.75)});
+
+  runNarrowPhase(
+      state,
+      plane,
+      Eigen::Isometry3d::Identity(),
+      convex,
+      Eigen::Isometry3d::Identity());
+}
+
 void BM_NativeConvexCylinder(benchmark::State& state)
 {
   ConvexShape convex(makeOctahedronVertices());
@@ -354,6 +410,10 @@ BENCHMARK(BM_NativeCylinderSphere)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeCylinderBox)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeCylinderCapsule)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeCylinderPlane)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_NativePlaneSphere)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_NativePlaneBox)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_NativePlaneCapsule)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_NativePlaneConvex)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeConvexCylinder)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeMeshMesh)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeMeshSphere)->Unit(benchmark::kNanosecond);

--- a/tests/unit/collision/native/CMakeLists.txt
+++ b/tests/unit/collision/native/CMakeLists.txt
@@ -45,8 +45,18 @@ dart_add_test(
 )
 dart_add_test(
   "unit"
+  UNIT_collision_native_distance
+  test_distance.cpp
+)
+dart_add_test(
+  "unit"
   UNIT_collision_native_mesh_mesh
   test_mesh_mesh.cpp
+)
+dart_add_test(
+  "unit"
+  UNIT_collision_native_plane_sphere
+  test_plane_sphere.cpp
 )
 dart_add_test(
   "unit"

--- a/tests/unit/collision/native/test_distance.cpp
+++ b/tests/unit/collision/native/test_distance.cpp
@@ -206,6 +206,54 @@ TEST(NativeDistance, ComputesPrimitiveDistances)
       1e-12);
 }
 
+TEST(NativeDistance, HandlesRotatedBoxOverlap)
+{
+  BoxShape bar(Eigen::Vector3d(5.0, 0.25, 0.25));
+
+  Eigen::Isometry3d rotated = Eigen::Isometry3d::Identity();
+  rotated.linear()
+      = Eigen::AngleAxisd(0.5 * std::acos(-1.0), Eigen::Vector3d::UnitZ())
+            .toRotationMatrix();
+
+  DistanceResult result;
+  EXPECT_LE(
+      distanceBoxBox(
+          bar,
+          Eigen::Isometry3d::Identity(),
+          bar,
+          rotated,
+          result,
+          DistanceOption::withUpperBound(0.0)),
+      0.0);
+  EXPECT_LE(result.distance, 0.0);
+  EXPECT_TRUE(result.normal.allFinite());
+}
+
+TEST(NativeDistance, ComputesExactCapsuleBoxAxisDistance)
+{
+  CapsuleShape capsule(0.25, 20.0);
+  BoxShape box(Eigen::Vector3d(1.0, 1.0, 1.0));
+
+  Eigen::Isometry3d capsuleTransform = translated(2.0, 2.0, 0.0);
+  capsuleTransform.linear()
+      = Eigen::AngleAxisd(0.5 * std::acos(-1.0), Eigen::Vector3d::UnitY())
+            .toRotationMatrix();
+
+  DistanceResult result;
+  EXPECT_NEAR(
+      0.75,
+      distanceCapsuleBox(
+          capsule,
+          capsuleTransform,
+          box,
+          Eigen::Isometry3d::Identity(),
+          result,
+          DistanceOption::withUpperBound(0.8)),
+      1e-12);
+  EXPECT_NEAR(1.75, result.pointOnObject1.y(), 1e-12);
+  EXPECT_NEAR(1.0, result.pointOnObject2.y(), 1e-12);
+}
+
 TEST(NativeDistance, ComputesPlaneShapeDistances)
 {
   PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);

--- a/tests/unit/collision/native/test_distance.cpp
+++ b/tests/unit/collision/native/test_distance.cpp
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/distance.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include <cmath>
+#include <cstdint>
+
+using namespace dart::collision::native;
+
+namespace {
+
+Eigen::Isometry3d translated(double x, double y, double z)
+{
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(x, y, z);
+  return tf;
+}
+
+MeshShape makePlaneMesh(double z)
+{
+  std::vector<Eigen::Vector3d> vertices
+      = {{-1.0, -1.0, z}, {1.0, -1.0, z}, {1.0, 1.0, z}, {-1.0, 1.0, z}};
+  std::vector<MeshShape::Triangle> triangles = {{0, 1, 2}, {0, 2, 3}};
+  return MeshShape(vertices, triangles);
+}
+
+class PlaneField final : public SignedDistanceField
+{
+public:
+  bool distance(
+      const Eigen::Vector3d& point_F,
+      double* distance,
+      const SdfQueryOptions& options) const override
+  {
+    return query(point_F, distance, nullptr, options);
+  }
+
+  bool distanceAndGradient(
+      const Eigen::Vector3d& point_F,
+      double* distance,
+      Eigen::Vector3d* gradient,
+      const SdfQueryOptions& options) const override
+  {
+    return query(point_F, distance, gradient, options);
+  }
+
+  void batchDistanceAndGradient(
+      span<const Eigen::Vector3d> points_F,
+      span<double> distances,
+      span<Eigen::Vector3d> gradients,
+      span<std::uint8_t> observed,
+      const SdfQueryOptions& options) const override
+  {
+    for (std::size_t i = 0; i < points_F.size(); ++i) {
+      double distance = 0.0;
+      Eigen::Vector3d gradient = Eigen::Vector3d::Zero();
+      const bool ok = query(points_F[i], &distance, &gradient, options);
+      distances[i] = distance;
+      gradients[i] = gradient;
+      observed[i] = ok ? 1u : 0u;
+    }
+  }
+
+  Aabb localAabb() const override
+  {
+    return Aabb(
+        Eigen::Vector3d(-1.0, -1.0, -1.0), Eigen::Vector3d(1.0, 1.0, 1.0));
+  }
+
+  double voxelSize() const override
+  {
+    return 0.5;
+  }
+
+  double maxDistance() const override
+  {
+    return 10.0;
+  }
+
+private:
+  bool query(
+      const Eigen::Vector3d& point,
+      double* distance,
+      Eigen::Vector3d* gradient,
+      const SdfQueryOptions& options) const
+  {
+    const double value = point.z();
+    if (std::abs(value) > options.maxDistance) {
+      return false;
+    }
+
+    if (distance) {
+      *distance = value;
+    }
+    if (gradient) {
+      *gradient = Eigen::Vector3d::UnitZ();
+    }
+    return true;
+  }
+};
+
+} // namespace
+
+TEST(NativeDistance, ComputesPrimitiveDistances)
+{
+  const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+
+  SphereShape sphereA(0.5);
+  SphereShape sphereB(0.25);
+  DistanceResult sphereResult;
+  EXPECT_NEAR(
+      1.25,
+      distanceSphereSphere(
+          sphereA, identity, sphereB, translated(2.0, 0.0, 0.0), sphereResult),
+      1e-12);
+  EXPECT_TRUE(
+      sphereResult.pointOnObject1.isApprox(Eigen::Vector3d(0.5, 0.0, 0.0)));
+  EXPECT_TRUE(
+      sphereResult.pointOnObject2.isApprox(Eigen::Vector3d(1.75, 0.0, 0.0)));
+  EXPECT_TRUE(sphereResult.normal.isApprox(Eigen::Vector3d::UnitX()));
+
+  BoxShape boxA(Eigen::Vector3d(0.5, 0.5, 0.5));
+  DistanceResult sphereBoxResult;
+  EXPECT_NEAR(
+      1.25,
+      distanceSphereBox(
+          sphereB, translated(-2.0, 0.0, 0.0), boxA, identity, sphereBoxResult),
+      1e-12);
+
+  BoxShape boxB(Eigen::Vector3d(0.25, 0.25, 0.25));
+  DistanceResult boxResult;
+  EXPECT_NEAR(
+      1.25,
+      distanceBoxBox(
+          boxA, identity, boxB, translated(2.0, 0.0, 0.0), boxResult),
+      1e-12);
+
+  CapsuleShape capsule(0.25, 1.0);
+  DistanceResult capsuleSphereResult;
+  EXPECT_NEAR(
+      0.5,
+      distanceCapsuleSphere(
+          capsule,
+          identity,
+          sphereB,
+          translated(1.0, 0.0, 0.0),
+          capsuleSphereResult),
+      1e-12);
+
+  DistanceResult capsuleCapsuleResult;
+  EXPECT_NEAR(
+      1.0,
+      distanceCapsuleCapsule(
+          capsule,
+          identity,
+          capsule,
+          translated(1.5, 0.0, 0.0),
+          capsuleCapsuleResult),
+      1e-12);
+
+  DistanceResult capsuleBoxResult;
+  EXPECT_NEAR(
+      0.5,
+      distanceCapsuleBox(
+          capsule,
+          translated(-1.25, 0.0, 0.0),
+          boxA,
+          identity,
+          capsuleBoxResult),
+      1e-12);
+}
+
+TEST(NativeDistance, ComputesPlaneShapeDistances)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+
+  SphereShape sphere(0.25);
+  DistanceResult sphereResult;
+  EXPECT_NEAR(
+      0.75,
+      distancePlaneShape(
+          plane, identity, sphere, translated(0.0, 0.0, 1.0), sphereResult),
+      1e-12);
+  EXPECT_TRUE(
+      sphereResult.pointOnObject1.isApprox(Eigen::Vector3d(0.0, 0.0, 0.0)));
+  EXPECT_TRUE(
+      sphereResult.pointOnObject2.isApprox(Eigen::Vector3d(0.0, 0.0, 0.75)));
+  EXPECT_TRUE(sphereResult.normal.isApprox(Eigen::Vector3d::UnitZ()));
+
+  BoxShape box(Eigen::Vector3d(0.5, 0.5, 0.25));
+  DistanceResult boxResult;
+  EXPECT_NEAR(
+      0.75,
+      distancePlaneShape(
+          plane, identity, box, translated(0.0, 0.0, 1.0), boxResult),
+      1e-12);
+
+  MeshShape mesh = makePlaneMesh(0.5);
+  DistanceResult meshResult;
+  EXPECT_NEAR(
+      0.5,
+      distancePlaneShape(plane, identity, mesh, identity, meshResult),
+      1e-12);
+}
+
+TEST(NativeDistance, HonorsUpperBoundAndNearestPointOptions)
+{
+  SphereShape sphereA(0.5);
+  SphereShape sphereB(0.25);
+
+  DistanceOption bounded = DistanceOption::withUpperBound(0.5);
+  DistanceResult boundedResult;
+  EXPECT_NEAR(
+      1.25,
+      distanceSphereSphere(
+          sphereA,
+          Eigen::Isometry3d::Identity(),
+          sphereB,
+          translated(2.0, 0.0, 0.0),
+          boundedResult,
+          bounded),
+      1e-12);
+  EXPECT_NEAR(1.25, boundedResult.distance, 1e-12);
+  EXPECT_TRUE(boundedResult.pointOnObject1.isApprox(Eigen::Vector3d::Zero()));
+
+  DistanceOption distanceOnly;
+  distanceOnly.enableNearestPoints = false;
+  DistanceResult distanceOnlyResult;
+  EXPECT_NEAR(
+      1.25,
+      distanceSphereSphere(
+          sphereA,
+          Eigen::Isometry3d::Identity(),
+          sphereB,
+          translated(2.0, 0.0, 0.0),
+          distanceOnlyResult,
+          distanceOnly),
+      1e-12);
+  EXPECT_TRUE(
+      distanceOnlyResult.pointOnObject1.isApprox(Eigen::Vector3d::Zero()));
+}
+
+TEST(NativeDistance, ComputesSdfDistances)
+{
+  auto field = std::make_shared<PlaneField>();
+  SdfShape sdf(field);
+  const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+
+  SphereShape sphere(0.25);
+  DistanceResult sphereResult;
+  EXPECT_NEAR(
+      0.75,
+      distanceSphereSdf(
+          sphere, translated(0.0, 0.0, 1.0), sdf, identity, sphereResult),
+      1e-12);
+
+  CapsuleShape capsule(0.25, 1.0);
+  DistanceResult capsuleResult;
+  EXPECT_NEAR(
+      0.25,
+      distanceCapsuleSdf(
+          capsule, translated(0.0, 0.0, 1.0), sdf, identity, capsuleResult),
+      1e-12);
+
+  CylinderShape cylinder(0.25, 1.0);
+  DistanceResult cylinderResult;
+  EXPECT_NEAR(
+      0.5,
+      distanceCylinderSdf(
+          cylinder, translated(0.0, 0.0, 1.0), sdf, identity, cylinderResult),
+      1e-12);
+
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, 0.0, 0.25),
+       Eigen::Vector3d(0.5, 0.0, 0.25),
+       Eigen::Vector3d(0.0, 0.5, 0.5),
+       Eigen::Vector3d(0.0, 0.0, 1.0)});
+  DistanceResult convexResult;
+  EXPECT_NEAR(
+      0.25,
+      distanceConvexSdf(convex, identity, sdf, identity, convexResult),
+      1e-12);
+
+  MeshShape mesh = makePlaneMesh(0.4);
+  DistanceResult meshResult;
+  EXPECT_NEAR(
+      0.4, distanceMeshSdf(mesh, identity, sdf, identity, meshResult), 1e-12);
+
+  DistanceResult sdfResult;
+  EXPECT_NEAR(
+      -0.5,
+      distanceSdfSdf(sdf, identity, sdf, translated(0.0, 0.0, 0.5), sdfResult),
+      1e-12);
+}

--- a/tests/unit/collision/native/test_distance.cpp
+++ b/tests/unit/collision/native/test_distance.cpp
@@ -35,6 +35,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -60,7 +61,7 @@ MeshShape makePlaneMesh(double z)
   return MeshShape(vertices, triangles);
 }
 
-class PlaneField final : public SignedDistanceField
+class PlaneField : public SignedDistanceField
 {
 public:
   bool distance(
@@ -135,6 +136,64 @@ private:
   }
 };
 
+class RejectingField final : public SignedDistanceField
+{
+public:
+  bool distance(
+      const Eigen::Vector3d&, double*, const SdfQueryOptions&) const override
+  {
+    return false;
+  }
+
+  bool distanceAndGradient(
+      const Eigen::Vector3d&,
+      double*,
+      Eigen::Vector3d*,
+      const SdfQueryOptions&) const override
+  {
+    return false;
+  }
+
+  void batchDistanceAndGradient(
+      span<const Eigen::Vector3d> points_F,
+      span<double> distances,
+      span<Eigen::Vector3d> gradients,
+      span<std::uint8_t> observed,
+      const SdfQueryOptions&) const override
+  {
+    for (std::size_t i = 0; i < points_F.size(); ++i) {
+      distances[i] = std::numeric_limits<double>::max();
+      gradients[i] = Eigen::Vector3d::Zero();
+      observed[i] = 0u;
+    }
+  }
+
+  Aabb localAabb() const override
+  {
+    return Aabb(
+        Eigen::Vector3d(-1.0, -1.0, -1.0), Eigen::Vector3d(1.0, 1.0, 1.0));
+  }
+
+  double voxelSize() const override
+  {
+    return 0.5;
+  }
+
+  double maxDistance() const override
+  {
+    return 10.0;
+  }
+};
+
+class InvalidAabbField final : public PlaneField
+{
+public:
+  Aabb localAabb() const override
+  {
+    return Aabb(Eigen::Vector3d::Ones(), -Eigen::Vector3d::Ones());
+  }
+};
+
 } // namespace
 
 TEST(NativeDistance, ComputesPrimitiveDistances)
@@ -155,6 +214,14 @@ TEST(NativeDistance, ComputesPrimitiveDistances)
       sphereResult.pointOnObject2.isApprox(Eigen::Vector3d(1.75, 0.0, 0.0)));
   EXPECT_TRUE(sphereResult.normal.isApprox(Eigen::Vector3d::UnitX()));
 
+  DistanceResult coincidentSphereResult;
+  EXPECT_NEAR(
+      -0.75,
+      distanceSphereSphere(
+          sphereA, identity, sphereB, identity, coincidentSphereResult),
+      1e-12);
+  EXPECT_TRUE(coincidentSphereResult.normal.isApprox(Eigen::Vector3d::UnitX()));
+
   BoxShape boxA(Eigen::Vector3d(0.5, 0.5, 0.5));
   DistanceResult sphereBoxResult;
   EXPECT_NEAR(
@@ -162,6 +229,16 @@ TEST(NativeDistance, ComputesPrimitiveDistances)
       distanceSphereBox(
           sphereB, translated(-2.0, 0.0, 0.0), boxA, identity, sphereBoxResult),
       1e-12);
+
+  BoxShape largeBox(Eigen::Vector3d(3.0, 2.0, 1.0));
+  DistanceResult containedSphereBoxResult;
+  EXPECT_NEAR(
+      -1.25,
+      distanceSphereBox(
+          sphereB, identity, largeBox, identity, containedSphereBoxResult),
+      1e-12);
+  EXPECT_TRUE(
+      containedSphereBoxResult.normal.isApprox(Eigen::Vector3d::UnitZ()));
 
   BoxShape boxB(Eigen::Vector3d(0.25, 0.25, 0.25));
   DistanceResult boxResult;
@@ -183,6 +260,15 @@ TEST(NativeDistance, ComputesPrimitiveDistances)
           capsuleSphereResult),
       1e-12);
 
+  DistanceResult coincidentCapsuleSphereResult;
+  EXPECT_NEAR(
+      -0.5,
+      distanceCapsuleSphere(
+          capsule, identity, sphereB, identity, coincidentCapsuleSphereResult),
+      1e-12);
+  EXPECT_TRUE(
+      coincidentCapsuleSphereResult.normal.isApprox(Eigen::Vector3d::UnitX()));
+
   DistanceResult capsuleCapsuleResult;
   EXPECT_NEAR(
       1.0,
@@ -193,6 +279,15 @@ TEST(NativeDistance, ComputesPrimitiveDistances)
           translated(1.5, 0.0, 0.0),
           capsuleCapsuleResult),
       1e-12);
+
+  DistanceResult coincidentCapsuleCapsuleResult;
+  EXPECT_NEAR(
+      -0.5,
+      distanceCapsuleCapsule(
+          capsule, identity, capsule, identity, coincidentCapsuleCapsuleResult),
+      1e-12);
+  EXPECT_TRUE(
+      coincidentCapsuleCapsuleResult.normal.isApprox(Eigen::Vector3d::UnitX()));
 
   DistanceResult capsuleBoxResult;
   EXPECT_NEAR(
@@ -301,12 +396,47 @@ TEST(NativeDistance, ComputesPlaneShapeDistances)
           plane, identity, box, translated(0.0, 0.0, 1.0), boxResult),
       1e-12);
 
+  CapsuleShape capsule(0.25, 1.0);
+  DistanceResult capsuleResult;
+  EXPECT_NEAR(
+      0.25,
+      distancePlaneShape(
+          plane, identity, capsule, translated(0.0, 0.0, 1.0), capsuleResult),
+      1e-12);
+
+  CylinderShape cylinder(0.25, 1.0);
+  DistanceResult cylinderResult;
+  EXPECT_NEAR(
+      0.5,
+      distancePlaneShape(
+          plane, identity, cylinder, translated(0.0, 0.0, 1.0), cylinderResult),
+      1e-12);
+
   MeshShape mesh = makePlaneMesh(0.5);
   DistanceResult meshResult;
   EXPECT_NEAR(
       0.5,
       distancePlaneShape(plane, identity, mesh, identity, meshResult),
       1e-12);
+
+  DistanceResult tangentSphereResult;
+  EXPECT_NEAR(
+      0.0,
+      distancePlaneShape(
+          plane,
+          identity,
+          sphere,
+          translated(0.0, 0.0, 0.25),
+          tangentSphereResult),
+      1e-12);
+  EXPECT_TRUE(tangentSphereResult.normal.isApprox(Eigen::Vector3d::UnitZ()));
+
+  SdfShape unsupported(nullptr);
+  DistanceResult unsupportedResult;
+  EXPECT_EQ(
+      std::numeric_limits<double>::max(),
+      distancePlaneShape(
+          plane, identity, unsupported, identity, unsupportedResult));
 }
 
 TEST(NativeDistance, HonorsUpperBoundAndNearestPointOptions)
@@ -344,6 +474,44 @@ TEST(NativeDistance, HonorsUpperBoundAndNearestPointOptions)
       1e-12);
   EXPECT_TRUE(
       distanceOnlyResult.pointOnObject1.isApprox(Eigen::Vector3d::Zero()));
+
+  BoxShape box(Eigen::Vector3d(0.5, 0.5, 0.5));
+  DistanceResult sphereBoxBoundedResult;
+  EXPECT_NEAR(
+      1.25,
+      distanceSphereBox(
+          sphereB,
+          translated(-2.0, 0.0, 0.0),
+          box,
+          Eigen::Isometry3d::Identity(),
+          sphereBoxBoundedResult,
+          bounded),
+      1e-12);
+
+  CapsuleShape capsule(0.25, 1.0);
+  DistanceResult capsuleSphereBoundedResult;
+  EXPECT_NEAR(
+      0.5,
+      distanceCapsuleSphere(
+          capsule,
+          Eigen::Isometry3d::Identity(),
+          sphereB,
+          translated(1.0, 0.0, 0.0),
+          capsuleSphereBoundedResult,
+          DistanceOption::withUpperBound(0.1)),
+      1e-12);
+
+  DistanceResult capsuleBoxBoundedResult;
+  EXPECT_NEAR(
+      0.5,
+      distanceCapsuleBox(
+          capsule,
+          translated(-1.25, 0.0, 0.0),
+          box,
+          Eigen::Isometry3d::Identity(),
+          capsuleBoxBoundedResult,
+          DistanceOption::withUpperBound(0.1)),
+      1e-12);
 }
 
 TEST(NativeDistance, ComputesSdfDistances)
@@ -359,6 +527,9 @@ TEST(NativeDistance, ComputesSdfDistances)
       distanceSphereSdf(
           sphere, translated(0.0, 0.0, 1.0), sdf, identity, sphereResult),
       1e-12);
+  EXPECT_TRUE(
+      sphereResult.pointOnObject1.isApprox(Eigen::Vector3d(0.0, 0.0, 0.75)));
+  EXPECT_TRUE(sphereResult.pointOnObject2.isApprox(Eigen::Vector3d::Zero()));
 
   CapsuleShape capsule(0.25, 1.0);
   DistanceResult capsuleResult;
@@ -367,6 +538,9 @@ TEST(NativeDistance, ComputesSdfDistances)
       distanceCapsuleSdf(
           capsule, translated(0.0, 0.0, 1.0), sdf, identity, capsuleResult),
       1e-12);
+  EXPECT_TRUE(
+      capsuleResult.pointOnObject1.isApprox(Eigen::Vector3d(0.0, 0.0, 0.25)));
+  EXPECT_TRUE(capsuleResult.pointOnObject2.isApprox(Eigen::Vector3d::Zero()));
 
   CylinderShape cylinder(0.25, 1.0);
   DistanceResult cylinderResult;
@@ -397,4 +571,114 @@ TEST(NativeDistance, ComputesSdfDistances)
       -0.5,
       distanceSdfSdf(sdf, identity, sdf, translated(0.0, 0.0, 0.5), sdfResult),
       1e-12);
+}
+
+TEST(NativeDistance, PlacesRoundedSdfWitnessesOnFacingSide)
+{
+  auto field = std::make_shared<PlaneField>();
+  SdfShape sdf(field);
+  const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+
+  SphereShape sphere(0.25);
+  DistanceResult separatedSphere;
+  EXPECT_NEAR(
+      0.75,
+      distanceSphereSdf(
+          sphere, translated(0.0, 0.0, 1.0), sdf, identity, separatedSphere),
+      1e-12);
+  EXPECT_NEAR(0.75, separatedSphere.pointOnObject1.z(), 1e-12);
+  EXPECT_NEAR(0.0, separatedSphere.pointOnObject2.z(), 1e-12);
+
+  DistanceResult penetratingSphere;
+  EXPECT_NEAR(
+      -0.35,
+      distanceSphereSdf(
+          sphere, translated(0.0, 0.0, -0.1), sdf, identity, penetratingSphere),
+      1e-12);
+  EXPECT_NEAR(0.15, penetratingSphere.pointOnObject1.z(), 1e-12);
+  EXPECT_NEAR(0.0, penetratingSphere.pointOnObject2.z(), 1e-12);
+
+  CapsuleShape capsule(0.25, 1.0);
+  DistanceResult separatedCapsule;
+  EXPECT_NEAR(
+      0.25,
+      distanceCapsuleSdf(
+          capsule, translated(0.0, 0.0, 1.0), sdf, identity, separatedCapsule),
+      1e-12);
+  EXPECT_NEAR(0.25, separatedCapsule.pointOnObject1.z(), 1e-12);
+  EXPECT_NEAR(0.0, separatedCapsule.pointOnObject2.z(), 1e-12);
+
+  DistanceResult penetratingCapsule;
+  EXPECT_NEAR(
+      -0.35,
+      distanceCapsuleSdf(
+          capsule,
+          translated(0.0, 0.0, 0.4),
+          sdf,
+          identity,
+          penetratingCapsule),
+      1e-12);
+  EXPECT_NEAR(0.15, penetratingCapsule.pointOnObject1.z(), 1e-12);
+  EXPECT_NEAR(0.0, penetratingCapsule.pointOnObject2.z(), 1e-12);
+}
+
+TEST(NativeDistance, HandlesSdfMissesAndNullFields)
+{
+  const double maxDistance = std::numeric_limits<double>::max();
+  const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+  SdfShape nullSdf(nullptr);
+  SdfShape rejectingSdf(std::make_shared<RejectingField>());
+  SdfShape invalidAabbSdf(std::make_shared<InvalidAabbField>());
+  SdfShape planeSdf(std::make_shared<PlaneField>());
+
+  SphereShape sphere(0.25);
+  CapsuleShape capsule(0.25, 1.0);
+  CylinderShape cylinder(0.25, 1.0);
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, 0.0, 0.25),
+       Eigen::Vector3d(0.5, 0.0, 0.25),
+       Eigen::Vector3d(0.0, 0.5, 0.5),
+       Eigen::Vector3d(0.0, 0.0, 1.0)});
+  MeshShape mesh = makePlaneMesh(0.4);
+
+  DistanceResult result;
+  EXPECT_EQ(
+      maxDistance,
+      distanceSphereSdf(sphere, identity, nullSdf, identity, result));
+
+  result.clear();
+  EXPECT_EQ(
+      maxDistance,
+      distanceCapsuleSdf(capsule, identity, nullSdf, identity, result));
+
+  result.clear();
+  EXPECT_EQ(
+      maxDistance,
+      distanceCylinderSdf(cylinder, identity, nullSdf, identity, result));
+
+  result.clear();
+  EXPECT_EQ(
+      maxDistance,
+      distanceCylinderSdf(cylinder, identity, rejectingSdf, identity, result));
+
+  result.clear();
+  EXPECT_EQ(
+      maxDistance,
+      distanceConvexSdf(convex, identity, nullSdf, identity, result));
+
+  result.clear();
+  EXPECT_EQ(
+      maxDistance,
+      distanceMeshSdf(mesh, identity, rejectingSdf, identity, result));
+
+  result.clear();
+  EXPECT_EQ(
+      maxDistance,
+      distanceSdfSdf(nullSdf, identity, planeSdf, identity, result));
+
+  result.clear();
+  EXPECT_EQ(
+      maxDistance,
+      distanceSdfSdf(
+          invalidAabbSdf, identity, invalidAabbSdf, identity, result));
 }

--- a/tests/unit/collision/native/test_distance.cpp
+++ b/tests/unit/collision/native/test_distance.cpp
@@ -229,6 +229,11 @@ TEST(NativeDistance, ComputesPrimitiveDistances)
       distanceSphereBox(
           sphereB, translated(-2.0, 0.0, 0.0), boxA, identity, sphereBoxResult),
       1e-12);
+  EXPECT_TRUE(sphereBoxResult.pointOnObject1.isApprox(
+      Eigen::Vector3d(-1.75, 0.0, 0.0)));
+  EXPECT_TRUE(
+      sphereBoxResult.pointOnObject2.isApprox(Eigen::Vector3d(-0.5, 0.0, 0.0)));
+  EXPECT_TRUE(sphereBoxResult.normal.isApprox(Eigen::Vector3d::UnitX()));
 
   BoxShape largeBox(Eigen::Vector3d(3.0, 2.0, 1.0));
   DistanceResult containedSphereBoxResult;
@@ -347,6 +352,7 @@ TEST(NativeDistance, ComputesExactCapsuleBoxAxisDistance)
       1e-12);
   EXPECT_NEAR(1.75, result.pointOnObject1.y(), 1e-12);
   EXPECT_NEAR(1.0, result.pointOnObject2.y(), 1e-12);
+  EXPECT_TRUE(result.normal.isApprox(-Eigen::Vector3d::UnitY(), 1e-12));
 }
 
 TEST(NativeDistance, AccountsForCapsuleBoxContainmentDepth)
@@ -530,6 +536,7 @@ TEST(NativeDistance, ComputesSdfDistances)
   EXPECT_TRUE(
       sphereResult.pointOnObject1.isApprox(Eigen::Vector3d(0.0, 0.0, 0.75)));
   EXPECT_TRUE(sphereResult.pointOnObject2.isApprox(Eigen::Vector3d::Zero()));
+  EXPECT_TRUE(sphereResult.normal.isApprox(-Eigen::Vector3d::UnitZ()));
 
   CapsuleShape capsule(0.25, 1.0);
   DistanceResult capsuleResult;
@@ -541,6 +548,7 @@ TEST(NativeDistance, ComputesSdfDistances)
   EXPECT_TRUE(
       capsuleResult.pointOnObject1.isApprox(Eigen::Vector3d(0.0, 0.0, 0.25)));
   EXPECT_TRUE(capsuleResult.pointOnObject2.isApprox(Eigen::Vector3d::Zero()));
+  EXPECT_TRUE(capsuleResult.normal.isApprox(-Eigen::Vector3d::UnitZ()));
 
   CylinderShape cylinder(0.25, 1.0);
   DistanceResult cylinderResult;
@@ -549,6 +557,7 @@ TEST(NativeDistance, ComputesSdfDistances)
       distanceCylinderSdf(
           cylinder, translated(0.0, 0.0, 1.0), sdf, identity, cylinderResult),
       1e-12);
+  EXPECT_TRUE(cylinderResult.normal.isApprox(-Eigen::Vector3d::UnitZ()));
 
   ConvexShape convex(
       {Eigen::Vector3d(-0.5, 0.0, 0.25),
@@ -560,17 +569,20 @@ TEST(NativeDistance, ComputesSdfDistances)
       0.25,
       distanceConvexSdf(convex, identity, sdf, identity, convexResult),
       1e-12);
+  EXPECT_TRUE(convexResult.normal.isApprox(-Eigen::Vector3d::UnitZ()));
 
   MeshShape mesh = makePlaneMesh(0.4);
   DistanceResult meshResult;
   EXPECT_NEAR(
       0.4, distanceMeshSdf(mesh, identity, sdf, identity, meshResult), 1e-12);
+  EXPECT_TRUE(meshResult.normal.isApprox(-Eigen::Vector3d::UnitZ()));
 
   DistanceResult sdfResult;
   EXPECT_NEAR(
       -0.5,
       distanceSdfSdf(sdf, identity, sdf, translated(0.0, 0.0, 0.5), sdfResult),
       1e-12);
+  EXPECT_TRUE(sdfResult.normal.isApprox(Eigen::Vector3d::UnitZ()));
 }
 
 TEST(NativeDistance, PlacesRoundedSdfWitnessesOnFacingSide)
@@ -588,6 +600,7 @@ TEST(NativeDistance, PlacesRoundedSdfWitnessesOnFacingSide)
       1e-12);
   EXPECT_NEAR(0.75, separatedSphere.pointOnObject1.z(), 1e-12);
   EXPECT_NEAR(0.0, separatedSphere.pointOnObject2.z(), 1e-12);
+  EXPECT_TRUE(separatedSphere.normal.isApprox(-Eigen::Vector3d::UnitZ()));
 
   DistanceResult penetratingSphere;
   EXPECT_NEAR(
@@ -597,6 +610,7 @@ TEST(NativeDistance, PlacesRoundedSdfWitnessesOnFacingSide)
       1e-12);
   EXPECT_NEAR(0.15, penetratingSphere.pointOnObject1.z(), 1e-12);
   EXPECT_NEAR(0.0, penetratingSphere.pointOnObject2.z(), 1e-12);
+  EXPECT_TRUE(penetratingSphere.normal.isApprox(Eigen::Vector3d::UnitZ()));
 
   CapsuleShape capsule(0.25, 1.0);
   DistanceResult separatedCapsule;
@@ -607,6 +621,7 @@ TEST(NativeDistance, PlacesRoundedSdfWitnessesOnFacingSide)
       1e-12);
   EXPECT_NEAR(0.25, separatedCapsule.pointOnObject1.z(), 1e-12);
   EXPECT_NEAR(0.0, separatedCapsule.pointOnObject2.z(), 1e-12);
+  EXPECT_TRUE(separatedCapsule.normal.isApprox(-Eigen::Vector3d::UnitZ()));
 
   DistanceResult penetratingCapsule;
   EXPECT_NEAR(
@@ -620,6 +635,7 @@ TEST(NativeDistance, PlacesRoundedSdfWitnessesOnFacingSide)
       1e-12);
   EXPECT_NEAR(0.15, penetratingCapsule.pointOnObject1.z(), 1e-12);
   EXPECT_NEAR(0.0, penetratingCapsule.pointOnObject2.z(), 1e-12);
+  EXPECT_TRUE(penetratingCapsule.normal.isApprox(Eigen::Vector3d::UnitZ()));
 }
 
 TEST(NativeDistance, HandlesSdfMissesAndNullFields)

--- a/tests/unit/collision/native/test_distance.cpp
+++ b/tests/unit/collision/native/test_distance.cpp
@@ -254,6 +254,27 @@ TEST(NativeDistance, ComputesExactCapsuleBoxAxisDistance)
   EXPECT_NEAR(1.0, result.pointOnObject2.y(), 1e-12);
 }
 
+TEST(NativeDistance, AccountsForCapsuleBoxContainmentDepth)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  BoxShape box(Eigen::Vector3d(10.0, 10.0, 10.0));
+
+  DistanceResult result;
+  EXPECT_NEAR(
+      -10.5,
+      distanceCapsuleBox(
+          capsule,
+          Eigen::Isometry3d::Identity(),
+          box,
+          Eigen::Isometry3d::Identity(),
+          result,
+          DistanceOption::withUpperBound(0.0)),
+      1e-12);
+  EXPECT_NEAR(-0.5, result.pointOnObject1.x(), 1e-12);
+  EXPECT_NEAR(10.0, result.pointOnObject2.x(), 1e-12);
+  EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitX(), 1e-12));
+}
+
 TEST(NativeDistance, ComputesPlaneShapeDistances)
 {
   PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -258,16 +258,16 @@ TEST(NarrowPhaseDispatch, SphereBoxBinaryCheckDoesNotAddContacts)
   EXPECT_EQ(boxFirstResult.numContacts(), 0u);
 }
 
-TEST(NarrowPhaseDispatch, ReturnsFalseForUnroutedPairs)
+TEST(NarrowPhaseDispatch, ReturnsFalseForUnsupportedPairs)
 {
   SphereShape sphere(1.0);
-  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SdfShape sdf(nullptr);
 
   CollisionResult result;
   const bool hit = NarrowPhase::collide(
-      &plane,
-      Eigen::Isometry3d::Identity(),
       &sphere,
+      Eigen::Isometry3d::Identity(),
+      &sdf,
       Eigen::Isometry3d::Identity(),
       CollisionOption(),
       result);
@@ -325,7 +325,7 @@ TEST(NarrowPhaseDispatch, BatchRecordsPerPairHits)
 {
   SphereShape sphere1(1.0);
   SphereShape sphere2(1.0);
-  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SdfShape sdf(nullptr);
 
   const std::array<NarrowPhasePair, 3> pairs{{
       {&sphere1,
@@ -337,7 +337,7 @@ TEST(NarrowPhaseDispatch, BatchRecordsPerPairHits)
        Eigen::Isometry3d::Identity(),
        translated(3.0, 0.0, 0.0)},
       {&sphere1,
-       &plane,
+       &sdf,
        Eigen::Isometry3d::Identity(),
        Eigen::Isometry3d::Identity()},
   }};
@@ -397,10 +397,18 @@ TEST(NarrowPhaseDispatch, BatchRejectsNullShapes)
       std::invalid_argument);
 }
 
-TEST(NarrowPhaseDispatch, ReportsP7SupportedPairs)
+TEST(NarrowPhaseDispatch, ReportsP9SupportedPairs)
 {
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Sphere));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Box, ShapeType::Box));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Plane, ShapeType::Sphere));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Plane));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Plane, ShapeType::Box));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Box, ShapeType::Plane));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Plane, ShapeType::Capsule));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Capsule, ShapeType::Plane));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Plane, ShapeType::Convex));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Convex, ShapeType::Plane));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Box));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Box, ShapeType::Sphere));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Capsule, ShapeType::Sphere));
@@ -438,8 +446,6 @@ TEST(NarrowPhaseDispatch, ReportsP7SupportedPairs)
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Convex, ShapeType::Mesh));
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Mesh, ShapeType::Convex));
 
-  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Plane));
-  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Plane, ShapeType::Sphere));
   EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Mesh, ShapeType::Sdf));
   EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Compound, ShapeType::Mesh));
 }
@@ -1036,6 +1042,97 @@ TEST(NarrowPhaseDispatch, ConvexFallbackBinaryCheckDoesNotAddContacts)
       result);
 
   EXPECT_TRUE(hit);
+  EXPECT_EQ(0u, result.numContacts());
+}
+
+TEST(NarrowPhaseDispatch, RoutesPlanePairsInBothOrders)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SphereShape sphere(1.0);
+  BoxShape box(Eigen::Vector3d(1.0, 1.0, 1.0));
+  CapsuleShape capsule(0.5, 2.0);
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.0, 0.75)});
+
+  CollisionResult planeSphere;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      &sphere,
+      translated(0.0, 0.0, 0.5),
+      CollisionOption(),
+      planeSphere));
+  ASSERT_EQ(1u, planeSphere.numContacts());
+  EXPECT_LT(planeSphere.getContact(0).normal.z(), -0.99);
+
+  CollisionResult spherePlane;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &sphere,
+      translated(0.0, 0.0, 0.5),
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      spherePlane));
+  ASSERT_EQ(1u, spherePlane.numContacts());
+  EXPECT_GT(spherePlane.getContact(0).normal.z(), 0.99);
+
+  CollisionResult planeBox;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      &box,
+      translated(0.0, 0.0, 0.5),
+      CollisionOption(),
+      planeBox));
+  EXPECT_EQ(1u, planeBox.numContacts());
+
+  CollisionResult boxPlane;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &box,
+      translated(0.0, 0.0, 0.5),
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      boxPlane));
+  EXPECT_EQ(1u, boxPlane.numContacts());
+
+  CollisionResult capsulePlane;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &capsule,
+      translated(0.0, 0.0, 1.3),
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      capsulePlane));
+  EXPECT_EQ(1u, capsulePlane.numContacts());
+
+  CollisionResult convexPlane;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      convexPlane));
+  EXPECT_EQ(1u, convexPlane.numContacts());
+}
+
+TEST(NarrowPhaseDispatch, PlanePairsBinaryCheckDoesNotAddContacts)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SphereShape sphere(1.0);
+
+  CollisionResult result;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      &sphere,
+      translated(0.0, 0.0, 0.5),
+      CollisionOption::binaryCheck(),
+      result));
   EXPECT_EQ(0u, result.numContacts());
 }
 

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -1109,6 +1109,16 @@ TEST(NarrowPhaseDispatch, RoutesPlanePairsInBothOrders)
       capsulePlane));
   EXPECT_EQ(1u, capsulePlane.numContacts());
 
+  CollisionResult planeCapsule;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      &capsule,
+      translated(0.0, 0.0, 1.3),
+      CollisionOption(),
+      planeCapsule));
+  EXPECT_EQ(1u, planeCapsule.numContacts());
+
   CollisionResult convexPlane;
   EXPECT_TRUE(NarrowPhase::collide(
       &convex,
@@ -1118,6 +1128,16 @@ TEST(NarrowPhaseDispatch, RoutesPlanePairsInBothOrders)
       CollisionOption(),
       convexPlane));
   EXPECT_EQ(1u, convexPlane.numContacts());
+
+  CollisionResult planeConvex;
+  EXPECT_TRUE(NarrowPhase::collide(
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption(),
+      planeConvex));
+  EXPECT_EQ(1u, planeConvex.numContacts());
 }
 
 TEST(NarrowPhaseDispatch, PlanePairsBinaryCheckDoesNotAddContacts)

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -1134,6 +1134,18 @@ TEST(NarrowPhaseDispatch, PlanePairsBinaryCheckDoesNotAddContacts)
       CollisionOption::binaryCheck(),
       result));
   EXPECT_EQ(0u, result.numContacts());
+
+  CollisionResult reusedResult;
+  reusedResult.addContact(
+      Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitZ(), 0.0);
+  EXPECT_TRUE(NarrowPhase::collide(
+      &sphere,
+      translated(0.0, 0.0, 0.5),
+      &plane,
+      Eigen::Isometry3d::Identity(),
+      CollisionOption::binaryCheck(),
+      reusedResult));
+  EXPECT_EQ(1u, reusedResult.numContacts());
 }
 
 TEST(NarrowPhaseDispatch, RespectsExhaustedContactBudget)

--- a/tests/unit/collision/native/test_plane_sphere.cpp
+++ b/tests/unit/collision/native/test_plane_sphere.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/plane_sphere.hpp>
+#include <dart/collision/native/shapes/shape.hpp>
+#include <dart/collision/native/types.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace dart::collision::native;
+
+namespace {
+
+Eigen::Isometry3d translated(double x, double y, double z)
+{
+  Eigen::Isometry3d tf = Eigen::Isometry3d::Identity();
+  tf.translation() = Eigen::Vector3d(x, y, z);
+  return tf;
+}
+
+} // namespace
+
+TEST(PlaneCollision, SphereContacts)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SphereShape sphere(1.0);
+
+  CollisionResult separated;
+  EXPECT_FALSE(collidePlaneSphere(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 2.0),
+      separated));
+  EXPECT_EQ(0u, separated.numContacts());
+
+  CollisionResult touching;
+  EXPECT_TRUE(collidePlaneSphere(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 1.0),
+      touching));
+  ASSERT_EQ(1u, touching.numContacts());
+  EXPECT_NEAR(0.0, touching.getContact(0).depth, 1e-12);
+
+  CollisionResult penetrating;
+  EXPECT_TRUE(collidePlaneSphere(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 0.5),
+      penetrating));
+  ASSERT_EQ(1u, penetrating.numContacts());
+  EXPECT_NEAR(0.5, penetrating.getContact(0).depth, 1e-12);
+  EXPECT_TRUE(
+      penetrating.getContact(0).normal.isApprox(Eigen::Vector3d::UnitZ()));
+}
+
+TEST(PlaneCollision, BoxCapsuleAndConvexContacts)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+
+  BoxShape box(Eigen::Vector3d(1.0, 1.0, 1.0));
+  CollisionResult boxResult;
+  EXPECT_TRUE(collidePlaneBox(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.0, 0.0, 0.5),
+      boxResult));
+  ASSERT_EQ(1u, boxResult.numContacts());
+  EXPECT_NEAR(0.5, boxResult.getContact(0).depth, 1e-12);
+
+  CapsuleShape capsule(0.5, 2.0);
+  CollisionResult capsuleResult;
+  EXPECT_TRUE(collidePlaneCapsule(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, 1.3),
+      capsuleResult));
+  ASSERT_EQ(1u, capsuleResult.numContacts());
+  EXPECT_NEAR(0.2, capsuleResult.getContact(0).depth, 1e-12);
+
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.0, 0.75)});
+  CollisionResult convexResult;
+  EXPECT_TRUE(collidePlaneConvex(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      convex,
+      Eigen::Isometry3d::Identity(),
+      convexResult));
+  ASSERT_EQ(1u, convexResult.numContacts());
+  EXPECT_NEAR(0.25, convexResult.getContact(0).depth, 1e-12);
+}
+
+TEST(PlaneCollision, BinaryChecksDoNotAddContacts)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SphereShape sphere(1.0);
+  BoxShape box(Eigen::Vector3d(1.0, 1.0, 1.0));
+  CapsuleShape capsule(0.5, 2.0);
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.0, 0.75)});
+
+  CollisionResult sphereResult;
+  EXPECT_TRUE(collidePlaneSphere(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 0.5),
+      sphereResult,
+      CollisionOption::binaryCheck()));
+  EXPECT_EQ(0u, sphereResult.numContacts());
+
+  CollisionResult boxResult;
+  EXPECT_TRUE(collidePlaneBox(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.0, 0.0, 0.5),
+      boxResult,
+      CollisionOption::binaryCheck()));
+  EXPECT_EQ(0u, boxResult.numContacts());
+
+  CollisionResult capsuleResult;
+  EXPECT_TRUE(collidePlaneCapsule(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, 1.3),
+      capsuleResult,
+      CollisionOption::binaryCheck()));
+  EXPECT_EQ(0u, capsuleResult.numContacts());
+
+  CollisionResult convexResult;
+  EXPECT_TRUE(collidePlaneConvex(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      convex,
+      Eigen::Isometry3d::Identity(),
+      convexResult,
+      CollisionOption::binaryCheck()));
+  EXPECT_EQ(0u, convexResult.numContacts());
+}

--- a/tests/unit/collision/native/test_plane_sphere.cpp
+++ b/tests/unit/collision/native/test_plane_sphere.cpp
@@ -36,6 +36,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 using namespace dart::collision::native;
 
 namespace {
@@ -100,6 +102,9 @@ TEST(PlaneCollision, BoxCapsuleAndConvexContacts)
       boxResult));
   ASSERT_EQ(1u, boxResult.numContacts());
   EXPECT_NEAR(0.5, boxResult.getContact(0).depth, 1e-12);
+  EXPECT_NEAR(0.0, boxResult.getContact(0).position.x(), 1e-12);
+  EXPECT_NEAR(0.0, boxResult.getContact(0).position.y(), 1e-12);
+  EXPECT_NEAR(-0.25, boxResult.getContact(0).position.z(), 1e-12);
 
   CapsuleShape capsule(0.5, 2.0);
   CollisionResult capsuleResult;
@@ -133,6 +138,23 @@ TEST(PlaneCollision, BoxCapsuleAndConvexContacts)
   ASSERT_EQ(1u, deepCapsuleResult.numContacts());
   EXPECT_NEAR(1.2, deepCapsuleResult.getContact(0).depth, 1e-12);
   EXPECT_NEAR(-0.6, deepCapsuleResult.getContact(0).position.z(), 1e-12);
+
+  Eigen::Isometry3d horizontalCapsuleTransform = translated(0.0, 0.0, 0.4);
+  horizontalCapsuleTransform.linear()
+      = Eigen::AngleAxisd(0.5 * std::acos(-1.0), Eigen::Vector3d::UnitY())
+            .toRotationMatrix();
+  CollisionResult horizontalCapsuleResult;
+  EXPECT_TRUE(collidePlaneCapsule(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      horizontalCapsuleTransform,
+      horizontalCapsuleResult));
+  ASSERT_EQ(1u, horizontalCapsuleResult.numContacts());
+  EXPECT_NEAR(0.1, horizontalCapsuleResult.getContact(0).depth, 1e-12);
+  EXPECT_NEAR(0.0, horizontalCapsuleResult.getContact(0).position.x(), 1e-12);
+  EXPECT_NEAR(0.0, horizontalCapsuleResult.getContact(0).position.y(), 1e-12);
+  EXPECT_NEAR(-0.05, horizontalCapsuleResult.getContact(0).position.z(), 1e-12);
 
   ConvexShape convex(
       {Eigen::Vector3d(-0.5, -0.5, -0.25),

--- a/tests/unit/collision/native/test_plane_sphere.cpp
+++ b/tests/unit/collision/native/test_plane_sphere.cpp
@@ -112,6 +112,17 @@ TEST(PlaneCollision, BoxCapsuleAndConvexContacts)
   ASSERT_EQ(1u, capsuleResult.numContacts());
   EXPECT_NEAR(0.2, capsuleResult.getContact(0).depth, 1e-12);
 
+  PlaneShape negativePlane(-Eigen::Vector3d::UnitZ(), 0.0);
+  CollisionResult flippedCapsuleResult;
+  EXPECT_TRUE(collidePlaneCapsule(
+      negativePlane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, -1.3),
+      flippedCapsuleResult));
+  ASSERT_EQ(1u, flippedCapsuleResult.numContacts());
+  EXPECT_NEAR(0.2, flippedCapsuleResult.getContact(0).depth, 1e-12);
+
   CollisionResult deepCapsuleResult;
   EXPECT_TRUE(collidePlaneCapsule(
       plane,
@@ -250,4 +261,93 @@ TEST(PlaneCollision, BinaryChecksIgnoreExistingContacts)
       convexResult,
       option));
   EXPECT_EQ(1u, convexResult.numContacts());
+}
+
+TEST(PlaneCollision, RespectsContactBudgetAndSeparatedPairs)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SphereShape sphere(1.0);
+  BoxShape box(Eigen::Vector3d(1.0, 1.0, 1.0));
+  CapsuleShape capsule(0.5, 2.0);
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.0, 0.75)});
+
+  CollisionOption zeroBudget;
+  zeroBudget.maxNumContacts = 0;
+
+  CollisionResult sphereBudget;
+  EXPECT_FALSE(collidePlaneSphere(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 0.5),
+      sphereBudget,
+      zeroBudget));
+
+  CollisionResult boxBudget;
+  EXPECT_FALSE(collidePlaneBox(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.0, 0.0, 0.5),
+      boxBudget,
+      zeroBudget));
+
+  CollisionResult capsuleBudget;
+  EXPECT_FALSE(collidePlaneCapsule(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, 1.3),
+      capsuleBudget,
+      zeroBudget));
+
+  CollisionResult convexBudget;
+  EXPECT_FALSE(collidePlaneConvex(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      convex,
+      Eigen::Isometry3d::Identity(),
+      convexBudget,
+      zeroBudget));
+
+  CollisionOption oneContact;
+  oneContact.maxNumContacts = 1;
+  CollisionResult fullResult;
+  fullResult.addContact(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitZ(), 0.0);
+  EXPECT_FALSE(collidePlaneSphere(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 0.5),
+      fullResult,
+      oneContact));
+  EXPECT_EQ(1u, fullResult.numContacts());
+
+  CollisionResult separatedBox;
+  EXPECT_FALSE(collidePlaneBox(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.0, 0.0, 2.0),
+      separatedBox));
+
+  CollisionResult separatedCapsule;
+  EXPECT_FALSE(collidePlaneCapsule(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, 2.0),
+      separatedCapsule));
+
+  CollisionResult separatedConvex;
+  EXPECT_FALSE(collidePlaneConvex(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      convex,
+      translated(0.0, 0.0, 1.0),
+      separatedConvex));
 }

--- a/tests/unit/collision/native/test_plane_sphere.cpp
+++ b/tests/unit/collision/native/test_plane_sphere.cpp
@@ -191,3 +191,63 @@ TEST(PlaneCollision, BinaryChecksDoNotAddContacts)
       CollisionOption::binaryCheck()));
   EXPECT_EQ(0u, convexResult.numContacts());
 }
+
+TEST(PlaneCollision, BinaryChecksIgnoreExistingContacts)
+{
+  PlaneShape plane(Eigen::Vector3d::UnitZ(), 0.0);
+  SphereShape sphere(1.0);
+  BoxShape box(Eigen::Vector3d(1.0, 1.0, 1.0));
+  CapsuleShape capsule(0.5, 2.0);
+  ConvexShape convex(
+      {Eigen::Vector3d(-0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.5, -0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.5, -0.25),
+       Eigen::Vector3d(0.0, 0.0, 0.75)});
+  const CollisionOption option = CollisionOption::binaryCheck();
+
+  auto makeFullResult = [] {
+    CollisionResult result;
+    result.addContact(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitZ(), 0.0);
+    return result;
+  };
+
+  CollisionResult sphereResult = makeFullResult();
+  EXPECT_TRUE(collidePlaneSphere(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      sphere,
+      translated(0.0, 0.0, 0.5),
+      sphereResult,
+      option));
+  EXPECT_EQ(1u, sphereResult.numContacts());
+
+  CollisionResult boxResult = makeFullResult();
+  EXPECT_TRUE(collidePlaneBox(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      box,
+      translated(0.0, 0.0, 0.5),
+      boxResult,
+      option));
+  EXPECT_EQ(1u, boxResult.numContacts());
+
+  CollisionResult capsuleResult = makeFullResult();
+  EXPECT_TRUE(collidePlaneCapsule(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, 1.3),
+      capsuleResult,
+      option));
+  EXPECT_EQ(1u, capsuleResult.numContacts());
+
+  CollisionResult convexResult = makeFullResult();
+  EXPECT_TRUE(collidePlaneConvex(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      convex,
+      Eigen::Isometry3d::Identity(),
+      convexResult,
+      option));
+  EXPECT_EQ(1u, convexResult.numContacts());
+}

--- a/tests/unit/collision/native/test_plane_sphere.cpp
+++ b/tests/unit/collision/native/test_plane_sphere.cpp
@@ -112,6 +112,17 @@ TEST(PlaneCollision, BoxCapsuleAndConvexContacts)
   ASSERT_EQ(1u, capsuleResult.numContacts());
   EXPECT_NEAR(0.2, capsuleResult.getContact(0).depth, 1e-12);
 
+  CollisionResult deepCapsuleResult;
+  EXPECT_TRUE(collidePlaneCapsule(
+      plane,
+      Eigen::Isometry3d::Identity(),
+      capsule,
+      translated(0.0, 0.0, 0.3),
+      deepCapsuleResult));
+  ASSERT_EQ(1u, deepCapsuleResult.numContacts());
+  EXPECT_NEAR(1.2, deepCapsuleResult.getContact(0).depth, 1e-12);
+  EXPECT_NEAR(-0.6, deepCapsuleResult.getContact(0).position.z(), 1e-12);
+
   ConvexShape convex(
       {Eigen::Vector3d(-0.5, -0.5, -0.25),
        Eigen::Vector3d(0.5, -0.5, -0.25),

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -563,10 +563,13 @@ TEST(NativeCollisionDetector, SkipsUnsupportedShapes)
 {
   auto detector = collision::NativeCollisionDetector::create();
   auto sphereFrame = makeFrame(std::make_shared<dynamics::SphereShape>(1.0));
-  auto planeFrame = makeFrame(
-      std::make_shared<dynamics::PlaneShape>(Eigen::Vector3d::UnitZ(), 0.0));
-  auto group
-      = detector->createCollisionGroup(sphereFrame.get(), planeFrame.get());
+  auto unsupportedFrame
+      = makeFrame(std::make_shared<dynamics::MultiSphereConvexHullShape>(
+          std::vector<dynamics::MultiSphereConvexHullShape::Sphere>{
+              {0.25, Eigen::Vector3d::Zero()},
+              {0.25, Eigen::Vector3d(0.5, 0.0, 0.0)}}));
+  auto group = detector->createCollisionGroup(
+      sphereFrame.get(), unsupportedFrame.get());
 
   collision::CollisionResult result;
   EXPECT_FALSE(group->collide(collision::CollisionOption(true, 10u), &result));


### PR DESCRIPTION
## Summary

- Add the phase-2 P8/P9 native collision slice: internal native distance helpers and plane-vs-sphere/box/capsule/convex narrowphase routes.
- Keep the `"native"` detector opt-in only; FCL remains the default detector and this PR does not touch `World`, `WorldConfig`, or `ConstraintSolver`.

## Motivation / Problem

- The DART 6 native detector needs plane coverage before phase 2 can be considered functionally complete for primitive/convex/mesh contact routing.
- The plane routes depend on a subset of the native distance module, so this keeps P8 and P9 together as one PR to reduce review and CI overhead.

## Changes / Key Changes

- Port `distance.{hpp,cpp}` into `dart/collision/native/narrow_phase/` as C++17/no-EnTT native engine support code.
- Add `plane_sphere.{hpp,cpp}` with plane-sphere, plane-box, plane-capsule, and plane-convex contact generation.
- Route plane pairs through the native narrowphase dispatcher in both shape orders, including binary-check behavior.
- Harden reviewed distance/contact cases: rotated box overlap, separated rotated box edge-edge distance, exact capsule-axis-to-box distance, capsule-box containment depth/witnesses, deep capsule-plane contact placement, and reused-result plane binary checks.
- Add focused unit tests for distance helpers, plane contacts, dispatcher support/order handling, and detector adapter unsupported-shape behavior.
- Add native benchmark rows for `BM_NativePlane{Sphere,Box,Capsule,Convex}` and refresh the dependency-minimization handoff/dashboard docs.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Native detector coverage | Plane-vs-primitive/convex pairs were unsupported by the native narrowphase dispatcher. | Plane-vs-sphere/box/capsule/convex pairs are supported in both object orders. |
| Default collision behavior | FCL remained the default detector. | Unchanged: FCL remains the default detector; `"native"` remains opt-in. |
| Performance evidence | New plane benchmark rows report unsupported on `origin/release-6.20` plus benchmark rows only. | PR head reports successful contacts and median/CV timings for each new plane row. |

## Performance

Baseline: `origin/release-6.20` at `44645974b3570b35db11c6c251117cc4d8dea624` with only the benchmark rows applied. All four rows reported `native narrow-phase benchmark case did not collide`.

Head: `d70a763dbec58902cb180534519b1b36f76256f0`, `taskset -c 2`, `--benchmark_min_time=1.0s`, `--benchmark_repetitions=9`, JSON artifact `/tmp/pr-3343-d70a763-plane-benchmark.json`. The run warned that CPU scaling was enabled and reported load averages `4.97, 4.83, 4.19`, so treat the numbers as current-head functional/performance evidence from a busy local machine rather than a controlled lab result.

| Benchmark | Baseline | Head median CPU | CPU CV | Contacts/iter |
| --- | --- | ---: | ---: | ---: |
| `BM_NativePlaneSphere` | unsupported | 95.20 ns | 0.75% | 1 |
| `BM_NativePlaneBox` | unsupported | 123.62 ns | 0.24% | 1 |
| `BM_NativePlaneCapsule` | unsupported | 100.57 ns | 13.63% | 1 |
| `BM_NativePlaneConvex` | unsupported | 132.88 ns | 11.61% | 1 |

## Testing

- `pixi run lint`
- `pixi run check-lint`
- `git diff --check`
- `rg -n "entt|EnTT|std::span|#include <span>" dart/collision/native/narrow_phase/distance.cpp dart/collision/native/narrow_phase/plane_sphere.cpp dart/collision/native/narrow_phase/distance.hpp dart/collision/native/narrow_phase/plane_sphere.hpp tests/unit/collision/native/test_distance.cpp tests/unit/collision/native/test_plane_sphere.cpp tests/benchmark/unit/bm_native_collision.cpp` (no output)
- `cmake --build build/default/cpp/Release --target UNIT_collision_native_distance -j 24 && ctest --test-dir build/default/cpp/Release -R '^UNIT_collision_native_distance$' --output-on-failure`
- `cmake --build build/default/cpp/Release --target UNIT_collision_native_aabb UNIT_collision_native_types UNIT_collision_native_shapes UNIT_collision_native_box_box UNIT_collision_native_brute_force UNIT_collision_native_capsule_box UNIT_collision_native_capsule_capsule UNIT_collision_native_capsule_sphere UNIT_collision_native_convex_convex UNIT_collision_native_cylinder_collision UNIT_collision_native_detector_adapter UNIT_collision_native_distance UNIT_collision_native_gjk UNIT_collision_native_gjk_degenerate UNIT_collision_native_mesh_mesh UNIT_collision_native_narrow_phase_dispatch UNIT_collision_native_plane_sphere UNIT_collision_native_sphere_box UNIT_collision_native_sphere_sphere BM_UNIT_native_collision -j 24`
- `ctest --test-dir build/default/cpp/Release -R '^UNIT_collision_native' --output-on-failure` (19/19 passed)
- `cmake --build build/default/cpp/Debug --target UNIT_collision_native_distance UNIT_collision_native_plane_sphere UNIT_collision_native_narrow_phase_dispatch UNIT_collision_native_detector_adapter BM_UNIT_native_collision -j 24`
- `ctest --test-dir build/default/cpp/Debug -R '^(UNIT_collision_native_(distance|plane_sphere|narrow_phase_dispatch)|UNIT_collision_native_detector_adapter)$' --output-on-failure` (4/4 passed)
- `cmake --build build/default/cpp/Release --target BM_UNIT_native_collision -j 8`
- `taskset -c 2 build/default/cpp/Release/bin/BM_UNIT_native_collision --benchmark_filter='BM_NativePlane(Sphere|Box|Capsule|Convex)$' --benchmark_min_time=1.0s --benchmark_repetitions=9 --benchmark_out=/tmp/pr-3343-d70a763-plane-benchmark.json --benchmark_out_format=json`
- Baseline benchmark-only probe on `origin/release-6.20` plus benchmark rows, output `/tmp/pr-p8p9-base-benchmark-plane-pinned.json`
- `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz` (gz-physics 199/199, performance/check 4/4, gz-sim `INTEGRATION_entity_system` 1/1)
- Post-review coverage/witness fix at `7edd84e303f59f3981999528c72ff463e92eab7f`:
  - `pixi run config-coverage`
  - `cmake --build build/default/cpp/Debug --target UNIT_collision_native_distance UNIT_collision_native_plane_sphere UNIT_collision_native_narrow_phase_dispatch -j 8`
  - `ctest --test-dir build/default/cpp/Debug --output-on-failure -R '^(UNIT_collision_native_(distance|plane_sphere|narrow_phase_dispatch))$'` (3/3 passed)
  - Focused Debug `gcov`: `distance.cpp` 84.12%, `plane_sphere.cpp` 100.00%, `narrow_phase.cpp` 95.47%
  - `pixi run lint`
  - `cmake --build build/default/cpp/Release --target UNIT_collision_native_distance UNIT_collision_native_plane_sphere UNIT_collision_native_narrow_phase_dispatch -j 8`
  - `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^(UNIT_collision_native_(distance|plane_sphere|narrow_phase_dispatch))$'` (3/3 passed)
  - `git diff --check`

- Post-review normal-direction fix at `3cc7e974ae467248e78aebf6cce4d88d43435646`:
  - `pixi run lint`
  - `cmake --build build/default/cpp/Debug --target UNIT_collision_native_distance -j 8`
  - `ctest --test-dir build/default/cpp/Debug --output-on-failure -R '^UNIT_collision_native_distance$'` (1/1 passed)
  - `cmake --build build/default/cpp/Release --target UNIT_collision_native_distance -j 8`
  - `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^UNIT_collision_native_distance$'` (1/1 passed)
  - `git diff --check`

- Post-review plane-contact centering fix at `d70a763dbec58902cb180534519b1b36f76256f0`:
  - `pixi run lint`
  - `cmake --build build/default/cpp/Debug --target UNIT_collision_native_plane_sphere -j 8`
  - `ctest --test-dir build/default/cpp/Debug --output-on-failure -R '^UNIT_collision_native_plane_sphere$'` (1/1 passed)
  - `cmake --build build/default/cpp/Release --target UNIT_collision_native_plane_sphere -j 8`
  - `ctest --test-dir build/default/cpp/Release --output-on-failure -R '^UNIT_collision_native_plane_sphere$'` (1/1 passed)
  - `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows the DART 6.20 native collision port sequence after #3325.
- No separate backport; this targets `release-6.20`.

---

#### Checklist

- [x] Milestone set: DART 6.20.0
- [x] CHANGELOG.md updated if required: N/A, internal opt-in native detector phase with no default/API change
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, internal native implementation details
- [x] Add Python bindings (dartpy) if applicable: N/A