### PR TITLE
Add native mixed-scene parity coverage

### DIFF
--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271) + phase 1 (#3281) merged; phase 2 in progress: P1-P7 merged through mesh (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325); P8/P9 active on `feature/native-distance-plane` |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271) + phase 1 (#3281) merged; phase 2 in progress: P1-P9 merged through distance/plane (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343); P10 active on `feature/native-mixed-scene-parity` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -88,6 +88,8 @@
   2026-07-07).
 - **#3324** phase-2 P6 cylinder collision pairs (merged 2026-07-07).
 - **#3325** phase-2 P7 mesh collision pairs (merged 2026-07-08).
+- **#3343** phase-2 P8/P9 distance module and plane primitive/convex coverage
+  (merged 2026-07-08).
 - **#3283** main-branch dual for the native sphere-sphere binary-check fix
   (merged 2026-07-07).
 
@@ -104,11 +106,11 @@
 
 ### 🔄 Open — monitoring (checked 2026-07-08)
 
-- **P8/P9** `feature/native-distance-plane` — active local slice for the
-  distance module and plane primitive/convex coverage. Keep it one PR to reduce
-  CI overhead.
-- **#3341** is the only current open `release-6.20` PR seen during this refresh;
-  it belongs to the separate performance-generalization lane, not this native
+- **P10** `feature/native-mixed-scene-parity` — active local slice for
+  mixed-scene fcl/dart/native parity coverage. Keep it one PR to reduce CI
+  overhead.
+- **#3348** is the only current open `release-6.20` PR seen during this refresh;
+  it belongs to the separate MSVC/toolchain policy lane, not this native
   collision port lane.
 - The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
   #3324, and #3325 are merged. The perf lane's WP-PG.01 baseline packet
@@ -125,8 +127,8 @@ before treating it as an open/active PR.)_
 
 ### 🛠️ Native-collision-port lane (the largest dependency lever — FCL/Bullet/ODE)
 - **Current state:** DART 6.20 now contains #3281's internal native math core,
-  phase-2 P1-P7, the DART 6 adapter, and the opt-in `"native"` factory key,
-  but it has no FCL-optional default.
+  phase-2 P1-P9, the DART 6 adapter, and the opt-in `"native"` factory key, but
+  it has no FCL-optional default.
   `release-6.20` still uses FCL as the default detector — created in *both*
   `ConstraintSolver` constructors.
 - **Phase 0 (captured 2026-07-04, recaptured 2026-07-05):** all
@@ -139,12 +141,11 @@ before treating it as an open/active PR.)_
   sequencing. For the phase-6 tolerance gate, retrieve JSONL dumps matching
   the recorded SHA-256 digests or recapture dumps on the flip PR's parent
   and compare within that same recapture.
-- **Phase 2 status:** P1-P7 are merged: broadphase, dispatcher, adapter bridge,
-  `"native"` registration, sphere/box/capsule/convex/cylinder/mesh coverage, and
-  associated parity tests. **Current slice is P8/P9:** distance module +
-  plane-sphere/box/capsule/convex routes, kept consolidated to avoid another CI
-  wave. P10 remains optional mixed-scene fcl/dart/native parity coverage after
-  P9.
+- **Phase 2 status:** P1-P9 are merged: broadphase, dispatcher, adapter bridge,
+  `"native"` registration, sphere/box/capsule/convex/cylinder/mesh/plane
+  coverage, distance helpers, and associated parity/performance tests. **Current
+  slice is P10:** mixed-scene fcl/dart/native parity coverage, kept as one small
+  PR to avoid another large CI wave.
 - **Default flip:** still late-phase only. Do not flip defaults until `03`'s full
   A/B packet and gz gate pass.
 - _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
@@ -156,7 +157,7 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `44645974b3570b35db11c6c251117cc4d8dea624`; `origin/main` =
+     `c1deaca67b8c0ea5ba2a182608e6407e84d58c31`; `origin/main` =
      `a1128c429223622790bf128c4a57f1e5d2c40b9b`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
@@ -195,9 +196,9 @@ before treating it as an open/active PR.)_
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
 - **Open queue (2026-07-08):** no open native-collision release PRs remain after
-  #3325. P8/P9 is active locally on `feature/native-distance-plane`; the former
-  #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319/#3321/#3322/#3324/#3325
-  lane milestones and main-branch dual #3283 are merged.
+  #3343. P10 is active locally on `feature/native-mixed-scene-parity`; the former
+  #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319/#3321/#3322/#3324/#3325/#3343
+  lane milestones, and main-branch dual #3283 are merged.
 - **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE
   optional and eventually drops `fcl` from core. The DART 7 native engine is
   only partially ported to DART 6.20; default-flip is still a late-phase

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -25,7 +25,7 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 | --- | --- | --- |
 | 0 | Baseline evidence packet (incumbent A/B envelope + default-flip verdict) | ✅ merged (#3271) |
 | 1 | Native math core (aabb/gjk/mpr/box_box/sphere_sphere/shapes/span shim) internal-only | ✅ merged (#3281) |
-| 2 | DART 6 detector adapter over the native core (bridge, sliced P1–P9) | 🔄 **in progress** — see §4 |
+| 2 | DART 6 detector adapter over the native core (bridge, sliced P1–P9 + P10 coverage) | 🔄 **in progress** — see §4 |
 | 3 | Capability parity (distance→FCL, raycast→Bullet, CCD, manifolds, voxel) | ⬜ not started |
 | 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | ⬜ not started |
 | 5 | Bullet/ODE/FCL facade decision (must keep gz subclassing) | ⬜ not started |
@@ -54,8 +54,10 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 - **#3322** phase-2 **P5**: convex foundation and capsule-capsule.
 - **#3324** phase-2 **P6**: cylinder collision pairs.
 - **#3325** phase-2 **P7**: mesh collision pairs.
+- **#3343** phase-2 **P8/P9**: distance module and plane primitive/convex
+  coverage.
 
-`origin/release-6.20` tip at this refresh: `44645974b35` (moves as the
+`origin/release-6.20` tip at this refresh: `c1deaca67b8` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
 ## 4. Phase 2 — the active work (plan: `07`, PR slices P1–P9 + P10)
@@ -75,27 +77,24 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **P5** | `convex_convex` (keystone) + `capsule_capsule` (first span pair) | ✅ **merged (#3322)** |
 | **P6** | `cylinder_collision` (needs convex_convex) | ✅ **merged (#3324)** |
 | **P7** | `mesh_mesh` (needs convex_convex; largest file) | ✅ **merged (#3325)** |
-| **P8** | `distance` module (engine-only; needs span shim) | 🔄 active on `feature/native-distance-plane`, combined with P9 |
-| **P9** | `plane_sphere` (needs `distance`) → completes primitive+convex+mesh+plane | 🔄 active on `feature/native-distance-plane`, combined with P8 |
-| **P10** | (optional) mixed-scene fcl/dart/native parity integration test | after P9 |
+| **P8** | `distance` module (engine-only; needs span shim) | ✅ **merged (#3343)**, combined with P9 |
+| **P9** | `plane_sphere` (needs `distance`) → completes primitive+convex+mesh+plane | ✅ **merged (#3343)**, combined with P8 |
+| **P10** | mixed-scene fcl/dart/native parity integration test | 🔄 active on `feature/native-mixed-scene-parity` |
 
-### Exact next step: execute P8/P9
+### Exact next step: execute P10
 
-1. Continue with the consolidated **P8/P9** branch
-   `feature/native-distance-plane`, based on the current
-   `origin/release-6.20`.
-2. Keep it as one PR to avoid another CI wave: port `distance.{hpp,cpp}`,
-   `plane_sphere.{hpp,cpp}`, dispatcher plane routes, and focused distance /
-   plane-pair tests. `NativeCollisionDetector::distance()` remains stubbed in
-   phase 2; this slice only provides the engine distance helpers needed by the
-   plane pair implementation.
-3. Include performance evidence for the newly routed plane rows. Baseline
-   `origin/release-6.20` plus benchmark rows should report unsupported; PR head
-   should report median CPU time, CV, and contacts/iter for
-   `BM_NativePlane{Sphere,Box,Capsule,Convex}`.
-4. After P8/P9 merges, phase 2 is functionally complete except for optional
-   **P10** mixed-scene fcl/dart/native parity coverage.
-5. Gates for **every** phase-2 PR (see `07` §3 — note the corrected commands):
+1. Continue with the **P10** branch `feature/native-mixed-scene-parity`, based
+   on the current `origin/release-6.20`.
+2. Keep it as one small PR to avoid unnecessary CI overhead: add a native adapter
+   boundary test that runs one deterministic mixed primitive scene through
+   `fcl`, legacy `dart`, and `native`, then compares the unordered colliding
+   frame-pair set. FCL does not support DART 6 `CapsuleShape`, so the
+   three-detector scene is limited to the common primitive subset; capsule
+   coverage remains in the focused native/DART pair tests.
+3. After P10 merges, phase 2 is functionally complete and the next executable
+   lane is **phase 3** capability parity (distance detector wiring, raycast,
+   CCD, manifolds, voxel/octree replacement).
+4. Gates for **every** phase-2 PR (see `07` §3 — note the corrected commands):
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
    UNIT_collision_native --output-on-failure` (`pixi run test-all` only *builds*);
@@ -106,13 +105,14 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 
 ## 5. Open PRs / loose ends
 
-- **P8/P9 distance + plane work** — active on `feature/native-distance-plane`
-  as one PR-sized slice to minimize CI overhead.
+- **P10 mixed-scene detector parity** — active on
+  `feature/native-mixed-scene-parity` as one small PR-sized slice to minimize CI
+  overhead.
 - **#3283 (main sphere-sphere `enableContact` fix)** — MERGED; main and
   `release-6.20` now agree on the squared binary predicate for the eventual
   phase-6 diff.
-- **#3341** is the only current open `release-6.20` PR seen during this
-  refresh, and it belongs to the separate performance-generalization lane.
+- **#3348** is the only current open `release-6.20` PR seen during this refresh,
+  and it belongs to the separate MSVC/toolchain policy lane.
 
 ## 6. Load-bearing invariants (do not violate)
 

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -20,12 +20,12 @@ Evidence was first collected on 2026-06-19 after fetching `origin/main`,
 `origin/release-6.20`, and `origin/release-6.19`. The native-collision port
 evidence in `03-native-collision-port-scoping.md` and the dashboard state in
 `04-orchestration-dashboard.md` were refreshed on 2026-07-08 after fetching
-`origin/main` and `origin/release-6.20`, and after phase-2 P7 merged.
+`origin/main` and `origin/release-6.20`, and after phase-2 P8/P9 merged.
 
 ## Current Branch State
 
 - `origin/release-6.20` currently points at
-  `44645974b3570b35db11c6c251117cc4d8dea624`.
+  `c1deaca67b8c0ea5ba2a182608e6407e84d58c31`.
 - `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x
   package version (`6.19.3` in the current CMake configure output).
 - DART 6.20 intentionally uses the release lane while package version metadata

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -47,7 +47,7 @@ contract to the ported `dart::collision::native` engine (BruteForce
 broadphase → narrowphase dispatcher → DART 6 `Contact`), **bypassing the
 EnTT world layer** by reusing DART 6's existing `shared_ptr`-based object
 manager. FCL stays default; no new dependency; C++17. The plan slices
-phase 2 into PRs **P1–P9** (+ optional P10), each gz-gated and
+phase 2 into PRs **P1–P9** (+ P10 coverage), each gz-gated and
 scope-diff-guarded.
 
 - **P1** (BroadPhase base + BruteForce): **#3303** — **merged**.
@@ -62,16 +62,19 @@ scope-diff-guarded.
 - **P5** (convex foundation + capsule-capsule): **#3322** — **merged**.
 - **P6** (cylinder collision pairs): **#3324** — **merged**.
 - **P7** (mesh collision pairs): **#3325** — **merged**.
+- **P8/P9** (distance module + plane primitive/convex coverage): **#3343** —
+  **merged**.
 
-**Next: P8/P9 — distance module + plane primitive/convex coverage** on
-`feature/native-distance-plane`. Keep this as one PR to minimize CI overhead:
-add `distance.{hpp,cpp}`, `plane_sphere.{hpp,cpp}`, dispatcher plane routes,
-focused distance/plane tests, and native plane benchmark rows. **Do not** add a
+**Next: P10 — mixed-scene detector parity coverage** on
+`feature/native-mixed-scene-parity`. Keep this as one small test/docs PR: add a
+native adapter boundary test that runs one deterministic mixed primitive scene
+through FCL, the legacy DART detector, and the new native detector, then compares
+the unordered colliding frame-pair set. **Do not** add a
 `CollisionDetectorType::Native` enum or touch `World`/`ConstraintSolver`/
 `WorldConfig`; FCL remains the default until phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
-PRs, worktrees, gotchas, and exact P8/P9 next steps).
+PRs, worktrees, gotchas, and exact P10 next steps).
 
 ## Standing constraints
 

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -32,6 +32,8 @@
 
 #include <dart/collision/CollisionFilter.hpp>
 #include <dart/collision/CollisionResult.hpp>
+#include <dart/collision/dart/DARTCollisionDetector.hpp>
+#include <dart/collision/fcl/FCLCollisionDetector.hpp>
 #include <dart/collision/native/NativeCollisionDetector.hpp>
 #include <dart/collision/native/NativeCollisionGroup.hpp>
 #include <dart/collision/native/NativeCollisionObject.hpp>
@@ -54,7 +56,9 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <memory>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -184,6 +188,162 @@ std::shared_ptr<math::TriMesh<double>> makePlaneTriMesh()
   mesh->addTriangle(0, 1, 2);
   mesh->addTriangle(0, 2, 3);
   return mesh;
+}
+
+//==============================================================================
+using ShapeFramePair
+    = std::pair<const dynamics::ShapeFrame*, const dynamics::ShapeFrame*>;
+
+struct ShapeFramePairLess
+{
+  bool operator()(const ShapeFramePair& lhs, const ShapeFramePair& rhs) const
+  {
+    const std::less<const dynamics::ShapeFrame*> isLess;
+    if (isLess(lhs.first, rhs.first))
+      return true;
+    if (isLess(rhs.first, lhs.first))
+      return false;
+    return isLess(lhs.second, rhs.second);
+  }
+};
+
+using ShapeFramePairSet = std::set<ShapeFramePair, ShapeFramePairLess>;
+
+//==============================================================================
+ShapeFramePair makeShapeFramePair(
+    const dynamics::ShapeFrame* frame1, const dynamics::ShapeFrame* frame2)
+{
+  const std::less<const dynamics::ShapeFrame*> isLess;
+  return isLess(frame1, frame2) ? ShapeFramePair{frame1, frame2}
+                                : ShapeFramePair{frame2, frame1};
+}
+
+//==============================================================================
+ShapeFramePairSet collectShapeFramePairs(
+    const collision::CollisionResult& result)
+{
+  ShapeFramePairSet pairs;
+  for (const auto& contact : result.getContacts()) {
+    EXPECT_NE(nullptr, contact.collisionObject1);
+    EXPECT_NE(nullptr, contact.collisionObject2);
+    if (!contact.collisionObject1 || !contact.collisionObject2)
+      continue;
+
+    pairs.insert(makeShapeFramePair(
+        contact.collisionObject1->getShapeFrame(),
+        contact.collisionObject2->getShapeFrame()));
+  }
+
+  return pairs;
+}
+
+//==============================================================================
+ShapeFramePairSet collideShapeFrames(
+    const collision::CollisionDetectorPtr& detector,
+    const std::vector<dynamics::SimpleFramePtr>& frames)
+{
+  auto group = detector->createCollisionGroup();
+  for (const auto& frame : frames)
+    group->addShapeFrame(frame.get());
+
+  collision::CollisionOption option(true, 256u);
+  option.maxNumContactsPerPair = 8u;
+
+  collision::CollisionResult result;
+  EXPECT_TRUE(group->collide(option, &result)) << detector->getType();
+  return collectShapeFramePairs(result);
+}
+
+//==============================================================================
+struct MixedPrimitiveScene
+{
+  std::vector<dynamics::SimpleFramePtr> frames;
+  ShapeFramePairSet expectedPairs;
+};
+
+//==============================================================================
+MixedPrimitiveScene makeMixedPrimitiveScene()
+{
+  MixedPrimitiveScene scene;
+
+  // DART 6 FCL does not support CapsuleShape, so this scene covers the
+  // primitive subset shared by FCL, the legacy DART detector, and native.
+  auto addFrame = [&](const dynamics::ShapePtr& shape,
+                      const Eigen::Vector3d& translation) {
+    auto frame = makeFrame(shape, translation);
+    scene.frames.push_back(frame);
+    return frame;
+  };
+
+  auto plane = addFrame(
+      std::make_shared<dynamics::PlaneShape>(Eigen::Vector3d::UnitZ(), 0.0),
+      Eigen::Vector3d::Zero());
+
+  auto planeSphere = addFrame(
+      std::make_shared<dynamics::SphereShape>(0.25),
+      Eigen::Vector3d(0.0, 0.0, 0.18));
+  auto planeBox = addFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Constant(0.4)),
+      Eigen::Vector3d(1.2, 0.0, 0.15));
+  auto planeCylinder = addFrame(
+      std::make_shared<dynamics::CylinderShape>(0.2, 0.5),
+      Eigen::Vector3d(2.4, 0.0, 0.20));
+
+  auto sphere1 = addFrame(
+      std::make_shared<dynamics::SphereShape>(0.25),
+      Eigen::Vector3d(0.0, 2.0, 1.0));
+  auto sphere2 = addFrame(
+      std::make_shared<dynamics::SphereShape>(0.25),
+      Eigen::Vector3d(0.4, 2.0, 1.0));
+
+  auto box1 = addFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Constant(0.4)),
+      Eigen::Vector3d(1.4, 2.0, 1.0));
+  auto box2 = addFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Constant(0.4)),
+      Eigen::Vector3d(1.75, 2.0, 1.0));
+
+  auto sphereBoxSphere = addFrame(
+      std::make_shared<dynamics::SphereShape>(0.25),
+      Eigen::Vector3d(2.8, 2.0, 1.0));
+  auto sphereBoxBox = addFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Constant(0.4)),
+      Eigen::Vector3d(3.15, 2.0, 1.0));
+
+  auto cylinderSphereCylinder = addFrame(
+      std::make_shared<dynamics::CylinderShape>(0.25, 0.5),
+      Eigen::Vector3d(4.2, 2.0, 1.0));
+  auto cylinderSphereSphere = addFrame(
+      std::make_shared<dynamics::SphereShape>(0.2),
+      Eigen::Vector3d(4.55, 2.0, 1.0));
+
+  auto cylinderBoxCylinder = addFrame(
+      std::make_shared<dynamics::CylinderShape>(0.25, 0.5),
+      Eigen::Vector3d(5.6, 2.0, 1.0));
+  auto cylinderBoxBox = addFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Constant(0.4)),
+      Eigen::Vector3d(5.95, 2.0, 1.0));
+
+  auto cylinder1 = addFrame(
+      std::make_shared<dynamics::CylinderShape>(0.25, 0.5),
+      Eigen::Vector3d(7.0, 2.0, 1.0));
+  auto cylinder2 = addFrame(
+      std::make_shared<dynamics::CylinderShape>(0.25, 0.5),
+      Eigen::Vector3d(7.4, 2.0, 1.0));
+
+  scene.expectedPairs
+      = {makeShapeFramePair(plane.get(), planeSphere.get()),
+         makeShapeFramePair(plane.get(), planeBox.get()),
+         makeShapeFramePair(plane.get(), planeCylinder.get()),
+         makeShapeFramePair(sphere1.get(), sphere2.get()),
+         makeShapeFramePair(box1.get(), box2.get()),
+         makeShapeFramePair(sphereBoxSphere.get(), sphereBoxBox.get()),
+         makeShapeFramePair(
+             cylinderSphereCylinder.get(), cylinderSphereSphere.get()),
+         makeShapeFramePair(cylinderBoxCylinder.get(), cylinderBoxBox.get()),
+         makeShapeFramePair(cylinder1.get(), cylinder2.get())};
+
+  return scene;
 }
 
 } // namespace
@@ -537,6 +697,27 @@ TEST(NativeCollisionDetector, CollidesSphereConvexMesh)
   const auto& contact = result.getContact(0);
   EXPECT_EQ(convexFrame.get(), contact.getShapeFrame1());
   EXPECT_EQ(sphereFrame.get(), contact.getShapeFrame2());
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, MixedPrimitiveSceneMatchesFclAndDart)
+{
+  const auto scene = makeMixedPrimitiveScene();
+
+  auto fclDetector = collision::FCLCollisionDetector::create();
+  fclDetector->setPrimitiveShapeType(collision::FCLCollisionDetector::MESH);
+  fclDetector->setContactPointComputationMethod(
+      collision::FCLCollisionDetector::DART);
+  auto dartDetector = collision::DARTCollisionDetector::create();
+  auto nativeDetector = collision::NativeCollisionDetector::create();
+
+  const auto fclPairs = collideShapeFrames(fclDetector, scene.frames);
+  const auto dartPairs = collideShapeFrames(dartDetector, scene.frames);
+  const auto nativePairs = collideShapeFrames(nativeDetector, scene.frames);
+
+  EXPECT_EQ(scene.expectedPairs, fclPairs);
+  EXPECT_EQ(scene.expectedPairs, dartPairs);
+  EXPECT_EQ(fclPairs, nativePairs);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Add phase-2 P10 mixed-scene adapter coverage for the native collision detector.
- Refresh the dependency-minimization handoff, resume note, and dashboard after #3343 merged.

## Motivation / Problem

- The native collision port has focused pair coverage for the ported primitive rows, but it lacked one adapter-boundary test proving a mixed scene produces the same colliding frame-pair set through FCL, the legacy DART detector, and the new native detector.
- This keeps phase 2 covered without changing the default collision detector; FCL remains the default until the later default-flip phase.

## Changes / Key Changes

- Add `NativeCollisionDetector.MixedPrimitiveSceneMatchesFclAndDart`, which builds one deterministic plane/sphere/box/cylinder scene and compares unordered colliding `ShapeFrame` pairs across FCL, DART, and native detectors.
- Limit the three-detector scene to the primitive subset shared by all three DART 6 detector paths. DART 6 FCL does not support `CapsuleShape`, so capsule coverage remains in the focused native/DART pair tests instead of this FCL parity scene.
- Update `docs/dev_tasks/dart6_dependency_minimization/` status surfaces to mark #3343 merged and P10 active.
- Leave `World`, `ConstraintSolver`, `WorldConfig`, detector defaults, and production native detector code untouched.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Phase 2 coverage | Focused pair tests covered the ported rows, but no mixed-scene detector-boundary parity test existed. | One deterministic mixed primitive scene checks FCL, DART, and native colliding frame-pair parity. |
| Runtime behavior | FCL remained the default detector. | Unchanged. This is test/docs-only. |
| Performance evidence | Prior performance PRs carried benchmark comparisons for production detector routes. | N/A here: no production runtime path changes or new benchmarkable detector route. |

## Testing

- `pixi run build`
- `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native --output-on-failure` (19/19 native collision tests passed)
- `pixi run cmake --build build/default/cpp/Release --target UNIT_collision_native_detector_adapter --parallel 8`
- `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native_detector_adapter --output-on-failure`
- `BUILD_TYPE=Debug pixi run cmake --build build/default/cpp/Debug --target UNIT_collision_native_detector_adapter --parallel 8`
- `ctest --test-dir build/default/cpp/Debug -R UNIT_collision_native_detector_adapter --output-on-failure`
- `pixi run lint`
- `pixi run check-lint`
- pre-commit hook: `pixi run check-lint-quick`
- `git diff --check`
- `rg -n "entt|EnTT|#include <span>|std::span" tests/unit/collision/test_NativeCollisionDetector.cpp dart/collision/native` (no matches)
- `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz`
  - gz-physics: 199/199 tests passed, plus 4/4 performance/symbol tests passed
  - gz-sim: `INTEGRATION_entity_system` passed against the source-built DART plugin
- Full phase-0 performance/guard matrix not rerun: this PR does not change production detector behavior or the default FCL path.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows #3343.
- Part of the DART 6.20 native collision port / dependency-minimization lane.

---

#### Checklist

- [x] Milestone set (`DART 6.20.0`)
- [x] CHANGELOG.md updated if required (N/A: test/docs-only, no public behavior or dependency change)
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: no new public methods/classes)
- [x] Add Python bindings (dartpy) if applicable (N/A)
