### PR TITLE
Refresh DART 6 RTD website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@
 
 * Build
 
+  * Refresh the release-6.20 Read the Docs build, install, tutorial, and
+    migration pages so the stable website reads version metadata from
+    `package.xml`, points users to the DART 6 LTS package lanes, and documents
+    the branch-owned Pixi/CMake build and verification tasks.
+
   * Replace the dartpy wheel publishing path with Pixi-managed build,
     repair, verification, and smoke-test tasks, and retire the legacy DART 6
     Docker dev/wheel images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@
   * Refresh the release-6.20 Read the Docs build, install, tutorial, and
     migration pages so the stable website reads version metadata from
     `package.xml`, points users to the DART 6 LTS package lanes, and documents
-    the branch-owned Pixi/CMake build and verification tasks.
+    the branch-owned Pixi/CMake build and verification tasks:
+    [#3346](https://github.com/dartsim/dart/pull/3346)
 
   * Replace the dartpy wheel publishing path with Pixi-managed build,
     repair, verification, and smoke-test tasks, and retire the legacy DART 6

--- a/docs/readthedocs/conf.py
+++ b/docs/readthedocs/conf.py
@@ -3,14 +3,27 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def _read_dart_version() -> str:
+    package_xml = Path(__file__).resolve().parents[2] / "package.xml"
+    try:
+        version = ET.parse(package_xml).getroot().findtext("version", default="")
+    except (FileNotFoundError, ET.ParseError):
+        return "0.0.0"
+    return version.strip() or "0.0.0"
+
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "DART: Dynamic Animation and Robotics Toolkit"
 copyright = "Copyright (c) 2011, The DART development contributors"
 author = "The DART development contributors"
-version = "7.0.0-alpha0"
-release = "7.0.0-alpha20230101"
+version = _read_dart_version()
+release = version
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/readthedocs/dart/developer_guide/build.rst
+++ b/docs/readthedocs/dart/developer_guide/build.rst
@@ -3,323 +3,132 @@
 Build
 =====
 
-Building DART
+This page describes the DART 6 LTS source-build paths for the ``release-6.20``
+branch. The current source version is read from ``package.xml``; until release
+packaging bumps it, this branch can still report a ``6.19.x`` package version
+while collecting changes for DART 6.20.0.
+
+Recommended Pixi build
+----------------------
+
+The reproducible developer path is the Pixi environment tracked in
+``pixi.toml``. It supplies the compiler tools, CMake, Ninja, Python, Doxygen,
+Sphinx, test tools, and the C++ dependencies used by the branch.
+
+.. code-block:: bash
+
+   pixi run config
+   pixi run build
+   pixi run build-py-dev
+
+Run the relevant verification gates from the same environment:
+
+.. code-block:: bash
+
+   pixi run lint
+   pixi run test
+   pixi run test-py
+   pixi run docs-build
+
+``pixi run test-all`` builds the default aggregate CMake target. Run the lint
+and test tasks separately when you need explicit verification output.
+
+Core requirements
+-----------------
+
+For manual builds, use the versions and dependency set in the source tree as
+the authority:
+
+* CMake minimum: ``3.22.1`` from ``CMakeLists.txt``.
+* Language level: C++17 from the DART CMake targets.
+* Build system: Ninja is the Pixi default; other CMake generators can work.
+* Core package dependencies: Assimp, Eigen, FCL, fmt, Bullet, ODE, OctoMap,
+  spdlog, tinyxml2, urdfdom, and OpenSceneGraph.
+* dartpy dependencies: Python, NumPy, and pybind11.
+
+Manual CMake build
+------------------
+
+Install the dependencies with your platform package manager or use the Pixi
+environment as the dependency prefix. Then configure and build:
+
+.. code-block:: bash
+
+   cmake -G Ninja -S . -B build/default/cpp/Release \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DDART_BUILD_DARTPY=ON \
+       -DDART_BUILD_PROFILE=ON \
+       -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
+       -DDART_USE_SYSTEM_GOOGLETEST=ON \
+       -DDART_USE_SYSTEM_IMGUI=ON \
+       -DDART_USE_SYSTEM_PYBIND11=ON \
+       -DDART_USE_SYSTEM_TRACY=ON
+   cmake --build build/default/cpp/Release -j
+
+Use ``-DCMAKE_PREFIX_PATH=<prefix>`` when dependencies are installed outside the
+compiler's default search paths.
+
+Important CMake options
+-----------------------
+
+The source-of-truth option list is in ``CMakeLists.txt``. Common branch options
+include:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 20 45
+
+   * - Option
+     - Default
+     - Purpose
+   * - ``DART_BUILD_DARTPY``
+     - ``OFF``
+     - Build the Python bindings.
+   * - ``DART_BUILD_GUI_OSG``
+     - ``ON``
+     - Build the OpenSceneGraph GUI component.
+   * - ``DART_ENABLE_GUI_OSG_SMOKE_TESTS``
+     - ``OFF``
+     - Build off-screen GUI capture smoke tests when a display or Xvfb is
+       available.
+   * - ``DART_ENABLE_SIMD``
+     - ``OFF``
+     - Add local-machine SIMD compiler flags such as ``-march=native``.
+   * - ``DART_SIMD_FORCE_SCALAR``
+     - ``OFF``
+     - Force the header-only ``dart/simd`` module to use its scalar fallback
+       backend in tests.
+   * - ``DART_BUILD_PROFILE``
+     - ``OFF``
+     - Build profiling support.
+   * - ``DART_PROFILE_BUILTIN``
+     - ``ON``
+     - Enable DART's built-in text profiling backend.
+   * - ``DART_PROFILE_TRACY``
+     - ``OFF``
+     - Enable the Tracy profiling backend for local developer profiling.
+   * - ``DART_USE_SYSTEM_IMGUI``
+     - ``OFF``
+     - Use a system ImGui package instead of the bundled compatibility target.
+   * - ``DART_USE_SYSTEM_PYBIND11``
+     - ``OFF``
+     - Use a system pybind11 package.
+
+Build targets
 -------------
 
-This guide describes how to build DART, a C++ library for robotics and motion
-planning, using CMake. DART also has Python bindings, called dartpy, which will
-be covered in a separate section.
-
-Supported Environments
-~~~~~~~~~~~~~~~~~~~~~~
-
-DART is supported on the following operating systems and compilers:
-
-+-----------------------+-----------------------+
-| Operating System      | Compiler              |
-+=======================+=======================+
-| Ubuntu 22.04 or later | GCC 11.2 or later     |
-+-----------------------+-----------------------+
-| Windows 2022 or later | Visual Studio 2022    |
-+-----------------------+-----------------------+
-| macOS 13 or later     | Clang 13 or later     |
-+-----------------------+-----------------------+
-
-Prerequisites
-~~~~~~~~~~~~~
-
-Before you can build DART, you'll need to install the required and optional
-dependencies. The required dependencies are the minimum set of dependencies
-needed to build DART, while the optional dependencies enable additional
-features in DART.
-
-The steps for installing dependencies may vary depending on your operating
-system and package manager. Below, we provide instructions for installing the
-required and optional dependencies on Ubuntu, macOS, and Windows, as well as
-some experimental guidance for other platforms.
-
-.. note::
-
-   Please note that the dependencies and installation steps are subject to
-   change, so we encourage you to report any issues you encounter and
-   contribute to keeping the instructions up-to-date for the community. By
-   working together, we can help ensure that the DART documentation is accurate
-   and helpful for everyone who uses it.
-
-Ubuntu
-^^^^^^
-
-The dependencies for Ubuntu can be installed using the ``apt`` package
-manager. The following command will install the required dependencies:
-
-.. code-block:: bash
-
-   $ sudo apt install \
-      build-essential cmake pkg-config git libassimp-dev \
-      libeigen3-dev libfcl-dev libfmt-dev
-
-The following command will install the optional dependencies:
-
-.. code-block:: bash
-
-   $ sudo apt install \
-      libbullet-dev \
-      libtinyxml2-dev liburdfdom-dev liburdfdom-headers-dev \
-      libopenscenegraph-dev liboctomap-dev libode-dev \
-      libspdlog-dev libyaml-cpp-dev ocl-icd-opencl-dev opencl-headers \
-      opencl-clhpp-headers
-
-macOS
-^^^^^
-
-The dependencies for macOS can be installed using the ``brew`` package
-manager. The following command will install the required dependencies:
-
-.. code-block:: bash
-
-   $ brew install assimp cmake eigen fmt fcl
-
-The following command will install the optional dependencies:
-
-.. code-block:: bash
-
-   $ brew install bullet octomap ode \
-      open-scene-graph --HEAD \
-      spdlog tinyxml2 urdfdom yaml-cpp
-
-Windows
-^^^^^^^
-
-The dependencies for Windows can be installed using the ``vcpkg`` package
-manager. The following command will install the required dependencies:
-
-.. code-block:: bash
-
-   $ vcpkg install --triplet x64-windows assimp eigen3 fcl fmt spdlog
-
-The following command will install the optional dependencies:
-
-.. code-block:: bash
-
-   $ vcpkg install --triplet x64-windows \
-      assimp eigen3 fcl fmt spdlog bullet3 ode \
-      opencl opengl osg pybind11 tinyxml2 urdfdom yaml-cpp
-
-Arch Linux (experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The dependencies for Arch Linux can be installed using the ``yay`` package
-manager. The following command will install the required dependencies:
-
-.. code-block:: bash
-
-   $ yay -S assimp cmake eigen fcl fmt
-
-The following command will install the optional dependencies:
-
-.. code-block:: bash
-
-   $ yay -S \
-      bullet octomap ode opencl-clhpp \
-      opencl-headers opencl-icd-loader openscenegraph spdlog tinyxml2 \
-      urdfdom pybind11
-
-FreeBSD (experimental)
-^^^^^^^^^^^^^^^^^^^^^^
-
-TODO
-
-Dependency Info
-~~~~~~~~~~~~~~~
-
-Here's a summary of the dependencies required to build DART (WIP):
-
-+----------------+----------+---------+--------------+-------+
-| Dependency     | Required | Type    | Min. Version | Notes |
-+================+==========+=========+==============+=======+
-| CMake          | Yes      | Build   | 3.22.1       |       |
-+----------------+----------+---------+--------------+-------+
-| Assimp         | Yes      | Runtime | 5.2.2        |       |
-+----------------+----------+---------+--------------+-------+
-| Eigen          | Yes      | Runtime | 3.4.0        |       |
-+----------------+----------+---------+--------------+-------+
-| FCL            | Yes      | Runtime | 0.7.0        |       |
-+----------------+----------+---------+--------------+-------+
-| fmt            | Yes      | Runtime | 8.1.1        |       |
-+----------------+----------+---------+--------------+-------+
-| Bullet         | No       | Runtime | 3.06         |       |
-+----------------+----------+---------+--------------+-------+
-| Octomap        | No       | Runtime | 1.9.7        |       |
-+----------------+----------+---------+--------------+-------+
-| ODE            | No       | Runtime | 0.16.2       |       |
-+----------------+----------+---------+--------------+-------+
-| spdlog         | No       | Runtime | 1.9.2        |       |
-+----------------+----------+---------+--------------+-------+
-| tinyxml2       | No       | Runtime | 9.0.0        |       |
-+----------------+----------+---------+--------------+-------+
-| urdfdom        | No       | Runtime | 3.0.1        |       |
-+----------------+----------+---------+--------------+-------+
-| OpenSceneGraph | No       | Runtime | 3.6.5        |       |
-+----------------+----------+---------+--------------+-------+
-
-Clone the DART Repository
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To get started with building DART, you'll need to clone the DART repository.
-Here's how to do it:
-
-1. Clone the DART repository by running the following command in your terminal:
-
-   .. code-block:: bash
-
-      $ git clone https://github.com/dartsim/dart.git
-
-2. (Optional) If you want to build a specific version of DART, you can checkout
-   a specific branch, tag, or commit.
-
-   .. code-block:: bash
-
-      $ git checkout -b <branch_or_tag_or_commit>
-
-.. note::
-
-   Please note that the DART repository is actively maintained, so there may be
-   changes and updates to the repository over time. To get the latest
-   information, we recommend referring to the DART GitHub repository.
-
-Build Configuration
-~~~~~~~~~~~~~~~~~~~
-
-DART uses CMake as its build system. CMake is a powerful tool that generates
-build files for a variety of build systems, including Makefiles, Visual Studio
-projects, and Xcode projects. For more information about available generators,
-we recommend referring to the
-`CMake documentation <https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html>`_.
-
-To configure the build, you'll need to create a build directory and run CMake
-from that directory. Here's how to do it:
-
-1. Create a build directory by running the following command in your terminal:
-
-   .. code-block:: bash
-
-      $ mkdir build
-
-2. Change into the build directory by running the following command:
-
-   .. code-block:: bash
-
-      $ cd build
-
-3. Run CMake from the build directory by running the following command:
-
-   .. code-block:: bash
-
-      $ cmake ..
-
-If you want to configure the build, you can pass additional options to CMake.
-For example, you can specify the build type by passing the
-``-DCMAKE_BUILD_TYPE`` option. DART provides a number of CMake options that
-allow you to customize the build process. Here are some of the most important
-options:
-
-+-------------------------+---------------+----------------------------------------------+
-| Option                  | Default Value | Description                                  |
-+=========================+===============+==============================================+
-| CMAKE_BUILD_TYPE        | Release       | Specifies the build type.                    |
-+-------------------------+---------------+----------------------------------------------+
-| DART_ENABLE_SIMD        | OFF           | Adds local-machine SIMD compiler flags such  |
-|                         |               | as ``-march=native``. Use only for builds    |
-|                         |               | that run on the same machine architecture.   |
-+-------------------------+---------------+----------------------------------------------+
-| DART_SIMD_FORCE_SCALAR  | OFF           | Forces the header-only ``dart/simd`` module  |
-|                         |               | to use its scalar fallback backend in tests. |
-+-------------------------+---------------+----------------------------------------------+
-
-.. note::
-
-   This list of options may not be exhaustive or up-to-date. Please refer to
-   the main CMakeLists.txt file in the DART repository to confirm the list of
-   available options. If you find any discrepancies or errors, please consider
-   submitting a pull request to update this document.
-
-Here are some example commands that you can use to configure the build on
-different platforms with different generators:
-
-.. code-block:: bash
-
-   $ cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
-   $ cmake .. -G "Visual Studio 15 2017" -A x64 -DCMAKE_BUILD_TYPE=Release
-   $ cmake .. -G "Xcode" -DCMAKE_BUILD_TYPE=Release
-
-Building DART from Command Line
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Whether or not you configured the build for IDEs, you can still build DART from
-the command line using CMake's unified build commands.
-
-To build DART from the command line, you'll need to run the build command from
-the build directory. Here's how to do it:
-
-1. Change into the build directory by running the following command:
-
-   .. code-block:: bash
-
-      $ cd build
-
-2. Run the build command by running the following command:
-
-   .. code-block:: bash
-
-      $ cmake --build . [--target <target> [, <target2>, ...]] [-j<num_core>]
-
-DART provides a number of CMake targets that you can use to build different
-parts of the project. Here are some of the most important targets:
-
-* ``ALL``: Builds all the targets in the project, including building tests,
-  examples, tutorials, and running tests.
-* ``all``: Builds core targets without tests, examples, and tutorials.
-* ``tests``: Builds all the tests.
-* ``test``: Runs tests (need to build tests first).
-* ``tests_and_run``: Builds and runs tests.
-* ``examples``: Builds all the examples.
-* ``tutorials``: Builds all the tutorials.
-* ``benchmarks``: Builds all the benchmarks.
-* ``view_docs``: Builds the documentation and opens it in a web browser.
-* ``install``: Installs the project.
-* ``dartpy``: Builds the Python bindings (it's encouraged to build using pip
-  instead).
-* ``pytest``: Runs Python tests (building tests if necessary).
-* ``coverage``: Runs tests and generates a coverage report.
-* ``coverage_html``: Runs tests and generates an HTML coverage report.
-* ``coverage_view``: Runs tests, generates an HTML coverage report, and opens
-  it in a web browser.
-
-.. note::
-
-   Please note that this list of targets may not be exhaustive or up-to-date.
-   To confirm the full list of available targets, we recommend referring to the
-   main CMakeLists.txt file in the DART repository. If you find any
-   discrepancies or errors, we encourage you to submit a pull request to
-   update this document and help keep the documentation up-to-date for the
-   community.
-
-Building DART from IDEs
-~~~~~~~~~~~~~~~~~~~~~~~
-
-If you configured the build for IDEs, you can build DART from the IDEs. This
-section doesn't cover how to build DART from IDEs. Please refer to the IDEs
-documentation for more information. However, it's always to welcome to submit a
-pull request to update this document with instructions for your favorite IDE!
-
-Building dartpy
----------------
-
-In general, building dartpy from source is not necessary. The easiest way to
-install dartpy is to use pip:
-
-.. code-block:: bash
-
-   $ pip install dartpy -U
-
-TODO
+Useful CMake targets include:
+
+* ``all``: build the default libraries and tools.
+* ``tests``: build the C++ tests.
+* ``test``: run CTest after tests are built.
+* ``examples``: build examples.
+* ``tutorials``: build tutorials.
+* ``dartpy``: build the Python bindings.
+* ``pytest``: run Python tests through the CMake target.
+* ``install``: install the configured components.
+* ``view_docs``: build and open local documentation.
+
+For most development work, prefer the Pixi task names above because they encode
+the branch's expected build directory, dependency prefix, and platform-specific
+settings.

--- a/docs/readthedocs/dart/developer_guide/code_style_guide.rst
+++ b/docs/readthedocs/dart/developer_guide/code_style_guide.rst
@@ -82,4 +82,16 @@ help with integration with other Python modules or projects.
 CMake Style Guide
 -----------------
 
-TODO
+Follow the CMake style in ``CONTRIBUTING.md`` and nearby ``CMakeLists.txt`` or
+``*.cmake`` files:
+
+* Use two-space indentation.
+* Quote singleton variable expansions, especially paths.
+* Split complex commands across semantic groups instead of making one long
+  line.
+* Keep configure templates (``*.cmake.in``) conservative because they contain
+  substitution tokens that are expanded by CMake.
+
+The branch formats CMake sources with gersemi through ``scripts/lint_cmake.py``.
+Run ``pixi run lint-cmake`` for CMake-only edits, or ``pixi run lint`` before
+committing.

--- a/docs/readthedocs/dart/developer_guide/migration_guide.rst
+++ b/docs/readthedocs/dart/developer_guide/migration_guide.rst
@@ -4,4 +4,12 @@ Migration Guide
 From DART 6 to DART 7
 ----------------------
 
-TODO
+This stable site documents the DART 6 compatibility line. DART 7 migration
+guidance lives with the in-progress DART 7 documentation so it can track the
+new API surface as it changes:
+
+* `DART 7 migration guide <https://dart.readthedocs.io/en/latest/dart/user_guide/migration_guide.html>`_
+* `DART 7 latest documentation <https://dart.readthedocs.io/en/latest/>`_
+
+For DART 6 maintenance work, keep using the APIs, examples, tutorials, and
+package instructions in this stable documentation set.

--- a/docs/readthedocs/dart/user_guide/installation.rst
+++ b/docs/readthedocs/dart/user_guide/installation.rst
@@ -1,41 +1,35 @@
 Installation
 ============
 
-Ubuntu
-------
+Cross-platform
+--------------
 
-To install DART on Ubuntu, you can use the following commands:
-
-1. Add the DART PPA to your system:
-
-.. code-block:: bash
-
-   sudo apt-add-repository ppa:dartsim/ppa
-
-2. Update your package list:
+For a reproducible DART 6 environment across Linux, macOS, and Windows, use
+Pixi or conda-forge:
 
 .. code-block:: bash
 
-   sudo apt-get update
+   pixi add dartsim-cpp
+   # or
+   conda install -c conda-forge dartsim-cpp
 
-3. Install the `libdart7-all-dev-nightly` package:
+Ubuntu / Debian
+---------------
+
+To install the distro-packaged DART C++ libraries on Ubuntu or Debian:
 
 .. code-block:: bash
 
-   sudo apt-get install libdart7-all-dev-nightly
+   sudo apt update
+   sudo apt install libdart-all-dev
+
+If you need a newer DART 6 LTS build than your distro provides, prefer the
+cross-platform package channels above.
 
 macOS
 -----
 
-To install DART on macOS, you can use Homebrew:
-
-1. Install Homebrew if you haven't already:
-
-.. code-block:: bash
-
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-2. Install the `dartsim` formula:
+To install DART on macOS, use Homebrew:
 
 .. code-block:: bash
 
@@ -44,53 +38,39 @@ To install DART on macOS, you can use Homebrew:
 Windows
 -------
 
-To install DART on Windows, you can use vcpkg:
-
-1. Install vcpkg if you haven't already:
+To install DART on Windows, use vcpkg:
 
 .. code-block:: bash
 
    git clone https://github.com/microsoft/vcpkg.git
    cd vcpkg
-   bootstrap-vcpkg.bat
+   .\bootstrap-vcpkg.bat
+   .\vcpkg install dartsim:x64-windows
 
-2. Install the `dartsim` package:
+Arch Linux
+----------
 
-.. code-block:: bash
-
-   vcpkg install dartsim:x64-windows
-
-Arch Linux (experimental)
---------------------------
-
-To install DART on Arch Linux using the `yay` package manager, you can use the
-following commands:
-
-1. Update your package list:
-
-.. code-block:: bash
-
-   yay -Syu
-
-2. Install the `libdart` package:
+To install DART on Arch Linux using the ``yay`` package manager:
 
 .. code-block:: bash
 
    yay -S libdart
 
-FreeBSD (experimental)
-----------------------
+FreeBSD
+-------
 
-To install DART on FreeBSD, you can use the following commands:
-
-1. Update your package list:
-
-.. code-block:: bash
-
-   pkg update
-
-2. Install the `dartsim` package:
+To install DART on FreeBSD:
 
 .. code-block:: bash
 
    pkg install dartsim
+
+Package availability
+--------------------
+
+For an up-to-date view of every distribution that packages DART, refer to
+Repology:
+
+.. image:: https://repology.org/badge/vertical-allrepos/dart-sim.svg
+   :target: https://repology.org/project/dart-sim/versions
+   :alt: Packaging status

--- a/docs/readthedocs/dart/user_guide/tutorials.rst
+++ b/docs/readthedocs/dart/user_guide/tutorials.rst
@@ -5,13 +5,13 @@ The purpose of this tutorial is to provide a quick introduction to
 using DART. We designed many hands-on exercises to make the learning
 effective and fun. To follow along with this tutorial, first locate
 the tutorial code in the directory:
-`dart/tutorials <https://github.com/dartsim/dart/tree/2b59bd7b4ab7ea184026d5a19f1ad20df867012d/tutorials>`_.
+`tutorials <https://github.com/dartsim/dart/tree/release-6.20/tutorials>`_.
 For each of the four tutorials, we provide the skeleton code as the starting
 point (e.g.
-`tutorial_multi_pendulum <https://github.com/dartsim/dart/tree/2b59bd7b4ab7ea184026d5a19f1ad20df867012d/tutorials/tutorial_multi_pendulum>`_)
+`tutorial_multi_pendulum <https://github.com/dartsim/dart/tree/release-6.20/tutorials/tutorial_multi_pendulum>`_)
 and the final code as the answer to the tutorial (e.g.
-`tutorial_multi_pendulum_finished <https://github.com/dartsim/dart/tree/2b59bd7b4ab7ea184026d5a19f1ad20df867012d/tutorials/tutorial_multi_pendulum_finished>`_).
-The examples are based on the APIs of DART 7.0.
+`tutorial_multi_pendulum_finished <https://github.com/dartsim/dart/tree/release-6.20/tutorials/tutorial_multi_pendulum_finished>`_).
+The examples are based on the DART 6 API maintained on this branch.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/readthedocs/dartpy/user_guide/installation.rst
+++ b/docs/readthedocs/dartpy/user_guide/installation.rst
@@ -1,36 +1,48 @@
 Installation
 ============
 
-To install the Python bindings for DART using the `dartpy` package from PyPI,
-you can use the following command:
+Quick install commands
+----------------------
+
+For the DART 6 Python bindings, use one of the package channels below:
 
 .. code-block:: bash
 
-   pip install dartpy -U
+   pixi add dartpy
+   # or
+   conda install -c conda-forge dartpy
+   # or
+   pip install --upgrade dartpy
 
-The following operating systems are currently supported:
+Supported PyPI wheel lanes
+--------------------------
 
-+----------------+--------+--------+--------+--------+--------+
-| Operating      | Python | Python | Python | Python | Python |
-| System         | 3.7    | 3.8    | 3.9    | 3.10   | 3.11   |
-+================+========+========+========+========+========+
-| Linux x86_64   |   O    |   O    |   O    |   O    |   O    |
-+----------------+--------+--------+--------+--------+--------+
-| Linux arm64    |   X    |   X    |   X    |   X    |   O    |
-+----------------+--------+--------+--------+--------+--------+
-| macOS x86_64   |   X    |   O    |   O    |   O    |   O    |
-+----------------+--------+--------+--------+--------+--------+
-| macOS arm64    |   X    |   O    |   X    |   O    |   O    |
-+----------------+--------+--------+--------+--------+--------+
-| Windows x86_64 |   X    |   O    |   O    |   O    |   O    |
-+----------------+--------+--------+--------+--------+--------+
-| Windows arm64  |   X    |   X    |   X    |   X    |   O    |
-+----------------+--------+--------+--------+--------+--------+
+The release branch's ``publish_dartpy.yml`` workflow builds these PyPI wheel
+lanes. Wheel versions are sourced from ``package.xml`` and are published from
+matching version tags.
 
-.. note::
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
 
-   This table may not be up-to-date. For the latest information on the
-   availability of the Python bindings for DART, please refer to the dartpy
-   package on PyPI: https://pypi.org/project/dartpy/. If you would like to use
-   dartpy on an unsupported OS or Python version, please let us know so we can
-   consider adding support.
+   * - Platform
+     - CPython wheels built by this branch
+   * - Linux x86_64
+     - 3.13 on regular wheel runs; 3.10, 3.11, 3.12, and 3.13 on release branch
+       and tag builds
+   * - macOS arm64
+     - 3.13 on regular wheel runs; 3.12 and 3.13 on release branch and tag
+       builds
+   * - Windows x86_64
+     - 3.13 on regular wheel runs; 3.12 and 3.13 on release branch and tag
+       builds
+   * - Other Python versions or platforms
+     - Build from source with Python 3.7 or newer, or use conda-forge/Pixi when
+       packages are available there
+
+Building from source
+--------------------
+
+The DART 6 ``setup.py`` package supports Python 3.7 or newer. Building the
+bindings locally requires a matching C++ toolchain, CMake, Ninja, and the DART
+dependencies used by the source checkout.

--- a/docs/readthedocs/index.rst
+++ b/docs/readthedocs/index.rst
@@ -6,6 +6,15 @@
 Welcome to DART documentation!
 ==============================
 
+.. admonition:: You are reading the DART 6 LTS documentation
+   :class: important
+
+   This site documents the **DART 6** compatibility line. The active
+   maintenance branch is ``release-6.20``; its source version is read from
+   ``package.xml`` and release notes are tracked in ``CHANGELOG.md``. For the
+   in-progress DART 7 redesign, use the `latest documentation
+   <https://dart.readthedocs.io/en/latest/>`_.
+
 Introduction
 ------------
 
@@ -27,6 +36,10 @@ Articulated Body Algorithm to compute motion dynamics.
 Updates
 -------
 
+* 2026-06-27: DART version 6.19.3 released. See the
+  `CHANGELOG <https://github.com/dartsim/dart/blob/release-6.20/CHANGELOG.md>`_.
+* DART 6.20.0 is in progress on the
+  `release-6.20 branch <https://github.com/dartsim/dart/tree/release-6.20>`_.
 * 2022-12-31: DART version 6.13.0 released.
 
 Project Stats


### PR DESCRIPTION
## Summary

- Refreshes the `release-6.20` Read the Docs sources so the stable DART 6 site
  uses branch-owned version metadata, package guidance, and Pixi/CMake build
  instructions from the current codebase.

## Motivation / Problem

- The DART 6 stable docs had drifted toward stale DART 7/nightly-era wording and
  old manual build guidance. The stable website should describe the maintained
  DART 6 LTS branch using the branch's own `package.xml`, workflows, and build
  options as the source of truth.

## Changes / Key Changes

- Read the RTD version from `package.xml` instead of hardcoded DART 7 alpha
  values.
- Update the stable-site landing page for the `release-6.20` LTS line and the
  in-progress DART 6.20.0 release.
- Refresh C++ and dartpy install pages with current DART 6 package lanes,
  branch wheel behavior, and distro/package-manager guidance.
- Replace stale build docs with current Pixi/CMake tasks, requirements, targets,
  and important CMake options from the branch.
- Update tutorial, migration, and code-style pages so they no longer point users
  at stale DART 7 or release-6.19-era assumptions.
- Add the required DART 6 changelog entry for workflow-facing docs guidance.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Site version | RTD config used hardcoded DART 7 alpha values. | RTD reads the stable branch version from `package.xml`. |
| Install docs | Stable docs referenced stale nightly/DART 7 or older release lanes. | Stable docs describe DART 6 LTS package lanes and branch wheel behavior. |
| Build docs | Build page carried obsolete manual dependency tables and TODOs. | Build page documents current Pixi/CMake tasks and branch-owned options. |

## Testing

- `pixi run docs-build`
- `pixi run lint`
- `git diff --check origin/release-6.20..HEAD`
- Targeted stale-string scan over `README.md` and `docs/readthedocs` for stale
  DART 7/nightly/release-6.19-era references.

## Breaking Changes

- [x] None
- Documentation-only update; no API or package behavior changes.

## Related Issues / PRs (backports)

- Related DART 7 docs sync PR: #3347.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality (N/A: docs-only)
- [x] Document new methods and classes (N/A: no new API)
- [x] Add Python bindings (dartpy) if applicable (N/A)
