### PR TITLE
Centralize MSVC toolchain policy for DART 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,6 +372,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Centralized MSVC runtime, conformance, warning, and parallel-compile policy in
   CMake helpers so Windows builds use the same long-term toolchain settings
   across Pixi, CI, and source builds.
+  ([#3349](https://github.com/dartsim/dart/pull/3349))
 - Added a `DART_USE_SYSTEM_FMT` CMake option (default ON) that falls back to a
   FetchContent source build of fmt when set OFF, so source and container builds
   keep working when a distro's packaged fmt CMake config is broken; the Alt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,9 @@ compatibility remains on the active DART 6 LTS branch._
   `Composite::Properties` data by keeping zero-aspect composite-data template
   members owned by the exported `dart` instantiation.
   ([#3340](https://github.com/dartsim/dart/pull/3340))
+- Centralized MSVC runtime, conformance, warning, and parallel-compile policy in
+  CMake helpers so Windows builds use the same long-term toolchain settings
+  across Pixi, CI, and source builds.
 - Added a `DART_USE_SYSTEM_FMT` CMake option (default ON) that falls back to a
   FetchContent source build of fmt when set OFF, so source and container builds
   keep working when a distro's packaged fmt CMake config is broken; the Alt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,7 +618,9 @@ endif()
 #===============================================================================
 # Compiler flags
 #===============================================================================
-if(CMAKE_COMPILER_IS_GNUCXX)
+if(MSVC)
+  # MSVC policy is configured before dependency discovery.
+elseif(CMAKE_COMPILER_IS_GNUCXX)
   # There is a known bug in GCC 12.1 and above that leads to spurious
   # -Wmaybe-uninitialized warnings from gcc/x86_64-linux-gnu/12/include/avxintrin.h and
   # -Warray-bounds warnings from gcc/x86_64-linux-gnu/12/include/avx512fintrin.h.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,15 @@ endif()
 
 option(DART_BUILD_WHEELS "Indicate building dartpy for wheels" OFF)
 
+# Configure MSVC compile policy before dependency discovery so any dependency
+# targets created during configure inherit the same directory options.
+if(MSVC)
+  dart_configure_msvc_toolchain(
+    REQUIRED_VERSION 1950
+    REQUIRED_LABEL "Visual Studio 2026"
+  )
+endif()
+
 #===============================================================================
 # Uninstall
 #===============================================================================
@@ -609,12 +618,7 @@ endif()
 #===============================================================================
 # Compiler flags
 #===============================================================================
-if(MSVC)
-  dart_configure_msvc_toolchain(
-    REQUIRED_VERSION 1950
-    REQUIRED_LABEL "Visual Studio 2026"
-  )
-elseif(CMAKE_COMPILER_IS_GNUCXX)
+if(CMAKE_COMPILER_IS_GNUCXX)
   # There is a known bug in GCC 12.1 and above that leads to spurious
   # -Wmaybe-uninitialized warnings from gcc/x86_64-linux-gnu/12/include/avxintrin.h and
   # -Warray-bounds warnings from gcc/x86_64-linux-gnu/12/include/avx512fintrin.h.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,9 @@ endif()
 #===============================================================================
 if(MSVC)
   # MSVC policy is configured before dependency discovery.
+  if(DART_TREAT_WARNINGS_AS_ERRORS)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/WX>)
+  endif()
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   # There is a known bug in GCC 12.1 and above that leads to spurious
   # -Wmaybe-uninitialized warnings from gcc/x86_64-linux-gnu/12/include/avxintrin.h and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,45 +199,23 @@ if(MSVC)
     DART_RUNTIME_LIBRARY
     "/MD"
     CACHE STRING
-    "BaseName chosen by the user at CMake configure time"
+    "MSVC runtime family used when DART_MSVC_FORCE_RELEASE_RUNTIME is OFF"
   )
   set_property(CACHE DART_RUNTIME_LIBRARY PROPERTY STRINGS /MD /MT)
-  dart_option(DART_MSVC_DEFAULT_OPTIONS "Build DART with default Visual Studio options" OFF CATEGORY msvc)
+  dart_option(
+    DART_MSVC_DEFAULT_OPTIONS
+    "Use Visual Studio default Debug/Release tuning instead of DART's MSVC tuning"
+    OFF
+    CATEGORY msvc
+  )
 
-  # Option to force /MD (Release runtime) for all configurations including Debug.
-  # This is useful when linking against pre-built libraries (e.g., conda-forge packages)
-  # that are built with /MD to avoid LNK2038 runtime library mismatch errors.
-  # Default: ON (recommended for most users using package managers like conda/pixi)
-  # Set to OFF if you're building all dependencies from source with matching runtime libraries.
+  # Pre-built package-manager dependencies are generally built with /MD. Keep
+  # every configuration on that runtime by default to avoid LNK2038 mismatches.
   dart_option(DART_MSVC_FORCE_RELEASE_RUNTIME
     "Force /MD (Release DLL runtime) for all configurations to match pre-built packages (conda-forge, vcpkg, etc.)" ON
     CATEGORY msvc
   )
-
-  if(DART_MSVC_FORCE_RELEASE_RUNTIME)
-    # Use CMAKE_MSVC_RUNTIME_LIBRARY so all configurations match pre-built
-    # package-manager dependencies.
-    # This sets /MD for all configurations (Debug, Release, RelWithDebInfo, MinSizeRel)
-    set(
-      CMAKE_MSVC_RUNTIME_LIBRARY
-      "MultiThreadedDLL"
-      CACHE STRING
-      "MSVC runtime library - forced to /MD for all configs"
-      FORCE
-    )
-    message(
-      STATUS
-      "DART_MSVC_FORCE_RELEASE_RUNTIME=ON: Using /MD for all configurations"
-    )
-    message(
-      STATUS
-      "  This avoids LNK2038 errors when linking pre-built packages built with /MD"
-    )
-    message(
-      STATUS
-      "  Set -DDART_MSVC_FORCE_RELEASE_RUNTIME=OFF if building all deps from source"
-    )
-  endif()
+  dart_configure_msvc_runtime_library()
 else()
   dart_option(BUILD_SHARED_LIBS "Build shared libraries" ON CATEGORY build)
 endif()
@@ -632,52 +610,10 @@ endif()
 # Compiler flags
 #===============================================================================
 if(MSVC)
-  # Visual Studio 2026 required for supported Windows builds.
-  set(msvc_required_version 1950)
-  if(
-    MSVC_VERSION VERSION_LESS ${msvc_required_version}
-    AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC"
+  dart_configure_msvc_toolchain(
+    REQUIRED_VERSION 1950
+    REQUIRED_LABEL "Visual Studio 2026"
   )
-    message(
-      FATAL_ERROR
-      "MSVC ${MSVC_VERSION} is detected, but "
-      "${PROJECT_NAME_UPPERCASE} requires MSVC ${msvc_required_version} or greater (Visual Studio 2026)."
-    )
-  endif()
-
-  if(DART_TREAT_WARNINGS_AS_ERRORS)
-    add_compile_options(/WX)
-  endif()
-  # /MP - Multi-processor compilation (uses all available cores)
-  # /FS - Force synchronous PDB writes (prevents PDB conflicts in parallel builds with /MP)
-  # /utf-8 - Required by fmt's Unicode support on MSVC.
-  set(
-    CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} /EHsc /permissive- /Zc:twoPhase- /utf-8 /MP /FS"
-  )
-  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/INCREMENTAL:NO")
-  if(NOT DART_MSVC_DEFAULT_OPTIONS)
-    set(
-      CMAKE_CXX_FLAGS_DEBUG
-      "${CMAKE_CXX_FLAGS_DEBUG} ${DART_RUNTIME_LIBRARY}d /Zi /Gy /W1 /EHsc"
-    )
-    set(
-      CMAKE_CXX_FLAGS_RELEASE
-      "${CMAKE_CXX_FLAGS_RELEASE} ${DART_RUNTIME_LIBRARY} /Zi /GL /Gy /W1 /EHsc"
-    )
-  endif()
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_ENABLE_EXTENDED_ALIGNED_STORAGE)
-  add_compile_options(/wd4005)
-  add_compile_options(/wd4099)
-  add_compile_options(/wd4146) # for FCL warnings: https://github.com/dartsim/dart/runs/4568423649?check_suite_focus=true#step:5:407
-  add_compile_options(/wd4244)
-  add_compile_options(/wd4250)
-  add_compile_options(/wd4267)
-  add_compile_options(/wd4305)
-  add_compile_options(/wd4334)
-  add_compile_options(/wd4838)
-  add_compile_options(/wd4996)
-  add_compile_options(/bigobj)
 elseif(CMAKE_COMPILER_IS_GNUCXX)
   # There is a known bug in GCC 12.1 and above that leads to spurious
   # -Wmaybe-uninitialized warnings from gcc/x86_64-linux-gnu/12/include/avxintrin.h and

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -532,7 +532,10 @@ function(dart_configure_msvc_runtime_library)
       "MSVC runtime library for DART targets"
       FORCE
     )
-  elseif(DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+  elseif(
+    DEFINED CMAKE_MSVC_RUNTIME_LIBRARY
+    AND NOT _dart_msvc_runtime_cache_managed
+  )
     set(_dart_msvc_runtime_library "${CMAKE_MSVC_RUNTIME_LIBRARY}")
     set(_dart_msvc_runtime_preserved ON)
   else()

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -346,6 +346,150 @@ function(dart_print_options)
   message(STATUS "")
 endfunction()
 
+function(_dart_msvc_runtime_flag_for_config out runtime_library config)
+  string(TOUPPER "${config}" config_upper)
+
+  if(runtime_library STREQUAL "MultiThreadedDLL")
+    set(runtime_flag "/MD")
+  elseif(runtime_library STREQUAL "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    if(config_upper STREQUAL "DEBUG")
+      set(runtime_flag "/MDd")
+    else()
+      set(runtime_flag "/MD")
+    endif()
+  elseif(runtime_library STREQUAL "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    if(config_upper STREQUAL "DEBUG")
+      set(runtime_flag "/MTd")
+    else()
+      set(runtime_flag "/MT")
+    endif()
+  else()
+    message(FATAL_ERROR "Unsupported MSVC runtime library: ${runtime_library}")
+  endif()
+
+  set(${out} "${runtime_flag}" PARENT_SCOPE)
+endfunction()
+
+function(_dart_replace_msvc_runtime_flag flags_variable runtime_flag)
+  if(DEFINED ${flags_variable})
+    set(flags_value "${${flags_variable}}")
+  else()
+    set(flags_value "")
+  endif()
+
+  string(
+    REGEX REPLACE
+    "(^|[ \t\r\n])[-/]M[DT]d?([ \t\r\n]|$)"
+    " "
+    flags_value
+    "${flags_value}"
+  )
+  string(STRIP "${flags_value}" flags_value)
+
+  if(flags_value)
+    set(flags_value "${flags_value} ${runtime_flag}")
+  else()
+    set(flags_value "${runtime_flag}")
+  endif()
+
+  set(
+    ${flags_variable}
+    "${flags_value}"
+    CACHE STRING
+    "Compiler flags updated by DART MSVC runtime policy"
+    FORCE
+  )
+endfunction()
+
+function(_dart_msvc_runtime_flag_fallback_needed out)
+  set(needs_fallback OFF)
+  set(configs Debug Release RelWithDebInfo MinSizeRel)
+
+  if(CMAKE_CONFIGURATION_TYPES)
+    list(APPEND configs ${CMAKE_CONFIGURATION_TYPES})
+  endif()
+  if(CMAKE_BUILD_TYPE)
+    list(APPEND configs ${CMAKE_BUILD_TYPE})
+  endif()
+  list(REMOVE_DUPLICATES configs)
+
+  foreach(lang C CXX)
+    if(DEFINED CMAKE_${lang}_FLAGS)
+      if(
+        "${CMAKE_${lang}_FLAGS}" MATCHES "(^|[ \t\r\n])[-/]M[DT]d?([ \t\r\n]|$)"
+      )
+        set(needs_fallback ON)
+      endif()
+    endif()
+
+    foreach(config IN LISTS configs)
+      string(TOUPPER "${config}" config_upper)
+      set(flags_variable CMAKE_${lang}_FLAGS_${config_upper})
+
+      if(DEFINED ${flags_variable})
+        if(
+          "${${flags_variable}}" MATCHES "(^|[ \t\r\n])[-/]M[DT]d?([ \t\r\n]|$)"
+        )
+          set(needs_fallback ON)
+        endif()
+      endif()
+    endforeach()
+  endforeach()
+
+  if(POLICY CMP0091)
+    cmake_policy(GET CMP0091 cmp0091)
+    if(NOT cmp0091 STREQUAL "NEW")
+      set(needs_fallback ON)
+    endif()
+  endif()
+
+  set(${out} ${needs_fallback} PARENT_SCOPE)
+endfunction()
+
+function(_dart_apply_msvc_runtime_flag_fallback runtime_library)
+  set(configs Debug Release RelWithDebInfo MinSizeRel)
+
+  if(CMAKE_CONFIGURATION_TYPES)
+    list(APPEND configs ${CMAKE_CONFIGURATION_TYPES})
+  endif()
+  if(CMAKE_BUILD_TYPE)
+    list(APPEND configs ${CMAKE_BUILD_TYPE})
+  endif()
+  list(REMOVE_DUPLICATES configs)
+
+  _dart_msvc_runtime_flag_for_config(
+    default_runtime_flag
+    "${runtime_library}"
+    ""
+  )
+
+  foreach(lang C CXX)
+    if(DEFINED CMAKE_${lang}_FLAGS)
+      _dart_replace_msvc_runtime_flag(
+        CMAKE_${lang}_FLAGS
+        "${default_runtime_flag}"
+      )
+    endif()
+
+    foreach(config IN LISTS configs)
+      string(TOUPPER "${config}" config_upper)
+      set(flags_variable CMAKE_${lang}_FLAGS_${config_upper})
+
+      if(DEFINED ${flags_variable})
+        _dart_msvc_runtime_flag_for_config(
+          config_runtime_flag
+          "${runtime_library}"
+          "${config}"
+        )
+        _dart_replace_msvc_runtime_flag(
+          ${flags_variable}
+          "${config_runtime_flag}"
+        )
+      endif()
+    endforeach()
+  endforeach()
+endfunction()
+
 #-------------------------------------------------------------------------------
 # Configure MSVC runtime-library policy before any targets are created.
 #-------------------------------------------------------------------------------
@@ -377,6 +521,11 @@ function(dart_configure_msvc_runtime_library)
         "MultiThreaded$<$<CONFIG:Debug>:Debug>"
   )
 
+  _dart_msvc_runtime_flag_fallback_needed(_dart_msvc_runtime_fallback_needed)
+  if(_dart_msvc_runtime_fallback_needed)
+    _dart_apply_msvc_runtime_flag_fallback("${_dart_msvc_runtime_library}")
+  endif()
+
   if(DART_MSVC_FORCE_RELEASE_RUNTIME)
     message(
       STATUS
@@ -384,6 +533,10 @@ function(dart_configure_msvc_runtime_library)
     )
   else()
     message(STATUS "MSVC runtime library: ${CMAKE_MSVC_RUNTIME_LIBRARY}")
+  endif()
+
+  if(_dart_msvc_runtime_fallback_needed)
+    message(STATUS "Updated MSVC runtime flags for CMP0091 OLD compatibility")
   endif()
 endfunction()
 

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -351,6 +351,12 @@ function(_dart_msvc_runtime_flag_for_config out runtime_library config)
 
   if(runtime_library STREQUAL "MultiThreadedDLL")
     set(runtime_flag "/MD")
+  elseif(runtime_library STREQUAL "MultiThreadedDebugDLL")
+    set(runtime_flag "/MDd")
+  elseif(runtime_library STREQUAL "MultiThreaded")
+    set(runtime_flag "/MT")
+  elseif(runtime_library STREQUAL "MultiThreadedDebug")
+    set(runtime_flag "/MTd")
   elseif(runtime_library STREQUAL "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     if(config_upper STREQUAL "DEBUG")
       set(runtime_flag "/MDd")
@@ -370,7 +376,7 @@ function(_dart_msvc_runtime_flag_for_config out runtime_library config)
   set(${out} "${runtime_flag}" PARENT_SCOPE)
 endfunction()
 
-function(_dart_replace_msvc_runtime_flag flags_variable runtime_flag)
+macro(_dart_replace_msvc_runtime_flag flags_variable runtime_flag)
   if(DEFINED ${flags_variable})
     set(flags_value "${${flags_variable}}")
   else()
@@ -392,14 +398,9 @@ function(_dart_replace_msvc_runtime_flag flags_variable runtime_flag)
     set(flags_value "${runtime_flag}")
   endif()
 
-  set(
-    ${flags_variable}
-    "${flags_value}"
-    CACHE STRING
-    "Compiler flags updated by DART MSVC runtime policy"
-    FORCE
-  )
-endfunction()
+  set(${flags_variable} "${flags_value}")
+  set(${flags_variable} "${flags_value}" PARENT_SCOPE)
+endmacro()
 
 function(_dart_msvc_runtime_flag_fallback_needed out)
   set(needs_fallback OFF)
@@ -446,7 +447,7 @@ function(_dart_msvc_runtime_flag_fallback_needed out)
   set(${out} ${needs_fallback} PARENT_SCOPE)
 endfunction()
 
-function(_dart_apply_msvc_runtime_flag_fallback runtime_library)
+macro(_dart_apply_msvc_runtime_flag_fallback runtime_library)
   set(configs Debug Release RelWithDebInfo MinSizeRel)
 
   if(CMAKE_CONFIGURATION_TYPES)
@@ -488,7 +489,7 @@ function(_dart_apply_msvc_runtime_flag_fallback runtime_library)
       endif()
     endforeach()
   endforeach()
-endfunction()
+endmacro()
 
 #-------------------------------------------------------------------------------
 # Configure MSVC runtime-library policy before any targets are created.
@@ -498,35 +499,52 @@ function(dart_configure_msvc_runtime_library)
     return()
   endif()
 
-  if(DART_MSVC_FORCE_RELEASE_RUNTIME)
-    set(_dart_msvc_runtime_library "MultiThreadedDLL")
-  elseif(DART_RUNTIME_LIBRARY STREQUAL "/MT")
-    set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  set(_dart_msvc_runtime_preserved OFF)
+  if(
+    DEFINED CMAKE_MSVC_RUNTIME_LIBRARY
+    AND NOT CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL ""
+  )
+    set(_dart_msvc_runtime_library "${CMAKE_MSVC_RUNTIME_LIBRARY}")
+    set(_dart_msvc_runtime_preserved ON)
   else()
-    set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    if(DART_MSVC_FORCE_RELEASE_RUNTIME)
+      set(_dart_msvc_runtime_library "MultiThreadedDLL")
+    elseif(DART_RUNTIME_LIBRARY STREQUAL "/MT")
+      set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    else()
+      set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    endif()
+    set(
+      CMAKE_MSVC_RUNTIME_LIBRARY
+      "${_dart_msvc_runtime_library}"
+      CACHE STRING
+      "MSVC runtime library for DART targets"
+      FORCE
+    )
   endif()
-  set(
-    CMAKE_MSVC_RUNTIME_LIBRARY
-    "${_dart_msvc_runtime_library}"
-    CACHE STRING
-    "MSVC runtime library for DART targets"
-    FORCE
-  )
-  set_property(
-    CACHE CMAKE_MSVC_RUNTIME_LIBRARY
-    PROPERTY
-      STRINGS
-        "MultiThreadedDLL"
-        "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
-        "MultiThreaded$<$<CONFIG:Debug>:Debug>"
-  )
+
+  if(DEFINED CACHE{CMAKE_MSVC_RUNTIME_LIBRARY})
+    set_property(
+      CACHE CMAKE_MSVC_RUNTIME_LIBRARY
+      PROPERTY
+        STRINGS
+          "MultiThreadedDLL"
+          "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+          "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+    )
+  endif()
 
   _dart_msvc_runtime_flag_fallback_needed(_dart_msvc_runtime_fallback_needed)
   if(_dart_msvc_runtime_fallback_needed)
     _dart_apply_msvc_runtime_flag_fallback("${_dart_msvc_runtime_library}")
   endif()
 
-  if(DART_MSVC_FORCE_RELEASE_RUNTIME)
+  if(_dart_msvc_runtime_preserved)
+    message(
+      STATUS
+      "MSVC runtime library: ${_dart_msvc_runtime_library} (preserved from caller)"
+    )
+  elseif(DART_MSVC_FORCE_RELEASE_RUNTIME)
     message(
       STATUS
       "DART_MSVC_FORCE_RELEASE_RUNTIME=ON: using /MD for all configurations"

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -500,10 +500,7 @@ function(dart_configure_msvc_runtime_library)
   endif()
 
   set(_dart_msvc_runtime_preserved OFF)
-  if(
-    DEFINED CMAKE_MSVC_RUNTIME_LIBRARY
-    AND NOT CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL ""
-  )
+  if(DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
     set(_dart_msvc_runtime_library "${CMAKE_MSVC_RUNTIME_LIBRARY}")
     set(_dart_msvc_runtime_preserved ON)
   else()
@@ -529,21 +526,32 @@ function(dart_configure_msvc_runtime_library)
       PROPERTY
         STRINGS
           "MultiThreadedDLL"
+          ""
           "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
           "MultiThreaded$<$<CONFIG:Debug>:Debug>"
     )
   endif()
 
-  _dart_msvc_runtime_flag_fallback_needed(_dart_msvc_runtime_fallback_needed)
-  if(_dart_msvc_runtime_fallback_needed)
-    _dart_apply_msvc_runtime_flag_fallback("${_dart_msvc_runtime_library}")
+  set(_dart_msvc_runtime_fallback_needed OFF)
+  if(
+    NOT _dart_msvc_runtime_preserved
+    OR NOT _dart_msvc_runtime_library STREQUAL ""
+  )
+    _dart_msvc_runtime_flag_fallback_needed(_dart_msvc_runtime_fallback_needed)
+    if(_dart_msvc_runtime_fallback_needed)
+      _dart_apply_msvc_runtime_flag_fallback("${_dart_msvc_runtime_library}")
+    endif()
   endif()
 
   if(_dart_msvc_runtime_preserved)
-    message(
-      STATUS
-      "MSVC runtime library: ${_dart_msvc_runtime_library} (preserved from caller)"
-    )
+    if(_dart_msvc_runtime_library STREQUAL "")
+      message(STATUS "MSVC runtime library: <empty> (preserved from caller)")
+    else()
+      message(
+        STATUS
+        "MSVC runtime library: ${_dart_msvc_runtime_library} (preserved from caller)"
+      )
+    endif()
   elseif(DART_MSVC_FORCE_RELEASE_RUNTIME)
     message(
       STATUS

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -633,10 +633,6 @@ function(dart_configure_msvc_toolchain)
     )
   endif()
 
-  if(DART_TREAT_WARNINGS_AS_ERRORS)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/WX>)
-  endif()
-
   if(NOT DART_MSVC_DEFAULT_OPTIONS)
     add_compile_options(
       $<$<COMPILE_LANGUAGE:CXX>:/W1>

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -346,6 +346,124 @@ function(dart_print_options)
   message(STATUS "")
 endfunction()
 
+#-------------------------------------------------------------------------------
+# Configure MSVC runtime-library policy before any targets are created.
+#-------------------------------------------------------------------------------
+function(dart_configure_msvc_runtime_library)
+  if(NOT MSVC)
+    return()
+  endif()
+
+  if(DART_MSVC_FORCE_RELEASE_RUNTIME)
+    set(_dart_msvc_runtime_library "MultiThreadedDLL")
+  elseif(DART_RUNTIME_LIBRARY STREQUAL "/MT")
+    set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  else()
+    set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  endif()
+  set(
+    CMAKE_MSVC_RUNTIME_LIBRARY
+    "${_dart_msvc_runtime_library}"
+    CACHE STRING
+    "MSVC runtime library for DART targets"
+    FORCE
+  )
+  set_property(
+    CACHE CMAKE_MSVC_RUNTIME_LIBRARY
+    PROPERTY
+      STRINGS
+        "MultiThreadedDLL"
+        "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+        "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+  )
+
+  if(DART_MSVC_FORCE_RELEASE_RUNTIME)
+    message(
+      STATUS
+      "DART_MSVC_FORCE_RELEASE_RUNTIME=ON: using /MD for all configurations"
+    )
+  else()
+    message(STATUS "MSVC runtime library: ${CMAKE_MSVC_RUNTIME_LIBRARY}")
+  endif()
+endfunction()
+
+#-------------------------------------------------------------------------------
+# Configure MSVC-specific compiler and linker policy.
+#-------------------------------------------------------------------------------
+function(dart_configure_msvc_toolchain)
+  if(NOT MSVC)
+    return()
+  endif()
+
+  set(options)
+  set(oneValueArgs REQUIRED_VERSION REQUIRED_LABEL)
+  set(multiValueArgs)
+  cmake_parse_arguments(
+    ARG
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+
+  if(
+    ARG_REQUIRED_VERSION
+    AND MSVC_VERSION VERSION_LESS "${ARG_REQUIRED_VERSION}"
+    AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+  )
+    if(ARG_REQUIRED_LABEL)
+      set(_dart_msvc_required_label " (${ARG_REQUIRED_LABEL})")
+    else()
+      set(_dart_msvc_required_label "")
+    endif()
+    message(
+      FATAL_ERROR
+      "MSVC ${MSVC_VERSION} is detected, but ${PROJECT_NAME_UPPERCASE} "
+      "requires MSVC ${ARG_REQUIRED_VERSION} or greater"
+      "${_dart_msvc_required_label}."
+    )
+  endif()
+
+  add_compile_definitions(
+    _CRT_SECURE_NO_WARNINGS
+    _ENABLE_EXTENDED_ALIGNED_STORAGE
+  )
+
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:CXX>:/EHsc>
+    $<$<COMPILE_LANGUAGE:CXX>:/permissive->
+    $<$<COMPILE_LANGUAGE:CXX>:/Zc:twoPhase->
+    $<$<COMPILE_LANGUAGE:CXX>:/utf-8>
+    $<$<COMPILE_LANGUAGE:CXX>:/MP>
+    $<$<COMPILE_LANGUAGE:CXX>:/FS>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4005>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4099>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4146>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4244>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4250>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4267>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4305>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4334>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4838>
+    $<$<COMPILE_LANGUAGE:CXX>:/wd4996>
+    $<$<COMPILE_LANGUAGE:CXX>:/bigobj>
+  )
+
+  if(DART_TREAT_WARNINGS_AS_ERRORS)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/WX>)
+  endif()
+
+  if(NOT DART_MSVC_DEFAULT_OPTIONS)
+    add_compile_options(
+      $<$<COMPILE_LANGUAGE:CXX>:/W1>
+      $<$<COMPILE_LANGUAGE:CXX>:/Zi>
+      $<$<COMPILE_LANGUAGE:CXX>:/Gy>
+      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/GL>
+    )
+    add_link_options($<$<CONFIG:Release>:/INCREMENTAL:NO>)
+  endif()
+endfunction()
+
 function(dart_apply_strict_symbol_visibility _target_name)
   if(NOT TARGET ${_target_name})
     message(

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -434,8 +434,6 @@ function(dart_configure_msvc_toolchain)
     $<$<COMPILE_LANGUAGE:CXX>:/permissive->
     $<$<COMPILE_LANGUAGE:CXX>:/Zc:twoPhase->
     $<$<COMPILE_LANGUAGE:CXX>:/utf-8>
-    $<$<COMPILE_LANGUAGE:CXX>:/MP>
-    $<$<COMPILE_LANGUAGE:CXX>:/FS>
     $<$<COMPILE_LANGUAGE:CXX>:/wd4005>
     $<$<COMPILE_LANGUAGE:CXX>:/wd4099>
     $<$<COMPILE_LANGUAGE:CXX>:/wd4146>
@@ -448,6 +446,13 @@ function(dart_configure_msvc_toolchain)
     $<$<COMPILE_LANGUAGE:CXX>:/wd4996>
     $<$<COMPILE_LANGUAGE:CXX>:/bigobj>
   )
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    add_compile_options(
+      $<$<COMPILE_LANGUAGE:CXX>:/MP>
+      $<$<COMPILE_LANGUAGE:CXX>:/FS>
+    )
+  endif()
 
   if(DART_TREAT_WARNINGS_AS_ERRORS)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/WX>)

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -499,14 +499,44 @@ function(dart_configure_msvc_runtime_library)
     return()
   endif()
 
+  set(_dart_msvc_runtime_cache_managed OFF)
+  if(DEFINED CACHE{CMAKE_MSVC_RUNTIME_LIBRARY})
+    get_property(
+      _dart_msvc_runtime_cache_help
+      CACHE CMAKE_MSVC_RUNTIME_LIBRARY
+      PROPERTY HELPSTRING
+    )
+    if(
+      _dart_msvc_runtime_cache_help
+        STREQUAL
+        "MSVC runtime library for DART targets"
+    )
+      set(_dart_msvc_runtime_cache_managed ON)
+    endif()
+  endif()
+
   set(_dart_msvc_runtime_preserved OFF)
-  if(DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+  if(
+    DART_MSVC_FORCE_RELEASE_RUNTIME
+    AND
+      (
+        NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY
+        OR _dart_msvc_runtime_cache_managed
+      )
+  )
+    set(_dart_msvc_runtime_library "MultiThreadedDLL")
+    set(
+      CMAKE_MSVC_RUNTIME_LIBRARY
+      "${_dart_msvc_runtime_library}"
+      CACHE STRING
+      "MSVC runtime library for DART targets"
+      FORCE
+    )
+  elseif(DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
     set(_dart_msvc_runtime_library "${CMAKE_MSVC_RUNTIME_LIBRARY}")
     set(_dart_msvc_runtime_preserved ON)
   else()
-    if(DART_MSVC_FORCE_RELEASE_RUNTIME)
-      set(_dart_msvc_runtime_library "MultiThreadedDLL")
-    elseif(DART_RUNTIME_LIBRARY STREQUAL "/MT")
+    if(DART_RUNTIME_LIBRARY STREQUAL "/MT")
       set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     else()
       set(_dart_msvc_runtime_library "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -488,6 +488,9 @@ The helpers own:
 - runtime selection through `dart_configure_msvc_runtime_library()` and
   `CMAKE_MSVC_RUNTIME_LIBRARY`; this runs before dependency discovery so targets
   created during configure inherit the same runtime model
+- compile-option policy through `dart_configure_msvc_toolchain()`; this also
+  runs before dependency discovery so dependency-created targets inherit DART's
+  MSVC directory options
 - standard conformance and encoding options (`/EHsc`, `/permissive-`,
   `/Zc:twoPhase-`, `/utf-8`)
 - multi-core compilation (`/MP` plus `/FS`)

--- a/docs/onboarding/ci-cd.md
+++ b/docs/onboarding/ci-cd.md
@@ -41,10 +41,11 @@ DART uses GitHub Actions for continuous integration and deployment. The CI syste
   - Example reorganizations can conflict in `examples/CMakeLists.txt`; reconcile any new example entries and keep the category layout aligned before pushing.
   - GitHub Actions API calls can return `HTTP 406` if you omit required headers; include an explicit `Accept` header.
   - `gh api` writes to stdout and does not support `--output`; redirect to a file when you need to search logs.
-  - Windows CI and Windows wheels are pinned to `windows-2022` because the
-    repository's Windows Pixi tasks request CMake's `Visual Studio 17 2022`
-    generator. Do not move them back to `windows-latest` unless the generator
-    and MSVC compatibility assumptions are updated together.
+  - Windows CI and Windows wheels are pinned to `windows-2025-vs2026` because
+    DART's Windows floor is Visual Studio 2026 and the Pixi tasks default to
+    CMake's `Visual Studio 18 2026` generator. Do not move them back to
+    `windows-latest` unless the generator and MSVC compatibility assumptions are
+    updated together.
   - The asserts-enabled CI job uses a custom CMake configure (`CMAKE_BUILD_TYPE=None`) instead of pixi tasks; keep native-only collision toggles explicit unless the job also installs a reference-engine Pixi environment.
   - The Eigen over-alignment job forces `EIGEN_MAX_ALIGN_BYTES=64` and `EIGEN_MAX_STATIC_ALIGN_BYTES=64`; failures usually indicate allocator, placement-new, or storage code assuming a smaller Eigen alignment.
   - Deprecated headers that emit `#warning` fail under `-Werror=cpp` (e.g., use `dart/io/urdf/All.hpp` instead of deprecated `dart/io/urdf/urdf.hpp`).
@@ -476,15 +477,22 @@ issues, but still allow C/CXX launchers unless
 - The `.github/actions/configure-compiler-cache` action may disable the sccache launcher on some Linux runners (e.g., self-hosted or non-Ubuntu) and fall back to `ccache` when available (otherwise `env`) to avoid flaky `try_compile` failures.
 - In `.github/workflows/ci_macos.yml`, the "Setup sccache" step is best-effort (`continue-on-error: true`) so transient download timeouts don't fail the job.
 
-## MSVC Multi-Core Compilation
+## MSVC Toolchain Policy
 
-**Critical configuration** (`CMakeLists.txt` line 282-284):
+MSVC settings are centralized in `cmake/dart_defs.cmake` and invoked from the
+root `CMakeLists.txt`. Keep new Windows compiler policy in those helpers
+instead of appending to `CMAKE_CXX_FLAGS`.
 
-```cmake
-# /MP - Multi-processor compilation (uses all available cores)
-# /FS - Force synchronous PDB writes (prevents PDB conflicts in parallel builds with /MP)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /permissive- /Zc:twoPhase- /MP /FS")
-```
+The helpers own:
+
+- runtime selection through `dart_configure_msvc_runtime_library()` and
+  `CMAKE_MSVC_RUNTIME_LIBRARY`; this runs before dependency discovery so targets
+  created during configure inherit the same runtime model
+- standard conformance and encoding options (`/EHsc`, `/permissive-`,
+  `/Zc:twoPhase-`, `/utf-8`)
+- multi-core compilation (`/MP` plus `/FS`)
+- DART's documented warning suppressions and warnings-as-errors wiring
+- Release/Debug tuning when `DART_MSVC_DEFAULT_OPTIONS=OFF`
 
 **Two levels of parallelization:**
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -2548,9 +2548,9 @@ libcxx = ">=22.1.7,<23"
 # System imgui that requires Vulkan will automatically fallback to fetching imgui from GitHub
 
 [target.win-64.tasks]
-# Note: DART_MSVC_FORCE_RELEASE_RUNTIME defaults to ON, which forces /MD for all
-# configurations (including Debug) to match conda-forge packages and avoid LNK2038
-# runtime library mismatch errors. Set to OFF if building all deps from source.
+# DART_MSVC_FORCE_RELEASE_RUNTIME defaults to ON, which forces /MD for every
+# configuration to match conda-forge packages and avoid LNK2038 mismatches.
+# Set it to OFF when building all dependencies from source with matching runtimes.
 config = { cmd = [
   "bash",
   "-lc",
@@ -2570,7 +2570,6 @@ DART_WINDOWS_CMAKE_GENERATOR=${DART_WINDOWS_CMAKE_GENERATOR:-Visual Studio 18 20
         -DDART_BUILD_PROFILE={{ build_profile }} \
         -DDART_PROFILE_BUILTIN={{ profile_builtin }} \
         -DDART_PROFILE_TRACY={{ profile_tracy }} \
-        -DDART_MSVC_DEFAULT_OPTIONS=ON \
         -DDART_MSVC_FORCE_RELEASE_RUNTIME=ON \
         -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
         -DDART_USE_SYSTEM_GOOGLETEST=ON \
@@ -2720,7 +2719,6 @@ DART_WINDOWS_CMAKE_GENERATOR=${DART_WINDOWS_CMAKE_GENERATOR:-Visual Studio 18 20
         -DDART_BUILD_PROFILE={{ build_profile }} \
         -DDART_PROFILE_BUILTIN={{ profile_builtin }} \
         -DDART_PROFILE_TRACY={{ profile_tracy }} \
-        -DDART_MSVC_DEFAULT_OPTIONS=ON \
         -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
         -DDART_USE_SYSTEM_GOOGLETEST=ON \
         -DDART_USE_SYSTEM_IMGUI=ON \
@@ -2888,7 +2886,6 @@ DART_WINDOWS_CMAKE_GENERATOR=${DART_WINDOWS_CMAKE_GENERATOR:-Visual Studio 18 20
         -DDART_BUILD_COLLISION_REFERENCE_TESTS=${DART_BUILD_COLLISION_REFERENCE_TESTS_OVERRIDE:-OFF} \
         -DDART_BUILD_COLLISION_REFERENCE_BENCHMARKS=${DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_OVERRIDE:-OFF} \
         -DDART_BUILD_PROFILE=OFF \
-        -DDART_MSVC_DEFAULT_OPTIONS=ON \
         -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
         -DDART_USE_SYSTEM_GOOGLETEST=ON \
         -DDART_USE_SYSTEM_IMGUI=ON \


### PR DESCRIPTION
## Summary

- Centralizes DART 7 MSVC runtime, conformance, warning, and parallel-compile policy in reusable CMake helpers so Pixi, CI, and source builds share the same long-term Windows defaults.

## Motivation / Problem

- DART 7's Windows toolchain policy should live in a durable CMake owner instead of being split between root `CMakeLists.txt`, Pixi task overrides, and CI documentation. The prior shape made the `/MD` package-manager runtime policy and MSVC tuning easier to bypass or drift.

## Changes / Key Changes

- Add `dart_configure_msvc_runtime_library()` and `dart_configure_msvc_toolchain()` in `cmake/dart_defs.cmake`.
- Select `CMAKE_MSVC_RUNTIME_LIBRARY` early, defaulting `DART_MSVC_FORCE_RELEASE_RUNTIME=ON` so all configurations use `/MD` with pre-built package dependencies.
- Move MSVC conformance, encoding, warning suppression, `/MP` plus `/FS`, and Release/Debug tuning out of ad hoc `CMAKE_CXX_FLAGS` appends.
- Remove Windows Pixi `DART_MSVC_DEFAULT_OPTIONS=ON` bypasses while preserving the DART 7 Visual Studio 2026/MSVC 1950 floor.
- Update Windows CI documentation to point at the new helper-owned policy and the VS2026 runner/generator expectation.
- Update `CHANGELOG.md` for the DART 7.0 release notes.

## Before / After

| Surface | Before | After |
| --- | --- | --- |
| MSVC runtime | Runtime flags were assembled from branch-local options and Pixi overrides. | `CMAKE_MSVC_RUNTIME_LIBRARY` owns the runtime policy before targets are created. |
| Windows Pixi builds | Pixi passed `DART_MSVC_DEFAULT_OPTIONS=ON`, bypassing DART's tuning. | Pixi uses the centralized defaults and keeps `/MD` explicit for package-manager compatibility. |
| Compiler policy | MSVC flags were appended directly to `CMAKE_CXX_FLAGS`. | MSVC settings live in one helper used by the root project. |
| Contributor docs | CI docs still described the older inline MSVC flag block. | CI docs name `cmake/dart_defs.cmake` as the MSVC policy owner. |

## Testing

- `pixi run config OFF`
- `pixi run lint`
- `pixi run build`
- `pixi run test-unit` — 168/168 tests passed
- `git diff --check`
- Stale-pattern scan for old Windows MSVC bypasses and flag-string snippets
- Review-fix follow-up: `pixi run lint`, `pixi run build`
- CI-fix follow-up: `pixi run lint`, `pixi run build`
- CMP0091 fallback follow-up: CMake helper script check, `pixi run lint`, `pixi run build`
- Runtime preservation follow-up: CMake helper script checks, `pixi run lint`, `pixi run build`
- Empty-runtime follow-up: CMake helper script check, `pixi run lint`, `pixi run build`
- Warnings-as-errors scoping follow-up: `pixi run lint`, `pixi run build`
- MSVC runtime cache-precedence follow-up: CMake helper script checks, `pixi run lint`, `pixi run build`
- Managed runtime cache recompute follow-up on current head: CMake helper script checks, `pixi run lint`, `pixi run build`

## Breaking Changes

- [x] None
- Existing user-facing CMake options are preserved; `DART_MSVC_FORCE_RELEASE_RUNTIME` remains opt-out for fully source-built dependency stacks.

## Related Issues / PRs (backports)

- DART 6 LTS companion: #3348

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality — N/A, build-system policy covered by configure/build/test validation
- [x] Document new methods and classes — N/A, no public API methods/classes added
- [x] Add Python bindings (dartpy) if applicable — N/A