### PR TITLE
Refresh DART 7 RTD package guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,7 +348,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Refreshed the DART 7 README and Read the Docs package guidance so the
   published install, dartpy smoke-test, and Python example paths match the
   current `package.xml`, wheel workflow, and `dart::simulation::World` API
-  surface.
+  surface. ([#3347](https://github.com/dartsim/dart/pull/3347))
 - Hardened the AI-native contributor workflow: `pixi run install-hooks` now
   installs a pre-commit hook running the Tier-0 lint gate (with a tracked
   Claude Code commit guard as fallback), the plan dashboard is bounded by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,10 @@ compatibility remains on the active DART 6 LTS branch._
 
 #### Build, Packaging, and Developer Tooling
 
+- Refreshed the DART 7 README and Read the Docs package guidance so the
+  published install, dartpy smoke-test, and Python example paths match the
+  current `package.xml`, wheel workflow, and `dart::simulation::World` API
+  surface.
 - Hardened the AI-native contributor workflow: `pixi run install-hooks` now
   installs a pre-commit hook running the Tier-0 lint gate (with a tracked
   Claude Code commit guard as fallback), the plan dashboard is bounded by

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ DART 6 package and should use the stable documentation.
 Run this after `pixi run build` from a source checkout:
 
 ```bash
-PYTHONPATH=build/default/cpp/Release/python python - <<'PY'
+PYTHONPATH=build/default/cpp/Release/python pixi run python - <<'PY'
 import dartpy as dart
 
 world = dart.World()

--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ DART 6 package and should use the stable documentation.
 
 **Python source build**
 
-```python
+Run this after `pixi run build` from a source checkout:
+
+```bash
+PYTHONPATH=build/default/cpp/Release/python python - <<'PY'
 import dartpy as dart
 
 world = dart.World()
@@ -127,6 +130,7 @@ body = world.add_rigid_body("box", dart.RigidBodyOptions())
 world.enter_simulation_mode()
 world.step()
 print(f"t = {world.time:.4f} s, box position = {body.translation}")
+PY
 ```
 
 **C++ package**

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Articulated Body Algorithm for accurate, stable motion dynamics.
 >
 > For a stable release, use **DART 6 LTS**:
 > [documentation](https://dart.readthedocs.io/en/stable/) ·
-> [`release-6.19` branch](https://github.com/dartsim/dart/tree/release-6.19).
+> [`release-6.20` branch](https://github.com/dartsim/dart/tree/release-6.20).
 
 <p align="center">
   <img src="docs/assets/unitree_g1_demo.gif" width="720" alt="Unitree G1 humanoid demo" />
@@ -54,18 +54,22 @@ Articulated Body Algorithm for accurate, stable motion dynamics.
 
 ```python
 import dartpy as dart
+import numpy as np
 
-world = dart.World()
+world = dart.World(time_step=1.0 / 1000.0)
 
-# Load a robot from URDF
-urdf = dart.io.UrdfParser()
-robot = urdf.parse_skeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
-world.add_skeleton(robot)
+# Add a 1 kg rigid body one metre above the origin.
+options = dart.RigidBodyOptions()
+options.mass = 1.0
+options.position = np.array([0.0, 0.0, 1.0])
+box = world.add_rigid_body("box", options)
 
-# Simulate 100 steps
+# Lock topology, then simulate 100 steps.
+world.enter_simulation_mode()
 for _ in range(100):
     world.step()
-    print(f"Positions: {robot.get_positions()}")
+
+print(f"t = {world.time:.3f} s, box z = {float(box.translation[2]):.3f} m")
 ```
 
 **C++**
@@ -79,20 +83,19 @@ for current source-checkout examples; DART 6 C++ snippets remain on the
 ## Installation
 
 The quick-start snippets above target the current `main` branch and DART 7 API.
-Until DART 7 package artifacts are published, package managers resolve the
-latest published DART 6 artifacts instead, and different indexes may briefly
-serve different DART 6 patch releases until their packages finish publishing.
-Use the file-free package smoke checks below for the installed package version,
-or use the source checkout path for the DART 7 quick starts.
+The tracked DART 7 wheel lane builds CPython 3.14 wheels on Linux, macOS, and
+Windows, while default package channels may still resolve stable DART 6
+artifacts. Use PyPI pre-release resolution for DART 7 packages, or use the
+source checkout path for the newest DART 7 surface.
 
 ### Python (Recommended)
 
-| Method             | Command                               |
-| ------------------ | ------------------------------------- |
-| **uv** (preferred) | `uv add dartpy`                       |
-| **pip**            | `pip install dartpy`                  |
-| **pixi**           | `pixi add dartpy`                     |
-| **conda**          | `conda install -c conda-forge dartpy` |
+| Method                   | Command                               |
+| ------------------------ | ------------------------------------- |
+| **uv** (DART 7 PyPI)     | `uv add dartpy --prerelease allow`    |
+| **pip** (DART 7 PyPI)    | `pip install --pre dartpy`            |
+| **pixi** (DART 6 today)  | `pixi add dartpy`                     |
+| **conda** (DART 6 today) | `conda install -c conda-forge dartpy` |
 
 ### C++
 
@@ -110,19 +113,20 @@ or use the source checkout path for the DART 7 quick starts.
 ### Current Package Smoke Checks
 
 These snippets create a tiny model in code, so they do not depend on sample data
-files being present in the installed package.
+files being present in the installed package. The Python snippet targets the
+DART 7 facade; if `dart.World` or `add_rigid_body` is missing, the environment
+resolved a stable DART 6 package and should use the stable documentation.
 
 **Python package**
 
 ```python
 import dartpy as dart
 
-world = dart.simulation.World()
-skeleton = dart.dynamics.Skeleton("box")
-skeleton.createFreeJointAndBodyNodePair()
-world.addSkeleton(skeleton)
+world = dart.World()
+body = world.add_rigid_body("box", dart.RigidBodyOptions())
+world.enter_simulation_mode()
 world.step()
-print(f"Positions: {skeleton.getPositions()}")
+print(f"t = {world.time:.4f} s, box position = {body.translation}")
 ```
 
 **C++ package**
@@ -173,7 +177,7 @@ search terms, and capture commands are in the
 #### Branches
 
 - `main` — Active development targeting DART 7 (not yet production-ready)
-- `release-6.19` — Maintenance branch for DART 6 LTS (critical fixes only); see
+- `release-6.20` — Maintenance branch for DART 6 LTS (critical fixes only); see
   the [DART 6 documentation](https://dart.readthedocs.io/en/stable/)
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ for current source-checkout examples; DART 6 C++ snippets remain on the
 
 The quick-start snippets above target the current `main` branch and DART 7 API.
 The tracked DART 7 wheel lane builds CPython 3.14 wheels on Linux, macOS, and
-Windows, while default package channels may still resolve stable DART 6
-artifacts. Use PyPI pre-release resolution for DART 7 packages, or use the
-source checkout path for the newest DART 7 surface.
+Windows, but PyPI currently serves the stable DART 6 line as the latest
+non-yanked `dartpy` package. Use the source checkout path for the DART 7 Python
+facade until a non-yanked DART 7 wheel is published.
 
 ### Python (Recommended)
 
-| Method                   | Command                               |
-| ------------------------ | ------------------------------------- |
-| **uv** (DART 7 PyPI)     | `uv add dartpy --prerelease allow`    |
-| **pip** (DART 7 PyPI)    | `pip install --pre dartpy`            |
-| **pixi** (DART 6 today)  | `pixi add dartpy`                     |
-| **conda** (DART 6 today) | `conda install -c conda-forge dartpy` |
+| Method                                  | Command                                                         |
+| --------------------------------------- | --------------------------------------------------------------- |
+| **source checkout** (DART 7 today)      | `pixi run build` from this repository                           |
+| **uv/pip** (DART 7 after wheel publish) | `uv add dartpy --prerelease allow` / `pip install --pre dartpy` |
+| **pixi** (DART 6 stable today)          | `pixi add dartpy`                                               |
+| **conda** (DART 6 stable today)         | `conda install -c conda-forge dartpy`                           |
 
 ### C++
 
@@ -110,14 +110,14 @@ source checkout path for the newest DART 7 surface.
 
 [All distributions →](https://repology.org/project/dart-sim/versions)
 
-### Current Package Smoke Checks
+### Current DART 7 Smoke Checks
 
 These snippets create a tiny model in code, so they do not depend on sample data
-files being present in the installed package. The Python snippet targets the
-DART 7 facade; if `dart.World` or `add_rigid_body` is missing, the environment
-resolved a stable DART 6 package and should use the stable documentation.
+files being present. The Python snippet targets a DART 7 source build; if
+`dart.World` or `add_rigid_body` is missing, the environment resolved a stable
+DART 6 package and should use the stable documentation.
 
-**Python package**
+**Python source build**
 
 ```python
 import dartpy as dart

--- a/docs/readthedocs/conf.py
+++ b/docs/readthedocs/conf.py
@@ -446,9 +446,9 @@ def _read_dart_semver():
         if version_elem is not None and version_elem.text:
             return version_elem.text.strip()
     except (FileNotFoundError, ET.ParseError):
-        pass
-    # Fallback to latest stable version
-    return "6.16.0"
+        logger.warning("Unable to read DART version from %s", package_xml)
+    # Keep this visibly synthetic instead of falling back to a stale real release.
+    return "0.0.0"
 
 
 def get_dart_version(prefix_with_v: bool = True):
@@ -459,19 +459,14 @@ def get_dart_version(prefix_with_v: bool = True):
 
 
 def _read_api_versions():
-    """Return the list of published documentation versions."""
+    """Return source-known documentation versions for local template context.
 
-    versions_file = REPO_ROOT / "scripts" / "docs_versions.txt"
-    versions = []
-    try:
-        for line in versions_file.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("DART "):
-                versions.append(line)
-    except FileNotFoundError:
-        # Fallback to a safe default when running locally without the helper.
-        versions = ["v6.16.0"]
-    return versions
+    Read the Docs owns the published version selector. Local builds only need a
+    non-stale current-source value, so derive it from package.xml instead of a
+    checked-out helper file that may not exist on every branch.
+    """
+
+    return [get_dart_version()]
 
 
 # Get current DART version from package.xml

--- a/docs/readthedocs/dartpy/python_api_reference.rst
+++ b/docs/readthedocs/dartpy/python_api_reference.rst
@@ -24,7 +24,7 @@ To explore the bindings locally:
    python - <<'PY'
    import dartpy as dart
    world = dart.World()
-   print(world.get_gravity())
+   print(world.gravity)
    PY
 
 Module Reference

--- a/docs/readthedocs/dartpy/python_api_reference.rst
+++ b/docs/readthedocs/dartpy/python_api_reference.rst
@@ -21,7 +21,7 @@ To explore the bindings from a source checkout:
 .. code-block:: bash
 
    pixi run build
-   PYTHONPATH=build/default/cpp/Release/python python - <<'PY'
+   PYTHONPATH=build/default/cpp/Release/python pixi run python - <<'PY'
    import dartpy as dart
    world = dart.World()
    print(world.gravity)

--- a/docs/readthedocs/dartpy/python_api_reference.rst
+++ b/docs/readthedocs/dartpy/python_api_reference.rst
@@ -16,12 +16,12 @@ current repository API shape without pinning an older release wheel.
 Getting Started
 ---------------
 
-To explore the bindings locally:
+To explore the bindings from a source checkout:
 
 .. code-block:: bash
 
-   pip install --pre dartpy
-   python - <<'PY'
+   pixi run build
+   PYTHONPATH=build/default/cpp/Release/python python - <<'PY'
    import dartpy as dart
    world = dart.World()
    print(world.gravity)

--- a/docs/readthedocs/dartpy/python_api_reference.rst
+++ b/docs/readthedocs/dartpy/python_api_reference.rst
@@ -1,11 +1,12 @@
 Python API Reference
 ====================
 
-The full ``dartpy`` API reference is built from the module pages under
-``docs/python_api/``. Sphinx imports a live ``dartpy`` module when one is
-available; otherwise ``docs/readthedocs/conf.py`` falls back to the committed
-stubs under ``python/stubs/dartpy`` so Read the Docs renders the current
-repository API shape without pinning an older release wheel.
+The full ``dartpy`` API reference is authored under ``docs/python_api/modules``
+and included into this site through the shims under
+``docs/readthedocs/dartpy/api/modules``. Sphinx imports a live ``dartpy`` module
+when one is available; otherwise ``docs/readthedocs/conf.py`` falls back to the
+committed stubs under ``python/stubs/dartpy`` so Read the Docs renders the
+current repository API shape without pinning an older release wheel.
 
 .. note::
    Local ``pixi run docs-build`` uses the same fallback path unless the current
@@ -19,7 +20,7 @@ To explore the bindings locally:
 
 .. code-block:: bash
 
-   pip install dartpy
+   pip install --pre dartpy
    python - <<'PY'
    import dartpy as dart
    world = dart.World()

--- a/docs/readthedocs/dartpy/user_guide/examples.rst
+++ b/docs/readthedocs/dartpy/user_guide/examples.rst
@@ -1,59 +1,55 @@
 Examples
 ========
 
-.. include:: /_includes/legacy_dart6.rst
-
-.. note::
-
-   For a DART 7 "Hello, World" simulation using the current API, see
-   :doc:`/user_guide/getting_started/hello_dart`.
-
-Once you have installed dartpy using pip install -U dartpy, you can run the following "Hello World" example to simulate a 6-DOF robot using DART.
-
-.. note::
-
-   In order to load the URDF, please clone dart repository and set the `DART_DATA_PATH` environment variable to where the `data` folder is in the cloned repository (e.g., `C:/ws/dart/data/` if cloned to `C:/ws/dart/`)
+DART 7's Python examples use the ``dartpy`` World facade. The smallest useful
+example builds a scene in code, steps it, and inspects the body state:
 
 .. code-block:: python
 
-    import dartpy as dart
+   import dartpy as dart
 
-    def main():
-        world = dart.World()
+   world = dart.World(time_step=1.0 / 1000.0)
 
-        urdf_parser = dart.io.UrdfParser()
-        kr5 = urdf_parser.parse_skeleton("dart://sample/urdf/KR5/KR5 sixx R650.urdf")
-        ground = urdf_parser.parse_skeleton("dart://sample/urdf/KR5/ground.urdf")
-        world.addSkeleton(kr5)
-        world.addSkeleton(ground)
-        print("Robot {} is loaded".format(kr5.getName()))
+   ground = world.add_rigid_body("ground", position=(0.0, 0.0, -0.5))
+   ground.is_static = True
+   ground.set_collision_shape(dart.CollisionShape.box((1.0, 1.0, 0.05)))
 
-        for i in range(100):
-            if i % 10 == 0:
-                print(
-                    "[{}] joint position: {}".format(
-                        world.getSimFrames(), kr5.getPositions()
-                    )
-                )
-            world.step()
+   box = world.add_rigid_body("box", mass=1.0, position=(0.0, 0.0, 1.0))
+   box.set_collision_shape(dart.CollisionShape.box((0.1, 0.1, 0.1)))
 
-    if __name__ == "__main__":
-        main()
+   world.enter_simulation_mode()
+   for _ in range(100):
+       world.step()
 
-When you run this script, it will perform a forward dynamic simulation of the 6-DOF robot for 100 steps. Joint angles are printed every 10 steps, producing the following output:
+   print(f"t = {world.time:.3f} s, box z = {float(box.translation[2]):.3f} m")
 
-.. code-block:: none
+For the same first step with more explanation, see
+:doc:`/user_guide/getting_started/hello_dart`.
 
-   Robot KR5sixxR650WP_description is loaded
-   [0] joint position: [0. 0. 0. 0. 0. 0.]
-   [10] joint position: [ 0.00220342  0.00021945 -0.00040518  0.00011133  0.00074889 -0.00010902]
-   [20] joint position: [ 0.00841056  0.0008539  -0.0015611   0.00042308  0.00284968 -0.00040791]
-   [30] joint position: [ 0.01861372  0.00194988 -0.00350848  0.00092958  0.0062733  -0.00087254]
-   [40] joint position: [ 0.03279843  0.00358421 -0.00631463  0.00162151  0.01097006 -0.0014636 ]
-   [50] joint position: [ 0.05094093  0.00586373 -0.01007336  0.00248606  0.01686793 -0.00212772]
-   [60] joint position: [ 0.07300469  0.00892482 -0.01490498  0.00350698  0.02387041 -0.00279907]
-   [70] joint position: [ 0.098936    0.01293271 -0.02095646  0.00466479  0.03185446 -0.0034017 ]
-   [80] joint position: [ 0.12865883  0.01808055 -0.02840175  0.00593683  0.04066865 -0.00385261]
-   [90] joint position: [ 0.16206903  0.02458815 -0.03744247  0.00729732  0.05013223 -0.00406555]
+Interactive demos
+-----------------
 
-You can find additional example code at https://github.com/dartsim/dart/tree/main/python/examples
+The source tree's maintained Python example surface is the ``py-demos`` runner
+under ``python/examples/demos``. It hosts World scenes in the same Filament
+viewer used by the C++ demo app:
+
+.. code-block:: bash
+
+   pixi run py-demos                                # open the default rigid_body scene
+   pixi run py-demos -- --scene rigid_solver_compare # compare solver behavior
+   pixi run py-demos -- --list                      # print the scene catalog
+   pixi run py-demo-capture -- --scene rigid_body --frames 2 --width 640 --height 360
+
+The demo catalog includes rigid bodies, multibody contact, solver comparisons,
+deformable examples, differentiable simulation scenes, and visual debugging
+packets. Start with ``python/examples/README.md`` and
+``python/examples/demos/README.md`` in the source checkout when you need the
+current scene list and command-line options.
+
+Legacy DART 6 examples
+----------------------
+
+If you need ``Skeleton``/``BodyNode``/``Joint`` examples such as URDF loading
+with ``World.addSkeleton()``, use the stable DART 6 documentation at
+https://dart.readthedocs.io/en/stable/. Those APIs are not the DART 7
+Python-first path documented here.

--- a/docs/readthedocs/dartpy/user_guide/installation.rst
+++ b/docs/readthedocs/dartpy/user_guide/installation.rst
@@ -1,19 +1,31 @@
 Installation
 ============
 
-Quick install commands
-----------------------
+DART 7 source build
+-------------------
 
-Use your preferred package manager to add ``dartpy`` to an existing environment.
-For DART 7, opt into PyPI pre-releases so the Python-first API in this guide is
-selected instead of the stable DART 6 package line:
+DART 7's Python-first API is available from a source checkout today. Public
+package channels currently resolve stable DART 6 artifacts, or no usable
+non-yanked DART 7 wheel, so do not use package-manager commands for the DART 7
+examples until a non-yanked DART 7 ``dartpy`` wheel is published.
 
 .. code-block:: bash
 
-   uv add dartpy --prerelease allow  # uv (recommended for Python-first projects)
-   pip install dartpy --pre          # PyPI wheels, CPython 3.14
-   pixi add dartpy                   # stable DART 6 package line today
-   conda install -c conda-forge dartpy
+   git clone https://github.com/dartsim/dart.git
+   cd dart
+   pixi install
+   pixi run build
+
+After a non-yanked DART 7 wheel is published on PyPI, use pre-release
+resolution to select it instead of the stable DART 6 package line:
+
+.. code-block:: bash
+
+   uv add dartpy --prerelease allow
+   pip install dartpy --pre
+
+The default ``pixi add dartpy`` and ``conda install -c conda-forge dartpy``
+commands currently install the stable DART 6 package line.
 
 Supported platforms
 -------------------
@@ -40,10 +52,10 @@ The tracked DART 7 wheel workflow builds these configurations:
 
 .. note::
 
-   Wheel versions are sourced from ``package.xml``. Use the ``--pre`` flag with
-   ``pip`` for DART 7 pre-release tags; otherwise package managers can fall
-   back to the stable DART 6 package line. For the most up-to-date published
-   availability, check the `dartpy project page on PyPI
+   Wheel versions are sourced from ``package.xml``. DART 7 wheels are usable
+   from PyPI only after a non-yanked DART 7 release is published. Until then,
+   build from source for this guide's DART 7 examples. For the most up-to-date
+   published availability, check the `dartpy project page on PyPI
    <https://pypi.org/project/dartpy/>`_.
 
 Building from source

--- a/docs/readthedocs/dartpy/user_guide/installation.rst
+++ b/docs/readthedocs/dartpy/user_guide/installation.rst
@@ -4,19 +4,21 @@ Installation
 Quick install commands
 ----------------------
 
-Use your preferred package manager to add ``dartpy`` to an existing environment:
+Use your preferred package manager to add ``dartpy`` to an existing environment.
+For DART 7, opt into PyPI pre-releases so the Python-first API in this guide is
+selected instead of the stable DART 6 package line:
 
 .. code-block:: bash
 
-   uv add dartpy                 # uv (recommended for Python-first projects)
-   pip install dartpy --pre      # PyPI wheels (Linux x86_64, CPython 3.14)
-   pixi add dartpy               # Pixi environment
+   uv add dartpy --prerelease allow  # uv (recommended for Python-first projects)
+   pip install dartpy --pre          # PyPI wheels, CPython 3.14
+   pixi add dartpy                   # stable DART 6 package line today
    conda install -c conda-forge dartpy
 
 Supported platforms
 -------------------
 
-Pre-built wheels on PyPI currently cover the following configurations:
+The tracked DART 7 wheel workflow builds these configurations:
 
 .. list-table::
    :header-rows: 1
@@ -24,14 +26,25 @@ Pre-built wheels on PyPI currently cover the following configurations:
 
    * - Platform / Python
      - Status
-   * - Linux x86_64 / CPython 3.14
-     - ✅ Published as ``dartpy`` wheels (7.0.0.dev0, ``pip install --pre``)
-   * - Other CPython versions and platforms
-     - ⚠️ Use conda-forge, pixi, or build from source (no recent wheels yet)
+   * - Linux / CPython 3.14
+     - Built by ``publish_dartpy.yml`` and installable from PyPI when the
+       matching tag is published
+   * - macOS / CPython 3.14
+     - Built by ``publish_dartpy.yml`` and installable from PyPI when the
+       matching tag is published
+   * - Windows / CPython 3.14
+     - Built by ``publish_dartpy.yml`` and installable from PyPI when the
+       matching tag is published
+   * - Other CPython versions
+     - Build from source with a matching Python 3.14 toolchain
 
 .. note::
 
-   The latest PyPI upload is a pre-release (``7.0.0.dev0``). Use the ``--pre`` flag with ``pip`` if you want that build; otherwise pip falls back to the last stable 0.2.x wheel. For the most up-to-date availability, check the `dartpy project page on PyPI <https://pypi.org/project/dartpy/>`_.
+   Wheel versions are sourced from ``package.xml``. Use the ``--pre`` flag with
+   ``pip`` for DART 7 pre-release tags; otherwise package managers can fall
+   back to the stable DART 6 package line. For the most up-to-date published
+   availability, check the `dartpy project page on PyPI
+   <https://pypi.org/project/dartpy/>`_.
 
 Building from source
 --------------------

--- a/docs/readthedocs/user_guide/getting_started/installation.md
+++ b/docs/readthedocs/user_guide/getting_started/installation.md
@@ -34,10 +34,12 @@ Run a headless smoke check to confirm the build works:
 pixi run py-demos -- --scene rigid_body --headless --frames 1
 ```
 
-Verify the install by creating a tiny world in code — this does not need any
-sample data files:
+Verify the install by creating a tiny world in code. Point `PYTHONPATH` at the
+built bindings before importing `dartpy`; this does not need any sample data
+files:
 
-```python
+```bash
+PYTHONPATH=build/default/cpp/Release/python python - <<'PY'
 import dartpy as dart
 
 world = dart.World()
@@ -45,13 +47,12 @@ world.add_rigid_body("box", dart.RigidBodyOptions())
 world.enter_simulation_mode()
 world.step()
 print(f"Stepped one frame to t = {world.time:.4f} s")
+PY
 ```
 
 If that prints without error, you are ready for {doc}`hello_dart`.
 
-To use your source build from a plain Python interpreter, point `PYTHONPATH` at
-the built bindings (the exact path is printed at the end of `pixi run build`),
-for example:
+Use the same prefix for your own scripts:
 
 ```bash
 PYTHONPATH=build/default/cpp/Release/python python your_script.py

--- a/docs/readthedocs/user_guide/getting_started/installation.md
+++ b/docs/readthedocs/user_guide/getting_started/installation.md
@@ -1,8 +1,8 @@
 # Install DART
 
-DART 7 is **Python-first**, but because it is still in development its `dartpy`
-packages are pre-releases. The two reliable ways to get the DART 7 API used
-throughout this guide are PyPI pre-release wheels and a source build.
+DART 7 is **Python-first**, but because it is still in development the default
+package channels may still resolve stable DART 6 artifacts. The two DART 7 paths
+tracked by this source tree are the CPython 3.14 wheel lane and a source build.
 
 ```{admonition} Default channels still install DART 6
 :class: important
@@ -15,8 +15,9 @@ with one of the options below, or build from source.
 
 ## Python package (pre-release)
 
-DART 7 wheels are published as pre-releases on PyPI (currently Linux x86_64 /
-CPython 3.14). Opt into pre-releases so you get DART 7 rather than DART 6:
+The tracked DART 7 wheel workflow builds `dartpy` for CPython 3.14 on Linux,
+macOS, and Windows. Opt into pre-releases when using PyPI so a DART 7 wheel is
+preferred over the stable DART 6 line:
 
 ```bash
 pip install --pre dartpy           # pip (PyPI)

--- a/docs/readthedocs/user_guide/getting_started/installation.md
+++ b/docs/readthedocs/user_guide/getting_started/installation.md
@@ -1,47 +1,19 @@
 # Install DART
 
-DART 7 is **Python-first**, but because it is still in development the default
-package channels may still resolve stable DART 6 artifacts. The two DART 7 paths
-tracked by this source tree are the CPython 3.14 wheel lane and a source build.
+DART 7 is **Python-first**, but because it is still in development, public
+package channels still resolve stable DART 6 artifacts today. The current DART 7
+path is a source build from this repository; the CPython 3.14 wheel lane becomes
+an install path after a non-yanked DART 7 `dartpy` wheel is published.
 
-```{admonition} Default channels still install DART 6
+```{admonition} Public package channels still install DART 6
 :class: important
 
-Plain `uv add dartpy`, `pixi add dartpy`, and `conda install dartpy` resolve the
-**stable DART 6** line, which uses a different API — `dart.World()` and
-`add_rigid_body` from this guide do not exist there. Install DART 7 explicitly
-with one of the options below, or build from source.
+`pip install --pre dartpy`, `uv add dartpy --prerelease allow`,
+`pixi add dartpy`, and `conda install dartpy` do not currently provide the DART
+7 API used by this guide. They resolve the **stable DART 6** line, or no usable
+non-yanked DART 7 wheel. Use a source build for DART 7 examples until a
+non-yanked DART 7 wheel is available on PyPI.
 ```
-
-## Python package (pre-release)
-
-The tracked DART 7 wheel workflow builds `dartpy` for CPython 3.14 on Linux,
-macOS, and Windows. Opt into pre-releases when using PyPI so a DART 7 wheel is
-preferred over the stable DART 6 line:
-
-```bash
-pip install --pre dartpy           # pip (PyPI)
-uv add dartpy --prerelease allow    # uv (PyPI)
-```
-
-The default `pixi add dartpy` and `conda install -c conda-forge dartpy` channels
-currently track the stable **DART 6** line; use them for DART 6, or build from
-source (below) for the DART 7 examples in this guide.
-
-Verify the install by creating a tiny world in code — this does not need any
-sample data files:
-
-```python
-import dartpy as dart
-
-world = dart.World()
-world.add_rigid_body("box", dart.RigidBodyOptions())
-world.enter_simulation_mode()
-world.step()
-print(f"Stepped one frame to t = {world.time:.4f} s")
-```
-
-If that prints without error, you are ready for {doc}`hello_dart`.
 
 ## Build from source
 
@@ -62,6 +34,21 @@ Run a headless smoke check to confirm the build works:
 pixi run py-demos -- --scene rigid_body --headless --frames 1
 ```
 
+Verify the install by creating a tiny world in code — this does not need any
+sample data files:
+
+```python
+import dartpy as dart
+
+world = dart.World()
+world.add_rigid_body("box", dart.RigidBodyOptions())
+world.enter_simulation_mode()
+world.step()
+print(f"Stepped one frame to t = {world.time:.4f} s")
+```
+
+If that prints without error, you are ready for {doc}`hello_dart`.
+
 To use your source build from a plain Python interpreter, point `PYTHONPATH` at
 the built bindings (the exact path is printed at the end of `pixi run build`),
 for example:
@@ -69,6 +56,22 @@ for example:
 ```bash
 PYTHONPATH=build/default/cpp/Release/python python your_script.py
 ```
+
+## Python package status
+
+The tracked DART 7 wheel workflow builds `dartpy` for CPython 3.14 on Linux,
+macOS, and Windows. After a non-yanked DART 7 wheel is published on PyPI, opt
+into pre-release resolution so the DART 7 wheel is preferred over the stable
+DART 6 line:
+
+```bash
+pip install --pre dartpy
+uv add dartpy --prerelease allow
+```
+
+The default `pixi add dartpy` and `conda install -c conda-forge dartpy` channels
+currently track the stable **DART 6** line; use them for DART 6, or build from
+source for the DART 7 examples in this guide.
 
 For more detail on supported platforms and wheels, see the
 {doc}`Python installation reference </dartpy/user_guide/installation>`. For

--- a/docs/readthedocs/user_guide/getting_started/installation.md
+++ b/docs/readthedocs/user_guide/getting_started/installation.md
@@ -39,7 +39,7 @@ built bindings before importing `dartpy`; this does not need any sample data
 files:
 
 ```bash
-PYTHONPATH=build/default/cpp/Release/python python - <<'PY'
+PYTHONPATH=build/default/cpp/Release/python pixi run python - <<'PY'
 import dartpy as dart
 
 world = dart.World()
@@ -55,7 +55,7 @@ If that prints without error, you are ready for {doc}`hello_dart`.
 Use the same prefix for your own scripts:
 
 ```bash
-PYTHONPATH=build/default/cpp/Release/python python your_script.py
+PYTHONPATH=build/default/cpp/Release/python pixi run python your_script.py
 ```
 
 ## Python package status


### PR DESCRIPTION
## Summary

- Refreshes the DART 7 README and Read the Docs sources so published install,
  dartpy smoke-test, and example guidance match the current `package.xml`,
  wheel workflow, PyPI availability, and `dart::simulation::World` API direction.

## Motivation / Problem

- The public DART 7 docs still carried stale DART 6-era package wording,
  fallback version metadata, and legacy dartpy examples. This made the hosted
  site a weaker source of truth than the codebase it is supposed to document.
- The current public PyPI state does not provide a usable non-yanked DART 7
  `dartpy` wheel, so package-manager snippets must not imply that PyPI installs
  the DART 7 `World` facade today.

## Changes / Key Changes

- Derive RTD version metadata from `package.xml` instead of stale fallback
  release data.
- Update README and RTD install pages for the current DART 7 dartpy lane:
  source builds are the DART 7 path today, while PyPI pre-release commands are
  conditional on a future non-yanked DART 7 wheel.
- Keep default `pixi`, `conda`, and current PyPI package guidance explicitly on
  the stable DART 6 line where that is what users receive today.
- Replace legacy dartpy example text with a DART 7 `World`-based snippet and
  point DART 6 users to the stable docs for `Skeleton` / `BodyNode` workflows.
- Clarify the dartpy API reference source/shim layout.
- Add the required DART 7 changelog entry for workflow-facing docs guidance.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Version metadata | RTD fallback still referenced stale DART 6-era data. | RTD reads the version from `package.xml`. |
| dartpy install | Public docs could imply default package channels or PyPI pre-release commands were DART 7-ready. | Public docs route DART 7 users to source builds today and keep PyPI DART 7 conditional on a non-yanked wheel. |
| Examples | Main docs showed legacy `World.addSkeleton()` style guidance as primary. | Main docs lead with the DART 7 `World` API and route legacy workflows to DART 6 stable docs. |

## Testing

- `pixi run docs-build`
  - Passed. The main build still reports the existing generated-stub autodoc
    warnings for `dartpy._world_render_bridge` and the existing Doxygen
    `DOT_MULTI_TARGETS` warning.
- `pixi run lint`
- `git diff --check origin/main..HEAD`
- Official PyPI JSON check for `dartpy`: latest non-yanked version is `6.19.3`,
  and `7.0.0` currently has no non-yanked files.
- Targeted stale-string scan over `README.md` and `docs/readthedocs` for stale
  DART 7 package/version/API references.

## Breaking Changes

- [x] None
- Documentation-only update; no API or package behavior changes.

## Related Issues / PRs (backports)

- Related stable-site sync PR: #3346.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality (N/A: docs-only)
- [x] Document new methods and classes (N/A: no new API)
- [x] Add Python bindings (dartpy) if applicable (N/A)
