### PR TITLE
Suppress unsupported MSVC dllexport inline flag

### DIFF
--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -1795,10 +1795,9 @@ macro(dart_add_library _name)
     PUBLIC DART_BUILD_SHARED=${_dart_target_build_shared}
     PRIVATE DART_BUILDING_${_dart_export_macro}
   )
-  if(MSVC AND BUILD_SHARED_LIBS)
-    # Keep inline members of exported classes header-owned on MSVC. Otherwise
-    # component DLLs that include exported DART core templates can collide with
-    # the same inline symbols from dart.lib.
+  if(MSVC AND BUILD_SHARED_LIBS AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Keep inline members of exported classes header-owned for clang-cl builds.
+    # Microsoft cl.exe does not recognize this clang-cl option and emits D9002.
     target_compile_options(${_name} PRIVATE /Zc:dllexportInlines-)
   endif()
   unset(_dart_target_build_shared)


### PR DESCRIPTION
## Summary

- Stops passing clang-cl's `/Zc:dllexportInlines-` option to Microsoft `cl.exe` builds.

## Motivation / Problem

- Follow-up to #3349: Windows Release CI passed, but the build log showed repeated `cl : command line warning D9002: ignoring unknown option '/Zc:dllexportInlines-'` diagnostics from the centralized MSVC policy.

## Changes / Key Changes

- Keep the `dllexportInlines` suppression for clang-cl/MSVC-ABI shared-library builds.
- Skip the unsupported flag for Microsoft `cl.exe`, matching the compiler that emitted D9002 in #3349 CI.

## Testing

- `pixi run lint`
- `pixi run build`
- `git diff --check`
- Inspected #3349 Windows Release log for D9002 diagnostics in job `85923843957`.

## Breaking Changes

- [x] None
- No API, ABI, or source behavior change is intended for Microsoft `cl.exe`; the option was already ignored there.

## Related Issues / PRs (backports)

- Follow-up to #3349
- DART 6 backport: N/A unless release-6.20 Windows CI exposes the same warning path; #3348 does not currently contain this flag.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required — N/A, warning-only follow-up to #3349 with no public API or behavior change
- [x] Add unit tests for new functionality — N/A, CMake compiler-option scoping only
- [x] Document new methods and classes — N/A
- [x] Add Python bindings (dartpy) if applicable — N/A
