### PR TITLE
Add native raycast adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,12 @@
     rows comparing native and FCL distance queries:
     [#3056](https://github.com/dartsim/dart/issues/3056)
 
+  * Add opt-in DART-native `CollisionDetector::raycast()` support for the
+    native detector's supported primitive, plane, convex-backed, and mesh shape
+    rows, preserving DART 6 closest-hit, all-hits, sorting, and filter behavior
+    while adding benchmark rows comparing native and Bullet raycast queries:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
   * Fix FCL primitive contact normal orientation and switch default FCL primitive
     handling to `PRIMITIVE` for `FCLCollisionDetector`, the default constraint
     solver, and SKEL parser fallback paths. Users needing legacy mesh

--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -35,6 +35,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Distance.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/MeshMesh.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/PlaneSphere.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Raycast.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereBox.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereSphere.hpp
 )
@@ -92,6 +93,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Distance.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/MeshMesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/PlaneSphere.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Raycast.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereBox.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereSphere.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/BruteForce.cpp

--- a/dart/collision/native/NativeCollisionDetector.cpp
+++ b/dart/collision/native/NativeCollisionDetector.cpp
@@ -43,6 +43,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <vector>
 
 namespace dart {
 namespace collision {
@@ -138,6 +139,92 @@ struct NativeDistanceCandidate
   const NativeCollisionObject* object2 = nullptr;
   bool found = false;
 };
+
+//==============================================================================
+struct NativeRayHitCandidate
+{
+  RayHit hit;
+  double distance = std::numeric_limits<double>::max();
+};
+
+//==============================================================================
+RayHit convertRayHit(
+    const native::RaycastResult& nativeResult,
+    const NativeCollisionObject* object,
+    double rayLength)
+{
+  RayHit hit;
+  hit.mCollisionObject = object;
+  hit.mPoint = nativeResult.point;
+  hit.mNormal = nativeResult.normal;
+  hit.mFraction = nativeResult.distance / rayLength;
+  return hit;
+}
+
+//==============================================================================
+bool processNativeRaycastObject(
+    const NativeCollisionObject* object,
+    const native::Ray& ray,
+    double rayLength,
+    const RaycastOption& option,
+    std::vector<NativeRayHitCandidate>& hits)
+{
+  const native::Shape* shape = object->getNativeShape();
+  if (!shape)
+    return false;
+
+  if (!native::NarrowPhase::isRaycastSupported(shape->getType()))
+    return false;
+
+  native::RaycastResult nativeResult;
+  native::RaycastOption nativeOption
+      = native::RaycastOption::withMaxDistance(rayLength);
+  nativeOption.backfaceCulling = false;
+  const bool hit = native::NarrowPhase::raycast(
+      ray, shape, object->getNativeTransform(), nativeOption, nativeResult);
+  if (!hit || !option.passesFilter(object))
+    return false;
+
+  hits.push_back(NativeRayHitCandidate{
+      convertRayHit(nativeResult, object, rayLength), nativeResult.distance});
+  return true;
+}
+
+//==============================================================================
+void convertRaycastResults(
+    const std::vector<NativeRayHitCandidate>& hits,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  if (hits.empty())
+    return;
+
+  if (!option.mEnableAllHits) {
+    const auto closest = std::min_element(
+        hits.begin(),
+        hits.end(),
+        [](const NativeRayHitCandidate& a, const NativeRayHitCandidate& b) {
+          return a.distance < b.distance;
+        });
+    result.mRayHits.emplace_back(closest->hit);
+    return;
+  }
+
+  result.mRayHits.reserve(hits.size());
+  for (const auto& hit : hits)
+    result.mRayHits.emplace_back(hit.hit);
+
+  if (option.mSortByClosest) {
+    std::sort(
+        result.mRayHits.begin(),
+        result.mRayHits.end(),
+        [](const RayHit& a, const RayHit& b) {
+          return a.mFraction < b.mFraction;
+        });
+  }
+}
 
 //==============================================================================
 bool processNativeDistancePair(
@@ -483,6 +570,49 @@ double NativeCollisionDetector::distance(
   }
 
   return convertDistanceResult(best, option, result);
+}
+
+//==============================================================================
+bool NativeCollisionDetector::raycast(
+    CollisionGroup* group,
+    const Eigen::Vector3d& from,
+    const Eigen::Vector3d& to,
+    const RaycastOption& option,
+    RaycastResult* result)
+{
+  if (result)
+    result->clear();
+
+  if (!checkGroupValidity(this, group))
+    return false;
+
+  const Eigen::Vector3d displacement = to - from;
+  const double rayLength = displacement.norm();
+  if (rayLength <= std::numeric_limits<double>::epsilon())
+    return false;
+
+  native::Ray ray(from, displacement, rayLength);
+
+  auto* nativeGroup = static_cast<NativeCollisionGroup*>(group);
+  nativeGroup->updateEngineData();
+
+  std::vector<NativeRayHitCandidate> hits;
+  for (auto* object : nativeGroup->mCollisionObjects) {
+    const auto* nativeObject
+        = static_cast<const NativeCollisionObject*>(object);
+    if (processNativeRaycastObject(nativeObject, ray, rayLength, option, hits)
+        && result == nullptr) {
+      return true;
+    }
+  }
+
+  if (hits.empty())
+    return false;
+
+  if (result)
+    convertRaycastResults(hits, option, *result);
+
+  return true;
 }
 
 //==============================================================================

--- a/dart/collision/native/NativeCollisionDetector.hpp
+++ b/dart/collision/native/NativeCollisionDetector.hpp
@@ -88,6 +88,14 @@ public:
       const DistanceOption& option = DistanceOption(false, 0.0, nullptr),
       DistanceResult* result = nullptr) override;
 
+  // Documentation inherited
+  bool raycast(
+      CollisionGroup* group,
+      const Eigen::Vector3d& from,
+      const Eigen::Vector3d& to,
+      const RaycastOption& option = RaycastOption(),
+      RaycastResult* result = nullptr) override;
+
 protected:
   NativeCollisionDetector();
 

--- a/dart/collision/native/detail/NativeShapeConversion.cpp
+++ b/dart/collision/native/detail/NativeShapeConversion.cpp
@@ -55,8 +55,32 @@ namespace detail {
 
 namespace {
 
+std::vector<native::ConvexShape::Face> makeConvexFacesFromTriangles(
+    const std::vector<Eigen::Vector3d>& vertices,
+    const dynamics::ConvexMeshShape::Triangles& triangles)
+{
+  std::vector<native::ConvexShape::Face> faces;
+  faces.reserve(triangles.size());
+
+  for (const auto& triangle : triangles) {
+    if (triangle[0] >= vertices.size() || triangle[1] >= vertices.size()
+        || triangle[2] >= vertices.size()) {
+      continue;
+    }
+
+    const Eigen::Vector3d& v0 = vertices[triangle[0]];
+    const Eigen::Vector3d& v1 = vertices[triangle[1]];
+    const Eigen::Vector3d& v2 = vertices[triangle[2]];
+    faces.push_back({v0, (v1 - v0).cross(v2 - v0)});
+  }
+
+  return faces;
+}
+
 std::unique_ptr<native::Shape> createConvexOrNull(
-    std::vector<Eigen::Vector3d> vertices, const std::string& shapeType)
+    std::vector<Eigen::Vector3d> vertices,
+    const std::string& shapeType,
+    std::vector<native::ConvexShape::Face> faces = {})
 {
   if (vertices.empty()) {
     static std::set<std::string> warnedInvalidShapeTypes;
@@ -68,7 +92,8 @@ std::unique_ptr<native::Shape> createConvexOrNull(
     return nullptr;
   }
 
-  return std::make_unique<native::ConvexShape>(std::move(vertices));
+  return std::make_unique<native::ConvexShape>(
+      std::move(vertices), std::move(faces));
 }
 
 std::unique_ptr<native::Shape> createMeshOrNull(
@@ -183,7 +208,11 @@ std::unique_ptr<native::Shape> NativeShapeConversion::create(
     if (!mesh) {
       return createConvexOrNull({}, shapeType);
     }
-    return createConvexOrNull(mesh->getVertices(), shapeType);
+    return createConvexOrNull(
+        mesh->getVertices(),
+        shapeType,
+        makeConvexFacesFromTriangles(
+            mesh->getVertices(), mesh->getTriangles()));
   }
 
   if (shapeType == dynamics::PyramidShape::getStaticType()) {

--- a/dart/collision/native/narrow_phase/NarrowPhase.cpp
+++ b/dart/collision/native/narrow_phase/NarrowPhase.cpp
@@ -40,6 +40,7 @@
 #include <dart/collision/native/narrow_phase/MeshMesh.hpp>
 #include <dart/collision/native/narrow_phase/NarrowPhase.hpp>
 #include <dart/collision/native/narrow_phase/PlaneSphere.hpp>
+#include <dart/collision/native/narrow_phase/Raycast.hpp>
 #include <dart/collision/native/narrow_phase/SphereBox.hpp>
 #include <dart/collision/native/narrow_phase/SphereSphere.hpp>
 #include <dart/collision/native/shapes/Shape.hpp>
@@ -661,6 +662,86 @@ double distanceShapes(
   return result.distance;
 }
 
+bool raycastShape(
+    const Ray& ray,
+    const Shape* shape,
+    const Eigen::Isometry3d& transform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  if (!shape) {
+    return false;
+  }
+
+  switch (shape->getType()) {
+    case ShapeType::Sphere: {
+      const auto* s = static_cast<const SphereShape*>(shape);
+      return raycastSphere(ray, *s, transform, option, result);
+    }
+    case ShapeType::Box: {
+      const auto* b = static_cast<const BoxShape*>(shape);
+      return raycastBox(ray, *b, transform, option, result);
+    }
+    case ShapeType::Capsule: {
+      const auto* c = static_cast<const CapsuleShape*>(shape);
+      return raycastCapsule(ray, *c, transform, option, result);
+    }
+    case ShapeType::Cylinder: {
+      const auto* c = static_cast<const CylinderShape*>(shape);
+      return raycastCylinder(ray, *c, transform, option, result);
+    }
+    case ShapeType::Plane: {
+      const auto* p = static_cast<const PlaneShape*>(shape);
+      return raycastPlane(ray, *p, transform, option, result);
+    }
+    case ShapeType::Mesh: {
+      const auto* m = static_cast<const MeshShape*>(shape);
+      return raycastMesh(ray, *m, transform, option, result);
+    }
+    case ShapeType::Convex: {
+      const auto* c = static_cast<const ConvexShape*>(shape);
+      return raycastConvex(ray, *c, transform, option, result);
+    }
+    case ShapeType::Compound: {
+      const auto* compound = static_cast<const CompoundShape*>(shape);
+      bool hit = false;
+      double bestDistance = std::min(ray.maxDistance, option.maxDistance);
+      RaycastResult bestResult;
+
+      for (const auto& child : compound->children()) {
+        if (!child.shape) {
+          continue;
+        }
+
+        RaycastOption childOption = option;
+        childOption.maxDistance = bestDistance;
+        RaycastResult childResult;
+        if (raycastShape(
+                ray,
+                child.shape.get(),
+                transform * child.localTransform,
+                childOption,
+                childResult)) {
+          if (childResult.distance < bestDistance) {
+            bestDistance = childResult.distance;
+            bestResult = childResult;
+          }
+          hit = true;
+        }
+      }
+
+      if (hit) {
+        result = bestResult;
+      }
+      return hit;
+    }
+    default:
+      return false;
+  }
+}
+
 bool collideBatchShapes(
     span<const NarrowPhasePair> pairs,
     span<CollisionResult> results,
@@ -735,6 +816,16 @@ double NarrowPhase::distance(
     DistanceResult& result)
 {
   return distanceShapes(shape1, tf1, shape2, tf2, option, result);
+}
+
+bool NarrowPhase::raycast(
+    const Ray& ray,
+    const Shape* shape,
+    const Eigen::Isometry3d& transform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  return raycastShape(ray, shape, transform, option, result);
 }
 
 bool NarrowPhase::isSupported(ShapeType type1, ShapeType type2)
@@ -858,6 +949,23 @@ bool NarrowPhase::isDistanceSupported(ShapeType type1, ShapeType type2)
     return true;
   }
   return false;
+}
+
+bool NarrowPhase::isRaycastSupported(ShapeType type)
+{
+  switch (type) {
+    case ShapeType::Sphere:
+    case ShapeType::Box:
+    case ShapeType::Capsule:
+    case ShapeType::Cylinder:
+    case ShapeType::Plane:
+    case ShapeType::Mesh:
+    case ShapeType::Convex:
+    case ShapeType::Compound:
+      return true;
+    default:
+      return false;
+  }
 }
 
 } // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/NarrowPhase.cpp
+++ b/dart/collision/native/narrow_phase/NarrowPhase.cpp
@@ -724,7 +724,7 @@ bool raycastShape(
                 transform * child.localTransform,
                 childOption,
                 childResult)) {
-          if (childResult.distance < bestDistance) {
+          if (!hit || childResult.distance <= bestDistance) {
             bestDistance = childResult.distance;
             bestResult = childResult;
           }

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -30,11 +30,11 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <dart/collision/native/narrow_phase/Gjk.hpp>
 #include <dart/collision/native/narrow_phase/Raycast.hpp>
 
 #include <algorithm>
 #include <limits>
+#include <vector>
 
 #include <cmath>
 
@@ -616,35 +616,89 @@ bool raycastMesh(
 
 namespace {
 
-bool isPointInConvex(
-    const Eigen::Vector3d& point,
-    const ConvexShape& convex,
-    const Eigen::Isometry3d& transform)
+struct ConvexFace
 {
-  auto pointSupport = [&point](const Eigen::Vector3d&) {
-    return point;
-  };
+  Eigen::Vector3d point;
+  Eigen::Vector3d normal;
+};
 
-  auto convexSupport = [&convex, transform](const Eigen::Vector3d& dir) {
-    Eigen::Vector3d localDir = transform.linear().transpose() * dir;
-    return transform * convex.support(localDir);
-  };
+std::vector<ConvexFace> computeConvexFaces(const ConvexShape& convex)
+{
+  const auto& vertices = convex.getVertices();
+  std::vector<ConvexFace> faces;
 
-  Eigen::Vector3d initialDir = point - transform.translation();
-  if (initialDir.squaredNorm() < 1e-10) {
-    initialDir = Eigen::Vector3d::UnitX();
+  if (vertices.size() < 4) {
+    return faces;
   }
 
-  return Gjk::intersect(pointSupport, convexSupport, initialDir);
-}
-
-double computeBoundingRadius(const ConvexShape& convex)
-{
-  double maxRadiusSq = 0.0;
-  for (const auto& v : convex.getVertices()) {
-    maxRadiusSq = std::max(maxRadiusSq, v.squaredNorm());
+  Eigen::Vector3d centroid = Eigen::Vector3d::Zero();
+  double maxVertexNorm = 0.0;
+  for (const auto& vertex : vertices) {
+    centroid += vertex;
+    maxVertexNorm = std::max(maxVertexNorm, vertex.norm());
   }
-  return std::sqrt(maxRadiusSq);
+  centroid /= static_cast<double>(vertices.size());
+
+  const double scale = std::max(1.0, maxVertexNorm);
+  const double areaTolerance = 1e-12 * scale * scale;
+  const double planeTolerance = 1e-8 * scale;
+  const double normalTolerance = 1e-8;
+
+  for (std::size_t i = 0; i + 2 < vertices.size(); ++i) {
+    for (std::size_t j = i + 1; j + 1 < vertices.size(); ++j) {
+      for (std::size_t k = j + 1; k < vertices.size(); ++k) {
+        const Eigen::Vector3d edge1 = vertices[j] - vertices[i];
+        const Eigen::Vector3d edge2 = vertices[k] - vertices[i];
+        Eigen::Vector3d normal = edge1.cross(edge2);
+        const double normalNorm = normal.norm();
+        if (normalNorm <= areaTolerance) {
+          continue;
+        }
+        normal /= normalNorm;
+
+        bool hasPositiveSide = false;
+        bool hasNegativeSide = false;
+        for (const auto& vertex : vertices) {
+          const double signedDistance = normal.dot(vertex - vertices[i]);
+          if (signedDistance > planeTolerance) {
+            hasPositiveSide = true;
+          } else if (signedDistance < -planeTolerance) {
+            hasNegativeSide = true;
+          }
+
+          if (hasPositiveSide && hasNegativeSide) {
+            break;
+          }
+        }
+
+        if (hasPositiveSide && hasNegativeSide) {
+          continue;
+        }
+
+        if (normal.dot(centroid - vertices[i]) > 0.0) {
+          normal = -normal;
+        }
+
+        bool duplicate = false;
+        for (const auto& face : faces) {
+          const double normalDot = face.normal.dot(normal);
+          const double planeDistance
+              = std::abs(normal.dot(face.point - vertices[i]));
+          if (normalDot > 1.0 - normalTolerance
+              && planeDistance <= planeTolerance) {
+            duplicate = true;
+            break;
+          }
+        }
+
+        if (!duplicate) {
+          faces.push_back({vertices[i], normal});
+        }
+      }
+    }
+  }
+
+  return faces;
 }
 
 } // namespace
@@ -659,102 +713,59 @@ bool raycastConvex(
   result.clear();
 
   const double maxDist = std::min(ray.maxDistance, option.maxDistance);
-
-  if (isPointInConvex(ray.origin, convex, convexTransform)) {
-    result.hit = true;
-    result.distance = 0.0;
-    result.point = ray.origin;
-    result.normal = -ray.direction.normalized();
-    return true;
-  }
-
-  const Eigen::Vector3d center = convexTransform.translation();
-  const double boundingRadius = computeBoundingRadius(convex);
-
-  const Eigen::Vector3d oc = ray.origin - center;
-  const double a = ray.direction.squaredNorm();
-  const double b = 2.0 * oc.dot(ray.direction);
-  const double c = oc.squaredNorm() - boundingRadius * boundingRadius;
-
-  double t0, t1;
-  if (solveQuadratic(a, b, c, t0, t1) < 0.0) {
+  const auto faces = computeConvexFaces(convex);
+  if (faces.empty()) {
     return false;
   }
 
-  if (t1 < 0.0 || t0 > maxDist) {
-    return false;
-  }
+  double entryDistance = 0.0;
+  double exitDistance = maxDist;
+  Eigen::Vector3d entryNormal = -ray.direction;
+  bool startsInside = true;
 
-  double lo = std::max(0.0, t0);
-  double hi = std::min(maxDist, t1);
+  for (const auto& face : faces) {
+    const Eigen::Vector3d worldPoint = convexTransform * face.point;
+    const Eigen::Vector3d worldNormal
+        = convexTransform.rotation() * face.normal;
 
-  if (!isPointInConvex(ray.pointAt(hi), convex, convexTransform)) {
-    bool foundEntry = false;
-    constexpr int kCoarseSteps = 16;
-    double step = (hi - lo) / kCoarseSteps;
-    for (int i = 1; i <= kCoarseSteps; ++i) {
-      double t = lo + i * step;
-      if (isPointInConvex(ray.pointAt(t), convex, convexTransform)) {
-        hi = t;
-        lo = t - step;
-        foundEntry = true;
-        break;
+    const double signedDistance = worldNormal.dot(ray.origin - worldPoint);
+    const double directionDot = worldNormal.dot(ray.direction);
+
+    if (signedDistance > kEpsilon) {
+      startsInside = false;
+      if (directionDot >= -kEpsilon) {
+        return false;
+      }
+
+      const double candidateEntry = -signedDistance / directionDot;
+      if (candidateEntry > entryDistance) {
+        entryDistance = candidateEntry;
+        entryNormal = worldNormal;
+      }
+    } else if (directionDot > kEpsilon) {
+      const double candidateExit = -signedDistance / directionDot;
+      if (candidateExit < exitDistance) {
+        exitDistance = candidateExit;
       }
     }
-    if (!foundEntry) {
+
+    if (entryDistance - exitDistance > kEpsilon) {
       return false;
     }
   }
 
-  constexpr int kBinarySearchIterations = 32;
-  for (int i = 0; i < kBinarySearchIterations; ++i) {
-    double mid = (lo + hi) * 0.5;
-    if (isPointInConvex(ray.pointAt(mid), convex, convexTransform)) {
-      hi = mid;
-    } else {
-      lo = mid;
-    }
-  }
-
-  double hitT = hi;
-  if (hitT > maxDist) {
+  if (entryDistance < 0.0 || entryDistance > maxDist) {
     return false;
   }
 
   result.hit = true;
-  result.distance = hitT;
-  result.point = ray.pointAt(hitT);
+  result.distance = startsInside ? 0.0 : entryDistance;
+  result.point = ray.pointAt(result.distance);
+  result.normal = startsInside ? -ray.direction : entryNormal;
 
-  const Eigen::Isometry3d invTransform = convexTransform.inverse();
-  const Eigen::Vector3d localPoint = invTransform * result.point;
-
-  Eigen::Vector3d bestNormal = -ray.direction.normalized();
-  double bestDot = -std::numeric_limits<double>::max();
-
-  constexpr int kNormalSamples = 6;
-  const Eigen::Vector3d directions[kNormalSamples]
-      = {Eigen::Vector3d::UnitX(),
-         -Eigen::Vector3d::UnitX(),
-         Eigen::Vector3d::UnitY(),
-         -Eigen::Vector3d::UnitY(),
-         Eigen::Vector3d::UnitZ(),
-         -Eigen::Vector3d::UnitZ()};
-
-  for (const auto& dir : directions) {
-    Eigen::Vector3d support = convex.support(dir);
-    Eigen::Vector3d toPoint = localPoint - support;
-    double dot = toPoint.dot(dir);
-    if (dot > bestDot) {
-      bestDot = dot;
-      bestNormal = convexTransform.rotation() * dir;
-    }
+  if (result.normal.dot(ray.direction) > 0.0) {
+    result.normal = -result.normal;
   }
-
-  if (bestNormal.dot(ray.direction) > 0.0) {
-    bestNormal = -bestNormal;
-  }
-
-  result.normal = bestNormal;
 
   return true;
 }

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -269,7 +269,7 @@ bool raycastCapsule(
     }
   }
 
-  auto testSphereCap = [&](const Eigen::Vector3d& center) {
+  auto testSphereCap = [&](const Eigen::Vector3d& center, double capSign) {
     Eigen::Vector3d oc = localOrigin - center;
     double a2 = localDir.squaredNorm();
     double b2 = 2.0 * oc.dot(localDir);
@@ -279,16 +279,20 @@ bool raycastCapsule(
     if (solveQuadratic(a2, b2, c2, t0, t1) >= 0.0) {
       for (double t : {t0, t1}) {
         if (acceptsHitDistance(t) && t < bestT) {
-          bestT = t;
           Eigen::Vector3d hitPoint = localOrigin + t * localDir;
+          if (capSign * hitPoint.z() < halfHeight - kEpsilon) {
+            continue;
+          }
+
+          bestT = t;
           bestNormal = (hitPoint - center).normalized();
         }
       }
     }
   };
 
-  testSphereCap(Eigen::Vector3d(0, 0, halfHeight));
-  testSphereCap(Eigen::Vector3d(0, 0, -halfHeight));
+  testSphereCap(Eigen::Vector3d(0, 0, halfHeight), 1.0);
+  testSphereCap(Eigen::Vector3d(0, 0, -halfHeight), -1.0);
 
   double maxDist = std::min(ray.maxDistance, option.maxDistance);
   if (bestT > maxDist || bestT == std::numeric_limits<double>::max()) {

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -273,20 +273,25 @@ bool raycastCapsule(
   const double oy = localOrigin.y();
   const double radiusSquared = radius * radius;
   const double radialSquared = ox * ox + oy * oy;
-  const bool originInsideCylinder = radialSquared <= radiusSquared + kEpsilon
-                                    && localOrigin.z() >= -halfHeight - kEpsilon
-                                    && localOrigin.z() <= halfHeight + kEpsilon;
-  const bool originInsideTopCap
+  const bool originStrictlyInsideCylinder
+      = radialSquared < radiusSquared - kEpsilon
+        && localOrigin.z() >= -halfHeight - kEpsilon
+        && localOrigin.z() <= halfHeight + kEpsilon;
+  const bool originStrictlyInsideTopCap
       = (localOrigin - Eigen::Vector3d(0, 0, halfHeight)).squaredNorm()
-        <= radiusSquared + kEpsilon;
-  const bool originInsideBottomCap
+        < radiusSquared - kEpsilon;
+  const bool originStrictlyInsideBottomCap
       = (localOrigin - Eigen::Vector3d(0, 0, -halfHeight)).squaredNorm()
-        <= radiusSquared + kEpsilon;
-  const bool originInsideCapsule
-      = originInsideCylinder || originInsideTopCap || originInsideBottomCap;
+        < radiusSquared - kEpsilon;
+  const bool originStrictlyInsideCapsule = originStrictlyInsideCylinder
+                                           || originStrictlyInsideTopCap
+                                           || originStrictlyInsideBottomCap;
 
-  auto acceptsHitDistance = [originInsideCapsule](double t) {
-    return originInsideCapsule ? t > kEpsilon : t >= 0.0;
+  auto acceptsHitDistance = [originStrictlyInsideCapsule](double& t) {
+    if (std::abs(t) <= kEpsilon) {
+      t = 0.0;
+    }
+    return originStrictlyInsideCapsule ? t > kEpsilon : t >= 0.0;
   };
 
   double a = dx * dx + dy * dy;

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -1,0 +1,762 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/Gjk.hpp>
+#include <dart/collision/native/narrow_phase/Raycast.hpp>
+
+#include <algorithm>
+#include <limits>
+
+#include <cmath>
+
+namespace dart::collision::native {
+
+namespace {
+
+constexpr double kEpsilon = 1e-10;
+
+double solveQuadratic(double a, double b, double c, double& t0, double& t1)
+{
+  double discriminant = b * b - 4.0 * a * c;
+  if (discriminant < 0.0) {
+    return -1.0;
+  }
+
+  double sqrtDisc = std::sqrt(discriminant);
+  double q = (b > 0.0) ? -0.5 * (b + sqrtDisc) : -0.5 * (b - sqrtDisc);
+
+  if (std::abs(q) < kEpsilon) {
+    const double invTwoA = 0.5 / a;
+    t0 = (-b - sqrtDisc) * invTwoA;
+    t1 = (-b + sqrtDisc) * invTwoA;
+  } else {
+    t0 = q / a;
+    t1 = c / q;
+  }
+
+  if (t0 > t1) {
+    std::swap(t0, t1);
+  }
+
+  return discriminant;
+}
+
+} // namespace
+
+bool raycastSphere(
+    const Ray& ray,
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  const Eigen::Vector3d center = sphereTransform.translation();
+  const double radius = sphere.getRadius();
+
+  const Eigen::Vector3d oc = ray.origin - center;
+
+  const double a = ray.direction.squaredNorm();
+  const double b = 2.0 * oc.dot(ray.direction);
+  const double c = oc.squaredNorm() - radius * radius;
+
+  double t0, t1;
+  if (solveQuadratic(a, b, c, t0, t1) < 0.0) {
+    return false;
+  }
+
+  double t = t0;
+  if (c < 0.0 && t <= kEpsilon) {
+    t = t1;
+  }
+  if (t < 0.0) {
+    t = t1;
+    if (t < 0.0) {
+      return false;
+    }
+  }
+
+  double maxDist = std::min(ray.maxDistance, option.maxDistance);
+  if (t > maxDist) {
+    return false;
+  }
+
+  result.hit = true;
+  result.distance = t;
+  result.point = ray.pointAt(t);
+  result.normal = (result.point - center).normalized();
+
+  return true;
+}
+
+bool raycastBox(
+    const Ray& ray,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  const Eigen::Isometry3d invTransform = boxTransform.inverse();
+  const Eigen::Vector3d localOrigin = invTransform * ray.origin;
+  const Eigen::Vector3d localDir = invTransform.rotation() * ray.direction;
+
+  const Eigen::Vector3d& halfExtents = box.getHalfExtents();
+
+  double tMin = 0.0;
+  double tMax = std::numeric_limits<double>::max();
+  int hitAxisMin = -1;
+  int hitSignMin = 1;
+  int hitAxisMax = -1;
+  int hitSignMax = 1;
+
+  for (int i = 0; i < 3; ++i) {
+    if (std::abs(localDir[i]) < kEpsilon) {
+      if (localOrigin[i] < -halfExtents[i] || localOrigin[i] > halfExtents[i]) {
+        return false;
+      }
+    } else {
+      double invD = 1.0 / localDir[i];
+      double t1 = (-halfExtents[i] - localOrigin[i]) * invD;
+      double t2 = (halfExtents[i] - localOrigin[i]) * invD;
+
+      int sign = -1;
+      if (t1 > t2) {
+        std::swap(t1, t2);
+        sign = 1;
+      }
+
+      if (t1 > tMin) {
+        tMin = t1;
+        hitAxisMin = i;
+        hitSignMin = sign;
+      }
+      if (t2 < tMax) {
+        tMax = t2;
+        hitAxisMax = i;
+        hitSignMax = -sign;
+      }
+
+      if (tMin > tMax) {
+        return false;
+      }
+    }
+  }
+
+  double tHit = tMin;
+  int hitAxis = hitAxisMin;
+  int hitSign = hitSignMin;
+  if (hitAxis < 0 || tHit < 0.0) {
+    if (tMax < 0.0) {
+      return false;
+    }
+    tHit = tMax;
+    hitAxis = hitAxisMax;
+    hitSign = hitSignMax;
+  }
+
+  double maxDist = std::min(ray.maxDistance, option.maxDistance);
+  if (tHit > maxDist) {
+    return false;
+  }
+
+  result.hit = true;
+  result.distance = tHit;
+  result.point = ray.pointAt(tHit);
+
+  Eigen::Vector3d localNormal = Eigen::Vector3d::Zero();
+  if (hitAxis < 0) {
+    return false;
+  }
+  localNormal[hitAxis] = static_cast<double>(hitSign);
+  result.normal = boxTransform.rotation() * localNormal;
+
+  return true;
+}
+
+bool raycastCapsule(
+    const Ray& ray,
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  const double radius = capsule.getRadius();
+  const double halfHeight = capsule.getHeight() / 2.0;
+
+  const Eigen::Isometry3d invTransform = capsuleTransform.inverse();
+  const Eigen::Vector3d localOrigin = invTransform * ray.origin;
+  const Eigen::Vector3d localDir = invTransform.rotation() * ray.direction;
+
+  double bestT = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestNormal = Eigen::Vector3d::UnitZ();
+
+  const double dx = localDir.x();
+  const double dy = localDir.y();
+  const double ox = localOrigin.x();
+  const double oy = localOrigin.y();
+  const double radiusSquared = radius * radius;
+  const double radialSquared = ox * ox + oy * oy;
+  const bool originInsideCylinder = radialSquared <= radiusSquared + kEpsilon
+                                    && localOrigin.z() >= -halfHeight - kEpsilon
+                                    && localOrigin.z() <= halfHeight + kEpsilon;
+  const bool originInsideTopCap
+      = (localOrigin - Eigen::Vector3d(0, 0, halfHeight)).squaredNorm()
+        <= radiusSquared + kEpsilon;
+  const bool originInsideBottomCap
+      = (localOrigin - Eigen::Vector3d(0, 0, -halfHeight)).squaredNorm()
+        <= radiusSquared + kEpsilon;
+  const bool originInsideCapsule
+      = originInsideCylinder || originInsideTopCap || originInsideBottomCap;
+
+  auto acceptsHitDistance = [originInsideCapsule](double t) {
+    return originInsideCapsule ? t > kEpsilon : t >= 0.0;
+  };
+
+  double a = dx * dx + dy * dy;
+  double b = 2.0 * (ox * dx + oy * dy);
+  double c = radialSquared - radiusSquared;
+
+  if (a > kEpsilon) {
+    double t0, t1;
+    if (solveQuadratic(a, b, c, t0, t1) >= 0.0) {
+      for (double t : {t0, t1}) {
+        if (acceptsHitDistance(t) && t < bestT) {
+          double z = localOrigin.z() + t * localDir.z();
+          if (z >= -halfHeight && z <= halfHeight) {
+            Eigen::Vector3d hitPoint = localOrigin + t * localDir;
+            Eigen::Vector3d normal(hitPoint.x(), hitPoint.y(), 0.0);
+            if (normal.squaredNorm() > kEpsilon) {
+              bestT = t;
+              bestNormal = normal.normalized();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  auto testSphereCap = [&](const Eigen::Vector3d& center) {
+    Eigen::Vector3d oc = localOrigin - center;
+    double a2 = localDir.squaredNorm();
+    double b2 = 2.0 * oc.dot(localDir);
+    double c2 = oc.squaredNorm() - radiusSquared;
+
+    double t0, t1;
+    if (solveQuadratic(a2, b2, c2, t0, t1) >= 0.0) {
+      for (double t : {t0, t1}) {
+        if (acceptsHitDistance(t) && t < bestT) {
+          bestT = t;
+          Eigen::Vector3d hitPoint = localOrigin + t * localDir;
+          bestNormal = (hitPoint - center).normalized();
+        }
+      }
+    }
+  };
+
+  testSphereCap(Eigen::Vector3d(0, 0, halfHeight));
+  testSphereCap(Eigen::Vector3d(0, 0, -halfHeight));
+
+  double maxDist = std::min(ray.maxDistance, option.maxDistance);
+  if (bestT > maxDist || bestT == std::numeric_limits<double>::max()) {
+    return false;
+  }
+
+  result.hit = true;
+  result.distance = bestT;
+  result.point = ray.pointAt(bestT);
+  result.normal = capsuleTransform.rotation() * bestNormal;
+
+  return true;
+}
+
+bool raycastCylinder(
+    const Ray& ray,
+    const CylinderShape& cylinder,
+    const Eigen::Isometry3d& cylinderTransform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  const double radius = cylinder.getRadius();
+  const double halfHeight = cylinder.getHeight() / 2.0;
+
+  const Eigen::Isometry3d invTransform = cylinderTransform.inverse();
+  const Eigen::Vector3d localOrigin = invTransform * ray.origin;
+  const Eigen::Vector3d localDir = invTransform.rotation() * ray.direction;
+
+  double bestT = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestNormal = Eigen::Vector3d::UnitZ();
+
+  const double dx = localDir.x();
+  const double dy = localDir.y();
+  const double ox = localOrigin.x();
+  const double oy = localOrigin.y();
+
+  double a = dx * dx + dy * dy;
+  double b = 2.0 * (ox * dx + oy * dy);
+  double c = ox * ox + oy * oy - radius * radius;
+
+  if (a > kEpsilon) {
+    double t0, t1;
+    if (solveQuadratic(a, b, c, t0, t1) >= 0.0) {
+      for (double t : {t0, t1}) {
+        if (t >= 0.0 && t < bestT) {
+          double z = localOrigin.z() + t * localDir.z();
+          if (z >= -halfHeight && z <= halfHeight) {
+            Eigen::Vector3d hitPoint = localOrigin + t * localDir;
+            Eigen::Vector3d normal(hitPoint.x(), hitPoint.y(), 0.0);
+            if (normal.squaredNorm() > kEpsilon) {
+              bestT = t;
+              bestNormal = normal.normalized();
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (std::abs(localDir.z()) > kEpsilon) {
+    for (double capZ : {-halfHeight, halfHeight}) {
+      double t = (capZ - localOrigin.z()) / localDir.z();
+      if (t >= 0.0 && t < bestT) {
+        Eigen::Vector3d hitPoint = localOrigin + t * localDir;
+        double distSq
+            = hitPoint.x() * hitPoint.x() + hitPoint.y() * hitPoint.y();
+        if (distSq <= radius * radius) {
+          bestT = t;
+          bestNormal = (capZ > 0.0) ? Eigen::Vector3d(0, 0, 1)
+                                    : Eigen::Vector3d(0, 0, -1);
+        }
+      }
+    }
+  }
+
+  double maxDist = std::min(ray.maxDistance, option.maxDistance);
+  if (bestT > maxDist || bestT == std::numeric_limits<double>::max()) {
+    return false;
+  }
+
+  result.hit = true;
+  result.distance = bestT;
+  result.point = ray.pointAt(bestT);
+  result.normal = cylinderTransform.rotation() * bestNormal;
+
+  return true;
+}
+
+bool raycastPlane(
+    const Ray& ray,
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  const Eigen::Vector3d worldNormal
+      = planeTransform.rotation() * plane.getNormal();
+  const Eigen::Vector3d worldPoint
+      = planeTransform.translation() + plane.getOffset() * worldNormal;
+
+  double denom = worldNormal.dot(ray.direction);
+
+  if (option.backfaceCulling && denom > -kEpsilon) {
+    return false;
+  }
+
+  if (std::abs(denom) < kEpsilon) {
+    return false;
+  }
+
+  double t = (worldPoint - ray.origin).dot(worldNormal) / denom;
+
+  if (t < 0.0) {
+    return false;
+  }
+
+  double maxDist = std::min(ray.maxDistance, option.maxDistance);
+  if (t > maxDist) {
+    return false;
+  }
+
+  result.hit = true;
+  result.distance = t;
+  result.point = ray.pointAt(t);
+  result.normal = (denom < 0.0) ? worldNormal : -worldNormal;
+
+  return true;
+}
+
+namespace {
+
+constexpr double kMeshEpsilon = 1e-10;
+
+bool rayTriangleMollerTrumbore(
+    const Eigen::Vector3d& origin,
+    const Eigen::Vector3d& dir,
+    const Eigen::Vector3d& v0,
+    const Eigen::Vector3d& v1,
+    const Eigen::Vector3d& v2,
+    double& t,
+    double& u,
+    double& v,
+    bool backfaceCulling)
+{
+  const Eigen::Vector3d edge1 = v1 - v0;
+  const Eigen::Vector3d edge2 = v2 - v0;
+
+  const Eigen::Vector3d h = dir.cross(edge2);
+  const double a = edge1.dot(h);
+
+  if (backfaceCulling) {
+    if (a < kMeshEpsilon) {
+      return false;
+    }
+  } else {
+    if (std::abs(a) < kMeshEpsilon) {
+      return false;
+    }
+  }
+
+  const double f = 1.0 / a;
+  const Eigen::Vector3d s = origin - v0;
+  u = f * s.dot(h);
+
+  if (u < 0.0 || u > 1.0) {
+    return false;
+  }
+
+  const Eigen::Vector3d q = s.cross(edge1);
+  v = f * dir.dot(q);
+
+  if (v < 0.0 || u + v > 1.0) {
+    return false;
+  }
+
+  t = f * edge2.dot(q);
+
+  return t > kMeshEpsilon;
+}
+
+bool rayAabbIntersect(
+    const Eigen::Vector3d& origin,
+    const Eigen::Vector3d& direction,
+    const Aabb& box,
+    double maxDistance,
+    double& tEnter,
+    double& tExit)
+{
+  tEnter = 0.0;
+  tExit = maxDistance;
+
+  for (int i = 0; i < 3; ++i) {
+    const double o = origin[i];
+    const double d = direction[i];
+    const double bMin = box.min[i];
+    const double bMax = box.max[i];
+
+    if (std::abs(d) < kMeshEpsilon) {
+      if (o < bMin || o > bMax) {
+        return false;
+      }
+      continue;
+    }
+
+    const double invD = 1.0 / d;
+    double t0 = (bMin - o) * invD;
+    double t1 = (bMax - o) * invD;
+    if (t0 > t1) {
+      std::swap(t0, t1);
+    }
+
+    tEnter = std::max(tEnter, t0);
+    tExit = std::min(tExit, t1);
+    if (tEnter > tExit) {
+      return false;
+    }
+  }
+
+  return tExit >= 0.0;
+}
+
+} // namespace
+
+bool raycastMesh(
+    const Ray& ray,
+    const MeshShape& mesh,
+    const Eigen::Isometry3d& meshTransform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  const Eigen::Isometry3d invTransform = meshTransform.inverse();
+  const Eigen::Vector3d localOrigin = invTransform * ray.origin;
+  const Eigen::Vector3d localDir = invTransform.rotation() * ray.direction;
+
+  const auto& vertices = mesh.getVertices();
+  const auto& triangles = mesh.getTriangles();
+  const auto& nodes = mesh.bvhNodes();
+  const auto& triIndices = mesh.bvhTriIndices();
+
+  if (nodes.empty()) {
+    return false;
+  }
+
+  double maxDist = std::min(ray.maxDistance, option.maxDistance);
+  double bestT = std::numeric_limits<double>::max();
+  Eigen::Vector3d bestNormal = Eigen::Vector3d::UnitZ();
+
+  std::vector<int> stack;
+  stack.push_back(0);
+  while (!stack.empty()) {
+    const int nodeIndex = stack.back();
+    stack.pop_back();
+
+    const auto& node = nodes[static_cast<std::size_t>(nodeIndex)];
+    double tEnter = 0.0;
+    double tExit = 0.0;
+    if (!rayAabbIntersect(
+            localOrigin, localDir, node.box, maxDist, tEnter, tExit)
+        || tEnter > bestT) {
+      continue;
+    }
+
+    if (node.count > 0) {
+      for (int i = 0; i < node.count; ++i) {
+        const int triIndex
+            = triIndices[static_cast<std::size_t>(node.first + i)];
+        const auto& tri = triangles[static_cast<std::size_t>(triIndex)];
+        const Eigen::Vector3d& v0 = vertices[static_cast<std::size_t>(tri[0])];
+        const Eigen::Vector3d& v1 = vertices[static_cast<std::size_t>(tri[1])];
+        const Eigen::Vector3d& v2 = vertices[static_cast<std::size_t>(tri[2])];
+
+        double t = 0.0;
+        double u = 0.0;
+        double v = 0.0;
+        if (rayTriangleMollerTrumbore(
+                localOrigin,
+                localDir,
+                v0,
+                v1,
+                v2,
+                t,
+                u,
+                v,
+                option.backfaceCulling)) {
+          if (t > 0.0 && t < bestT && t <= maxDist) {
+            bestT = t;
+            const Eigen::Vector3d edge1 = v1 - v0;
+            const Eigen::Vector3d edge2 = v2 - v0;
+            bestNormal = edge1.cross(edge2).normalized();
+          }
+        }
+      }
+      continue;
+    }
+
+    if (node.left >= 0) {
+      stack.push_back(node.left);
+    }
+    if (node.right >= 0) {
+      stack.push_back(node.right);
+    }
+  }
+
+  if (bestT >= std::numeric_limits<double>::max() || bestT > maxDist) {
+    return false;
+  }
+
+  result.hit = true;
+  result.distance = bestT;
+  result.point = ray.pointAt(bestT);
+  result.normal = meshTransform.rotation() * bestNormal;
+
+  if (result.normal.dot(ray.direction) > 0.0) {
+    result.normal = -result.normal;
+  }
+
+  return true;
+}
+
+namespace {
+
+bool isPointInConvex(
+    const Eigen::Vector3d& point,
+    const ConvexShape& convex,
+    const Eigen::Isometry3d& transform)
+{
+  auto pointSupport = [&point](const Eigen::Vector3d&) {
+    return point;
+  };
+
+  auto convexSupport = [&convex, transform](const Eigen::Vector3d& dir) {
+    Eigen::Vector3d localDir = transform.linear().transpose() * dir;
+    return transform * convex.support(localDir);
+  };
+
+  Eigen::Vector3d initialDir = point - transform.translation();
+  if (initialDir.squaredNorm() < 1e-10) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  return Gjk::intersect(pointSupport, convexSupport, initialDir);
+}
+
+double computeBoundingRadius(const ConvexShape& convex)
+{
+  double maxRadiusSq = 0.0;
+  for (const auto& v : convex.getVertices()) {
+    maxRadiusSq = std::max(maxRadiusSq, v.squaredNorm());
+  }
+  return std::sqrt(maxRadiusSq);
+}
+
+} // namespace
+
+bool raycastConvex(
+    const Ray& ray,
+    const ConvexShape& convex,
+    const Eigen::Isometry3d& convexTransform,
+    const RaycastOption& option,
+    RaycastResult& result)
+{
+  result.clear();
+
+  const double maxDist = std::min(ray.maxDistance, option.maxDistance);
+
+  if (isPointInConvex(ray.origin, convex, convexTransform)) {
+    result.hit = true;
+    result.distance = 0.0;
+    result.point = ray.origin;
+    result.normal = -ray.direction.normalized();
+    return true;
+  }
+
+  const Eigen::Vector3d center = convexTransform.translation();
+  const double boundingRadius = computeBoundingRadius(convex);
+
+  const Eigen::Vector3d oc = ray.origin - center;
+  const double a = ray.direction.squaredNorm();
+  const double b = 2.0 * oc.dot(ray.direction);
+  const double c = oc.squaredNorm() - boundingRadius * boundingRadius;
+
+  double t0, t1;
+  if (solveQuadratic(a, b, c, t0, t1) < 0.0) {
+    return false;
+  }
+
+  if (t1 < 0.0 || t0 > maxDist) {
+    return false;
+  }
+
+  double lo = std::max(0.0, t0);
+  double hi = std::min(maxDist, t1);
+
+  if (!isPointInConvex(ray.pointAt(hi), convex, convexTransform)) {
+    bool foundEntry = false;
+    constexpr int kCoarseSteps = 16;
+    double step = (hi - lo) / kCoarseSteps;
+    for (int i = 1; i <= kCoarseSteps; ++i) {
+      double t = lo + i * step;
+      if (isPointInConvex(ray.pointAt(t), convex, convexTransform)) {
+        hi = t;
+        lo = t - step;
+        foundEntry = true;
+        break;
+      }
+    }
+    if (!foundEntry) {
+      return false;
+    }
+  }
+
+  constexpr int kBinarySearchIterations = 32;
+  for (int i = 0; i < kBinarySearchIterations; ++i) {
+    double mid = (lo + hi) * 0.5;
+    if (isPointInConvex(ray.pointAt(mid), convex, convexTransform)) {
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+
+  double hitT = hi;
+  if (hitT > maxDist) {
+    return false;
+  }
+
+  result.hit = true;
+  result.distance = hitT;
+  result.point = ray.pointAt(hitT);
+
+  const Eigen::Isometry3d invTransform = convexTransform.inverse();
+  const Eigen::Vector3d localPoint = invTransform * result.point;
+
+  Eigen::Vector3d bestNormal = -ray.direction.normalized();
+  double bestDot = -std::numeric_limits<double>::max();
+
+  constexpr int kNormalSamples = 6;
+  const Eigen::Vector3d directions[kNormalSamples]
+      = {Eigen::Vector3d::UnitX(),
+         -Eigen::Vector3d::UnitX(),
+         Eigen::Vector3d::UnitY(),
+         -Eigen::Vector3d::UnitY(),
+         Eigen::Vector3d::UnitZ(),
+         -Eigen::Vector3d::UnitZ()};
+
+  for (const auto& dir : directions) {
+    Eigen::Vector3d support = convex.support(dir);
+    Eigen::Vector3d toPoint = localPoint - support;
+    double dot = toPoint.dot(dir);
+    if (dot > bestDot) {
+      bestDot = dot;
+      bestNormal = convexTransform.rotation() * dir;
+    }
+  }
+
+  if (bestNormal.dot(ray.direction) > 0.0) {
+    bestNormal = -bestNormal;
+  }
+
+  result.normal = bestNormal;
+
+  return true;
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -516,8 +516,11 @@ bool rayTriangleMollerTrumbore(
   }
 
   t = f * edge2.dot(q);
+  if (std::abs(t) <= kMeshEpsilon) {
+    t = 0.0;
+  }
 
-  return t > kMeshEpsilon;
+  return t >= 0.0;
 }
 
 bool rayAabbIntersect(
@@ -626,7 +629,7 @@ bool raycastMesh(
                 u,
                 v,
                 option.backfaceCulling)) {
-          if (t > 0.0 && t < bestT && t <= maxDist) {
+          if (t >= 0.0 && t < bestT && t <= maxDist) {
             bestT = t;
             const Eigen::Vector3d edge1 = v1 - v0;
             const Eigen::Vector3d edge2 = v2 - v0;

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -133,8 +133,52 @@ bool raycastBox(
   const Eigen::Vector3d localDir = invTransform.rotation() * ray.direction;
 
   const Eigen::Vector3d& halfExtents = box.getHalfExtents();
+  const double maxDist = std::min(ray.maxDistance, option.maxDistance);
 
-  double tMin = 0.0;
+  int boundaryAxis = -1;
+  int boundarySign = 1;
+  double boundaryDirectionDot = std::numeric_limits<double>::max();
+  bool originInsideOrOn = true;
+  for (int i = 0; i < 3; ++i) {
+    if (localOrigin[i] < -halfExtents[i] - kEpsilon
+        || localOrigin[i] > halfExtents[i] + kEpsilon) {
+      originInsideOrOn = false;
+      break;
+    }
+
+    const double distanceToMin = std::abs(localOrigin[i] + halfExtents[i]);
+    const double distanceToMax = std::abs(localOrigin[i] - halfExtents[i]);
+    if (distanceToMin <= kEpsilon) {
+      const double directionDot = -localDir[i];
+      if (directionDot < boundaryDirectionDot) {
+        boundaryAxis = i;
+        boundarySign = -1;
+        boundaryDirectionDot = directionDot;
+      }
+    }
+    if (distanceToMax <= kEpsilon) {
+      const double directionDot = localDir[i];
+      if (directionDot < boundaryDirectionDot) {
+        boundaryAxis = i;
+        boundarySign = 1;
+        boundaryDirectionDot = directionDot;
+      }
+    }
+  }
+
+  if (originInsideOrOn && boundaryAxis >= 0 && maxDist >= 0.0) {
+    result.hit = true;
+    result.distance = 0.0;
+    result.point = ray.origin;
+
+    Eigen::Vector3d localNormal = Eigen::Vector3d::Zero();
+    localNormal[boundaryAxis] = static_cast<double>(boundarySign);
+    result.normal = boxTransform.rotation() * localNormal;
+
+    return true;
+  }
+
+  double tMin = -std::numeric_limits<double>::max();
   double tMax = std::numeric_limits<double>::max();
   int hitAxisMin = -1;
   int hitSignMin = 1;
@@ -186,7 +230,6 @@ bool raycastBox(
     hitSign = hitSignMax;
   }
 
-  double maxDist = std::min(ray.maxDistance, option.maxDistance);
   if (tHit > maxDist) {
     return false;
   }
@@ -618,95 +661,6 @@ bool raycastMesh(
   return true;
 }
 
-namespace {
-
-struct ConvexFace
-{
-  Eigen::Vector3d point;
-  Eigen::Vector3d normal;
-};
-
-std::vector<ConvexFace> computeConvexFaces(const ConvexShape& convex)
-{
-  const auto& vertices = convex.getVertices();
-  std::vector<ConvexFace> faces;
-
-  if (vertices.size() < 4) {
-    return faces;
-  }
-
-  Eigen::Vector3d centroid = Eigen::Vector3d::Zero();
-  double maxVertexNorm = 0.0;
-  for (const auto& vertex : vertices) {
-    centroid += vertex;
-    maxVertexNorm = std::max(maxVertexNorm, vertex.norm());
-  }
-  centroid /= static_cast<double>(vertices.size());
-
-  const double scale = std::max(1.0, maxVertexNorm);
-  const double areaTolerance = 1e-12 * scale * scale;
-  const double planeTolerance = 1e-8 * scale;
-  const double normalTolerance = 1e-8;
-
-  for (std::size_t i = 0; i + 2 < vertices.size(); ++i) {
-    for (std::size_t j = i + 1; j + 1 < vertices.size(); ++j) {
-      for (std::size_t k = j + 1; k < vertices.size(); ++k) {
-        const Eigen::Vector3d edge1 = vertices[j] - vertices[i];
-        const Eigen::Vector3d edge2 = vertices[k] - vertices[i];
-        Eigen::Vector3d normal = edge1.cross(edge2);
-        const double normalNorm = normal.norm();
-        if (normalNorm <= areaTolerance) {
-          continue;
-        }
-        normal /= normalNorm;
-
-        bool hasPositiveSide = false;
-        bool hasNegativeSide = false;
-        for (const auto& vertex : vertices) {
-          const double signedDistance = normal.dot(vertex - vertices[i]);
-          if (signedDistance > planeTolerance) {
-            hasPositiveSide = true;
-          } else if (signedDistance < -planeTolerance) {
-            hasNegativeSide = true;
-          }
-
-          if (hasPositiveSide && hasNegativeSide) {
-            break;
-          }
-        }
-
-        if (hasPositiveSide && hasNegativeSide) {
-          continue;
-        }
-
-        if (normal.dot(centroid - vertices[i]) > 0.0) {
-          normal = -normal;
-        }
-
-        bool duplicate = false;
-        for (const auto& face : faces) {
-          const double normalDot = face.normal.dot(normal);
-          const double planeDistance
-              = std::abs(normal.dot(face.point - vertices[i]));
-          if (normalDot > 1.0 - normalTolerance
-              && planeDistance <= planeTolerance) {
-            duplicate = true;
-            break;
-          }
-        }
-
-        if (!duplicate) {
-          faces.push_back({vertices[i], normal});
-        }
-      }
-    }
-  }
-
-  return faces;
-}
-
-} // namespace
-
 bool raycastConvex(
     const Ray& ray,
     const ConvexShape& convex,
@@ -717,7 +671,7 @@ bool raycastConvex(
   result.clear();
 
   const double maxDist = std::min(ray.maxDistance, option.maxDistance);
-  const auto faces = computeConvexFaces(convex);
+  const auto& faces = convex.getFaces();
   if (faces.empty()) {
     return false;
   }

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -715,6 +715,11 @@ bool raycastConvex(
     } else if (std::abs(signedDistance) <= kEpsilon) {
       originOnBoundary = true;
       boundaryNormal = worldNormal;
+      if (directionDot > kEpsilon) {
+        exitDistance = 0.0;
+        exitNormal = worldNormal;
+        hasExitWithinMaxDistance = true;
+      }
     } else if (directionDot > kEpsilon) {
       const double candidateExit = -signedDistance / directionDot;
       if (candidateExit >= 0.0 && candidateExit <= exitDistance) {

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -783,12 +783,20 @@ bool raycastConvex(
     return false;
   }
 
-  result.hit = true;
-  result.distance = startsInside ? 0.0 : entryDistance;
-  result.point = ray.pointAt(result.distance);
-  result.normal = startsInside ? boundaryNormal : entryNormal;
+  if (startsInside) {
+    result.hit = true;
+    result.distance = 0.0;
+    result.point = ray.origin;
+    result.normal = boundaryNormal;
+    return true;
+  }
 
-  if (!startsInside && result.normal.dot(ray.direction) > 0.0) {
+  result.hit = true;
+  result.distance = entryDistance;
+  result.point = ray.pointAt(result.distance);
+  result.normal = entryNormal;
+
+  if (result.normal.dot(ray.direction) > 0.0) {
     result.normal = -result.normal;
   }
 

--- a/dart/collision/native/narrow_phase/Raycast.cpp
+++ b/dart/collision/native/narrow_phase/Raycast.cpp
@@ -725,7 +725,11 @@ bool raycastConvex(
   double entryDistance = 0.0;
   double exitDistance = maxDist;
   Eigen::Vector3d entryNormal = -ray.direction;
+  Eigen::Vector3d exitNormal = ray.direction;
+  Eigen::Vector3d boundaryNormal = -ray.direction;
   bool startsInside = true;
+  bool originOnBoundary = false;
+  bool hasExitWithinMaxDistance = false;
 
   for (const auto& face : faces) {
     const Eigen::Vector3d worldPoint = convexTransform * face.point;
@@ -746,16 +750,33 @@ bool raycastConvex(
         entryDistance = candidateEntry;
         entryNormal = worldNormal;
       }
+    } else if (std::abs(signedDistance) <= kEpsilon) {
+      originOnBoundary = true;
+      boundaryNormal = worldNormal;
     } else if (directionDot > kEpsilon) {
       const double candidateExit = -signedDistance / directionDot;
-      if (candidateExit < exitDistance) {
+      if (candidateExit >= 0.0 && candidateExit <= exitDistance) {
         exitDistance = candidateExit;
+        exitNormal = worldNormal;
+        hasExitWithinMaxDistance = true;
       }
     }
 
     if (entryDistance - exitDistance > kEpsilon) {
       return false;
     }
+  }
+
+  if (startsInside && !originOnBoundary) {
+    if (!hasExitWithinMaxDistance) {
+      return false;
+    }
+
+    result.hit = true;
+    result.distance = exitDistance;
+    result.point = ray.pointAt(result.distance);
+    result.normal = exitNormal;
+    return true;
   }
 
   if (entryDistance < 0.0 || entryDistance > maxDist) {
@@ -765,9 +786,9 @@ bool raycastConvex(
   result.hit = true;
   result.distance = startsInside ? 0.0 : entryDistance;
   result.point = ray.pointAt(result.distance);
-  result.normal = startsInside ? -ray.direction : entryNormal;
+  result.normal = startsInside ? boundaryNormal : entryNormal;
 
-  if (result.normal.dot(ray.direction) > 0.0) {
+  if (!startsInside && result.normal.dot(ray.direction) > 0.0) {
     result.normal = -result.normal;
   }
 

--- a/dart/collision/native/narrow_phase/Raycast.hpp
+++ b/dart/collision/native/narrow_phase/Raycast.hpp
@@ -34,65 +34,60 @@
 
 #include <dart/collision/native/Export.hpp>
 #include <dart/collision/native/Types.hpp>
-#include <dart/collision/native/detail/Span.hpp>
+#include <dart/collision/native/shapes/Shape.hpp>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
 namespace dart::collision::native {
 
-enum class ShapeType;
+[[nodiscard]] DART_COLLISION_NATIVE_API bool raycastSphere(
+    const Ray& ray,
+    const SphereShape& sphere,
+    const Eigen::Isometry3d& sphereTransform,
+    const RaycastOption& option,
+    RaycastResult& result);
 
-struct DART_COLLISION_NATIVE_API NarrowPhasePair
-{
-  const Shape* shapeA;
-  const Shape* shapeB;
-  Eigen::Isometry3d tfA;
-  Eigen::Isometry3d tfB;
-};
+[[nodiscard]] DART_COLLISION_NATIVE_API bool raycastBox(
+    const Ray& ray,
+    const BoxShape& box,
+    const Eigen::Isometry3d& boxTransform,
+    const RaycastOption& option,
+    RaycastResult& result);
 
-class DART_COLLISION_NATIVE_API NarrowPhase
-{
-public:
-  static bool collide(
-      const Shape* shape1,
-      const Eigen::Isometry3d& tf1,
-      const Shape* shape2,
-      const Eigen::Isometry3d& tf2,
-      const CollisionOption& option,
-      CollisionResult& result);
+[[nodiscard]] DART_COLLISION_NATIVE_API bool raycastCapsule(
+    const Ray& ray,
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& capsuleTransform,
+    const RaycastOption& option,
+    RaycastResult& result);
 
-  static bool collideBatch(
-      span<const NarrowPhasePair> pairs,
-      span<CollisionResult> results,
-      const CollisionOption& option = CollisionOption());
+[[nodiscard]] DART_COLLISION_NATIVE_API bool raycastCylinder(
+    const Ray& ray,
+    const CylinderShape& cylinder,
+    const Eigen::Isometry3d& cylinderTransform,
+    const RaycastOption& option,
+    RaycastResult& result);
 
-  static bool collideBatch(
-      span<const NarrowPhasePair> pairs,
-      span<CollisionResult> results,
-      span<bool> hits,
-      const CollisionOption& option = CollisionOption());
+[[nodiscard]] DART_COLLISION_NATIVE_API bool raycastPlane(
+    const Ray& ray,
+    const PlaneShape& plane,
+    const Eigen::Isometry3d& planeTransform,
+    const RaycastOption& option,
+    RaycastResult& result);
 
-  static double distance(
-      const Shape* shape1,
-      const Eigen::Isometry3d& tf1,
-      const Shape* shape2,
-      const Eigen::Isometry3d& tf2,
-      const DistanceOption& option,
-      DistanceResult& result);
+[[nodiscard]] DART_COLLISION_NATIVE_API bool raycastMesh(
+    const Ray& ray,
+    const MeshShape& mesh,
+    const Eigen::Isometry3d& meshTransform,
+    const RaycastOption& option,
+    RaycastResult& result);
 
-  static bool raycast(
-      const Ray& ray,
-      const Shape* shape,
-      const Eigen::Isometry3d& transform,
-      const RaycastOption& option,
-      RaycastResult& result);
-
-  static bool isSupported(ShapeType type1, ShapeType type2);
-
-  static bool isDistanceSupported(ShapeType type1, ShapeType type2);
-
-  static bool isRaycastSupported(ShapeType type);
-};
+[[nodiscard]] DART_COLLISION_NATIVE_API bool raycastConvex(
+    const Ray& ray,
+    const ConvexShape& convex,
+    const Eigen::Isometry3d& convexTransform,
+    const RaycastOption& option,
+    RaycastResult& result);
 
 } // namespace dart::collision::native

--- a/dart/collision/native/shapes/Shape.cpp
+++ b/dart/collision/native/shapes/Shape.cpp
@@ -36,7 +36,139 @@
 #include <limits>
 #include <numeric>
 
+#include <cmath>
+
 namespace dart::collision::native {
+
+namespace {
+
+constexpr double kConvexFaceAreaToleranceScale = 1e-12;
+constexpr double kConvexFacePlaneToleranceScale = 1e-8;
+constexpr double kConvexFaceNormalTolerance = 1e-8;
+
+double computeConvexScale(const std::vector<Eigen::Vector3d>& vertices)
+{
+  double maxVertexNorm = 0.0;
+  for (const auto& vertex : vertices) {
+    maxVertexNorm = std::max(maxVertexNorm, vertex.norm());
+  }
+
+  return std::max(1.0, maxVertexNorm);
+}
+
+Eigen::Vector3d computeCentroid(const std::vector<Eigen::Vector3d>& vertices)
+{
+  Eigen::Vector3d centroid = Eigen::Vector3d::Zero();
+  for (const auto& vertex : vertices) {
+    centroid += vertex;
+  }
+
+  if (!vertices.empty()) {
+    centroid /= static_cast<double>(vertices.size());
+  }
+
+  return centroid;
+}
+
+std::vector<ConvexShape::Face> normalizeConvexFaces(
+    const std::vector<Eigen::Vector3d>& vertices,
+    std::vector<ConvexShape::Face> faces)
+{
+  if (vertices.size() < 4) {
+    return {};
+  }
+
+  const Eigen::Vector3d centroid = computeCentroid(vertices);
+  const double scale = computeConvexScale(vertices);
+  const double planeTolerance = kConvexFacePlaneToleranceScale * scale;
+  const double normalTolerance = kConvexFaceNormalTolerance;
+
+  std::vector<ConvexShape::Face> normalizedFaces;
+  normalizedFaces.reserve(faces.size());
+
+  for (auto face : faces) {
+    const double normalNorm = face.normal.norm();
+    if (normalNorm <= kConvexFaceAreaToleranceScale) {
+      continue;
+    }
+    face.normal /= normalNorm;
+
+    if (face.normal.dot(centroid - face.point) > 0.0) {
+      face.normal = -face.normal;
+    }
+
+    bool duplicate = false;
+    for (const auto& existing : normalizedFaces) {
+      const double normalDot = existing.normal.dot(face.normal);
+      const double planeDistance
+          = std::abs(face.normal.dot(existing.point - face.point));
+      if (normalDot > 1.0 - normalTolerance
+          && planeDistance <= planeTolerance) {
+        duplicate = true;
+        break;
+      }
+    }
+
+    if (!duplicate) {
+      normalizedFaces.push_back(face);
+    }
+  }
+
+  return normalizedFaces;
+}
+
+std::vector<ConvexShape::Face> computeConvexFaces(
+    const std::vector<Eigen::Vector3d>& vertices)
+{
+  std::vector<ConvexShape::Face> faces;
+  if (vertices.size() < 4) {
+    return faces;
+  }
+
+  const double scale = computeConvexScale(vertices);
+  const double areaTolerance = kConvexFaceAreaToleranceScale * scale * scale;
+  const double planeTolerance = kConvexFacePlaneToleranceScale * scale;
+
+  for (std::size_t i = 0; i + 2 < vertices.size(); ++i) {
+    for (std::size_t j = i + 1; j + 1 < vertices.size(); ++j) {
+      for (std::size_t k = j + 1; k < vertices.size(); ++k) {
+        const Eigen::Vector3d edge1 = vertices[j] - vertices[i];
+        const Eigen::Vector3d edge2 = vertices[k] - vertices[i];
+        Eigen::Vector3d normal = edge1.cross(edge2);
+        const double normalNorm = normal.norm();
+        if (normalNorm <= areaTolerance) {
+          continue;
+        }
+        normal /= normalNorm;
+
+        bool hasPositiveSide = false;
+        bool hasNegativeSide = false;
+        for (const auto& vertex : vertices) {
+          const double signedDistance = normal.dot(vertex - vertices[i]);
+          if (signedDistance > planeTolerance) {
+            hasPositiveSide = true;
+          } else if (signedDistance < -planeTolerance) {
+            hasNegativeSide = true;
+          }
+
+          if (hasPositiveSide && hasNegativeSide) {
+            break;
+          }
+        }
+
+        if (hasPositiveSide && hasNegativeSide) {
+          continue;
+        }
+
+        faces.push_back({vertices[i], normal});
+      }
+    }
+  }
+
+  return normalizeConvexFaces(vertices, std::move(faces));
+}
+
+} // namespace
 
 SphereShape::SphereShape(double radius) : radius_(radius) {}
 
@@ -153,7 +285,16 @@ double PlaneShape::getOffset() const
 }
 
 ConvexShape::ConvexShape(std::vector<Eigen::Vector3d> vertices)
-  : vertices_(std::move(vertices))
+  : ConvexShape(std::move(vertices), {})
+{
+}
+
+ConvexShape::ConvexShape(
+    std::vector<Eigen::Vector3d> vertices, std::vector<Face> faces)
+  : vertices_(std::move(vertices)),
+    faces_(
+        faces.empty() ? computeConvexFaces(vertices_)
+                      : normalizeConvexFaces(vertices_, std::move(faces)))
 {
 }
 
@@ -182,6 +323,11 @@ Aabb ConvexShape::computeLocalAabb() const
 const std::vector<Eigen::Vector3d>& ConvexShape::getVertices() const
 {
   return vertices_;
+}
+
+const std::vector<ConvexShape::Face>& ConvexShape::getFaces() const
+{
+  return faces_;
 }
 
 Eigen::Vector3d ConvexShape::support(const Eigen::Vector3d& direction) const

--- a/dart/collision/native/shapes/Shape.hpp
+++ b/dart/collision/native/shapes/Shape.hpp
@@ -206,18 +206,27 @@ private:
 class DART_COLLISION_NATIVE_API ConvexShape : public Shape
 {
 public:
+  struct Face
+  {
+    Eigen::Vector3d point;
+    Eigen::Vector3d normal;
+  };
+
   explicit ConvexShape(std::vector<Eigen::Vector3d> vertices);
+  ConvexShape(std::vector<Eigen::Vector3d> vertices, std::vector<Face> faces);
 
   [[nodiscard]] ShapeType getType() const override;
   [[nodiscard]] Aabb computeLocalAabb() const override;
 
   [[nodiscard]] const std::vector<Eigen::Vector3d>& getVertices() const;
+  [[nodiscard]] const std::vector<Face>& getFaces() const;
 
   /// Returns the support point in the given direction (furthest vertex)
   [[nodiscard]] Eigen::Vector3d support(const Eigen::Vector3d& direction) const;
 
 private:
   std::vector<Eigen::Vector3d> vertices_;
+  std::vector<Face> faces_;
 };
 
 /// Triangle mesh shape defined by vertices and triangle indices

--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), and phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350) merged; phase 3 D1 active on `feature/native-distance-adapter` |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1 (#3352) merged; phase 3 D2 active on `feature/native-raycast-adapter` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -92,6 +92,8 @@
   (merged 2026-07-08).
 - **#3350** phase-2 P10 mixed-scene FCL/DART/native parity coverage (merged
   2026-07-08).
+- **#3352** phase-3 D1 native detector distance queries and native basename
+  normalization (merged 2026-07-08).
 - **#3283** main-branch dual for the native sphere-sphere binary-check fix
   (merged 2026-07-07).
 
@@ -108,12 +110,13 @@
 
 ### 🔄 Open — monitoring (checked 2026-07-08)
 
-- **Phase 3 D1** `feature/native-distance-adapter` — active local slice for
-  native `CollisionDetector::distance()` parity against FCL plus native
-  basename normalization. Keep it one PR to reduce CI overhead.
-- **#3348** is the only current open `release-6.20` PR seen during this refresh;
-  it belongs to the separate MSVC/toolchain policy lane, not this native
-  collision port lane.
+- **Phase 3 D2** `feature/native-raycast-adapter` — active local slice for
+  native `CollisionDetector::raycast()` parity against Bullet plus native-vs-
+  Bullet raycast benchmarks. Keep it one PR to reduce CI overhead.
+- **#3353** is open on `release-6.20` for the separate performance-generalization
+  plan parking lane.
+- **#3348** remains open on `release-6.20` for the separate MSVC/toolchain
+  policy lane.
 - The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
   #3324, and #3325 are merged. The perf lane's WP-PG.01 baseline packet
   **#3263** also merged.
@@ -146,9 +149,11 @@ before treating it as an open/active PR.)_
 - **Phase 2 status:** P1-P10 are merged: broadphase, dispatcher, adapter bridge,
   `"native"` registration, sphere/box/capsule/convex/cylinder/mesh/plane
   coverage, distance helpers, mixed-scene parity, and associated parity/
-  performance tests. **Current slice is phase 3 D1:** native detector distance
+  performance tests. **Phase 3 D1 is merged (#3352):** native detector distance
   adapter wiring against the FCL incumbent, bundled with DART 6-style native
-  source/header basenames to avoid another cleanup PR.
+  source/header basenames to avoid another cleanup PR. **Current slice is phase
+  3 D2:** native detector raycast wiring against the Bullet incumbent with
+  native-vs-Bullet raycast benchmark rows.
 - **Default flip:** still late-phase only. Do not flip defaults until `03`'s full
   A/B packet and gz gate pass.
 - _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
@@ -160,8 +165,8 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `b9f4b118e2e80c671df65bb5b58da4166cc284bd`; `origin/main` =
-     `e245f5ed3d577c8ea6ddac44ff3a9e1e752efd27`.
+     `f343528708ef52e520f6f2bdd1a0d371dc38a86b`; `origin/main` =
+     `8b2f3fd941a568bca3e15e9484fba7af5ab0d8d6`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
    - All remote mutations are owned by the maintainer.
@@ -199,10 +204,10 @@ before treating it as an open/active PR.)_
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
 - **Open queue (2026-07-08):** no open native-collision release PRs remain after
-  #3350. Phase 3 D1 is active locally on `feature/native-distance-adapter`; the
+  #3352. Phase 3 D2 is active locally on `feature/native-raycast-adapter`; the
   former #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319, plus
-  #3321/#3322/#3324/#3325/#3343/#3350 lane milestones, and main-branch dual
-  #3283 are merged.
+  #3321/#3322/#3324/#3325/#3343/#3350/#3352 lane milestones, and main-branch
+  dual #3283 are merged.
 - **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE
   optional and eventually drops `fcl` from core. The DART 7 native engine is
   only partially ported to DART 6.20; default-flip is still a late-phase

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -57,11 +57,13 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 - **#3343** phase-2 **P8/P9**: distance module and plane primitive/convex
   coverage.
 - **#3350** phase-2 **P10**: mixed-scene FCL/DART/native parity coverage.
+- **#3352** phase-3 **D1**: native detector distance adapter, DART 6-style
+  native basename normalization, and native-vs-FCL distance benchmarks.
 
-`origin/release-6.20` tip at this refresh: `b9f4b118e2e8` (moves as the
+`origin/release-6.20` tip at this refresh: `f343528708e` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
-## 4. Phase 2 complete; Phase 3 D1 active
+## 4. Phase 2 complete; Phase 3 D2 active
 
 Bridge design (see `07` §0–§1): **bypass DART 7's EnTT `CollisionWorld`**; the
 adapter (`NativeCollisionDetector/Group/Object` + `NativeShapeConversion`)
@@ -81,22 +83,20 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **P8** | `distance` module (engine-only; needs span shim) | ✅ **merged (#3343)**, combined with P9 |
 | **P9** | `plane_sphere` (needs `distance`) → completes primitive+convex+mesh+plane | ✅ **merged (#3343)**, combined with P8 |
 | **P10** | mixed-scene fcl/dart/native parity integration test | ✅ **merged (#3350)** |
+| **D1** | DART 6 `NativeCollisionDetector::distance()` adapter + native basename normalization | ✅ **merged (#3352)** |
+| **D2** | DART 6 `NativeCollisionDetector::raycast()` adapter + native-vs-Bullet raycast benchmarks | 🔄 **active local branch** `feature/native-raycast-adapter` |
 
-### Exact next step: execute Phase 3 D1
+### Exact next step: finish Phase 3 D2
 
-1. Continue with the **Phase 3 D1** branch `feature/native-distance-adapter`,
+1. Continue with the **Phase 3 D2** branch `feature/native-raycast-adapter`,
    based on the current `origin/release-6.20`.
-2. Keep it as one PR: port the native narrowphase distance dispatcher entrypoint,
-   normalize native engine basenames to DART 6 style (`Aabb.hpp`,
-   `NarrowPhase.cpp`, `SphereBox.hpp`, etc.), and wire
-   `NativeCollisionDetector::distance()` to the DART 6
-   `CollisionGroup` contract. Compare supported primitive rows against FCL,
-   including `DistanceOption::distanceLowerBound`, `DistanceFilter`, same-group
-   duplicate skipping, cross-group queries, and `DistanceResult` shape-frame
-   ownership.
-3. Leave raycast, CCD, persistent manifolds, voxel/octree replacement,
-   Bullet/ODE/FCL facades, and the default flip for later phase-3/phase-5/phase-6
-   slices.
+2. Keep it as one PR: port the native narrowphase raycast entrypoint, wire
+   `NativeCollisionDetector::raycast()` to the DART 6 `CollisionGroup`
+   contract, and compare native raycasts against the incumbent Bullet path.
+   Preserve DART 6 `RaycastOption` behavior: closest hit, all hits, optional
+   sorting, object filters, and `result == nullptr`.
+3. Leave CCD, persistent manifolds, voxel/octree replacement, Bullet/ODE/FCL
+   facades, and the default flip for later phase-3/phase-5/phase-6 slices.
 4. Gates for **every** native-collision capability PR:
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
@@ -108,14 +108,16 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 
 ## 5. Open PRs / loose ends
 
-- **Phase 3 D1 native distance adapter** — active on
-  `feature/native-distance-adapter` as one PR-sized slice to minimize CI
+- **Phase 3 D2 native raycast adapter** — active on
+  `feature/native-raycast-adapter` as one PR-sized slice to minimize CI
   overhead.
+- **#3353** is open on `release-6.20` for the separate performance-generalization
+  plan parking lane.
 - **#3283 (main sphere-sphere `enableContact` fix)** — MERGED; main and
   `release-6.20` now agree on the squared binary predicate for the eventual
   phase-6 diff.
-- **#3348** is the only current open `release-6.20` PR seen during this refresh,
-  and it belongs to the separate MSVC/toolchain policy lane.
+- **#3348** remains open on `release-6.20` and belongs to the separate
+  MSVC/toolchain policy lane.
 
 ## 6. Load-bearing invariants (do not violate)
 

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -25,7 +25,7 @@ evidence in `03-native-collision-port-scoping.md` and the dashboard state in
 ## Current Branch State
 
 - `origin/release-6.20` currently points at
-  `b9f4b118e2e80c671df65bb5b58da4166cc284bd`.
+  `f343528708ef52e520f6f2bdd1a0d371dc38a86b`.
 - `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x
   package version (`6.19.3` in the current CMake configure output).
 - DART 6.20 intentionally uses the release lane while package version metadata

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -66,20 +66,20 @@ scope-diff-guarded.
   **merged**.
 - **P10** (mixed-scene FCL/DART/native parity coverage): **#3350** —
   **merged**.
+- **D1** (native detector distance adapter + native basename normalization):
+  **#3352** — **merged**.
 
-**Next: Phase 3 D1 — native detector distance adapter** on
-`feature/native-distance-adapter`. Keep this as one PR: expose
-`NativeCollisionDetector::distance()` through the existing DART 6
-`CollisionGroup`/`DistanceOption`/`DistanceResult` contract, compare supported
-primitive rows against the incumbent FCL distance path, and keep the native
-detector opt-in only. Fold the native engine basename normalization
-(`Aabb.hpp`, `NarrowPhase.cpp`, `SphereBox.hpp`, etc.) into this PR rather than
-opening a separate cleanup PR. **Do not** add a
-`CollisionDetectorType::Native` enum or touch `World`/`ConstraintSolver`/
-`WorldConfig`; FCL remains the default until phase 6.
+**Next: Phase 3 D2 — native detector raycast adapter** on
+`feature/native-raycast-adapter`. Keep this as one PR: expose
+`NativeCollisionDetector::raycast()` through the existing DART 6
+`CollisionGroup`/`RaycastOption`/`RaycastResult` contract, compare supported
+raycast rows against the incumbent Bullet raycast path, and keep the native
+detector opt-in only. **Do not** add a `CollisionDetectorType::Native` enum or
+touch `World`/`ConstraintSolver`/`WorldConfig`; FCL remains the default until
+phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
-PRs, worktrees, gotchas, and exact Phase 3 D1 next steps).
+PRs, worktrees, gotchas, and exact Phase 3 D2 next steps).
 
 ## Standing constraints
 

--- a/tests/benchmark/unit/CMakeLists.txt
+++ b/tests/benchmark/unit/CMakeLists.txt
@@ -28,12 +28,17 @@
 #   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #   POSSIBILITY OF SUCH DAMAGE.
 
+set(unit_benchmark_link_libraries dart dart-baseline-ode)
+
+if(HAVE_BULLET AND TARGET dart-collision-bullet)
+  list(APPEND unit_benchmark_link_libraries dart-collision-bullet)
+endif()
+
 dart_benchmarks(
   TYPE BM_UNIT
   SOURCES
     bm_dantzig_lcp.cpp
     bm_native_collision.cpp
   LINK_LIBRARIES
-    dart
-    dart-baseline-ode
+    ${unit_benchmark_link_libraries}
 )

--- a/tests/benchmark/unit/bm_native_collision.cpp
+++ b/tests/benchmark/unit/bm_native_collision.cpp
@@ -2,6 +2,11 @@
 #include <dart/collision/CollisionGroup.hpp>
 #include <dart/collision/DistanceOption.hpp>
 #include <dart/collision/DistanceResult.hpp>
+#include <dart/collision/RaycastOption.hpp>
+#include <dart/collision/RaycastResult.hpp>
+#if HAVE_BULLET
+  #include <dart/collision/bullet/BulletCollisionDetector.hpp>
+#endif
 #include <dart/collision/fcl/FCLCollisionDetector.hpp>
 #include <dart/collision/native/NativeCollisionDetector.hpp>
 #include <dart/collision/native/Types.hpp>
@@ -189,6 +194,59 @@ void runFclDetectorDistance(
       shapeB,
       translationB);
 }
+
+void runDetectorRaycast(
+    benchmark::State& state,
+    const dart::collision::CollisionDetectorPtr& detector,
+    const dart::dynamics::ShapePtr& shape,
+    const Eigen::Vector3d& translation)
+{
+  auto frame = makeDistanceFrame(shape, translation);
+  auto group = detector->createCollisionGroup(frame.get());
+
+  const Eigen::Vector3d from(-5.0, 0.0, 0.0);
+  const Eigen::Vector3d to(5.0, 0.0, 0.0);
+  dart::collision::RaycastOption option(false, false, nullptr);
+  dart::collision::RaycastResult result;
+  bool hit = false;
+
+  for (auto _ : state) {
+    result.clear();
+    hit = group->raycast(from, to, option, &result);
+    benchmark::DoNotOptimize(hit);
+    benchmark::DoNotOptimize(result.mRayHits.size());
+  }
+
+  if (!hit) {
+    state.SkipWithError("raycast benchmark case did not produce a hit");
+  }
+}
+
+void runNativeDetectorRaycast(
+    benchmark::State& state,
+    const dart::dynamics::ShapePtr& shape,
+    const Eigen::Vector3d& translation = Eigen::Vector3d::Zero())
+{
+  runDetectorRaycast(
+      state,
+      dart::collision::NativeCollisionDetector::create(),
+      shape,
+      translation);
+}
+
+#if HAVE_BULLET
+void runBulletDetectorRaycast(
+    benchmark::State& state,
+    const dart::dynamics::ShapePtr& shape,
+    const Eigen::Vector3d& translation = Eigen::Vector3d::Zero())
+{
+  runDetectorRaycast(
+      state,
+      dart::collision::BulletCollisionDetector::create(),
+      shape,
+      translation);
+}
+#endif
 
 void BM_NativeSphereSphere(benchmark::State& state)
 {
@@ -568,6 +626,36 @@ void BM_DistanceFclPlaneSphere(benchmark::State& state)
       Eigen::Vector3d(0.0, 0.0, 0.75));
 }
 
+void BM_RaycastNativeSphere(benchmark::State& state)
+{
+  runNativeDetectorRaycast(
+      state, std::make_shared<dart::dynamics::SphereShape>(1.0));
+}
+
+void BM_RaycastNativeBox(benchmark::State& state)
+{
+  runNativeDetectorRaycast(
+      state,
+      std::make_shared<dart::dynamics::BoxShape>(
+          Eigen::Vector3d(2.0, 2.0, 2.0)));
+}
+
+#if HAVE_BULLET
+void BM_RaycastBulletSphere(benchmark::State& state)
+{
+  runBulletDetectorRaycast(
+      state, std::make_shared<dart::dynamics::SphereShape>(1.0));
+}
+
+void BM_RaycastBulletBox(benchmark::State& state)
+{
+  runBulletDetectorRaycast(
+      state,
+      std::make_shared<dart::dynamics::BoxShape>(
+          Eigen::Vector3d(2.0, 2.0, 2.0)));
+}
+#endif
+
 } // namespace
 
 BENCHMARK(BM_NativeSphereSphere)->Unit(benchmark::kNanosecond);
@@ -600,3 +688,9 @@ BENCHMARK(BM_DistanceNativeBoxBox)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_DistanceFclBoxBox)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_DistanceNativePlaneSphere)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_DistanceFclPlaneSphere)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RaycastNativeSphere)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RaycastNativeBox)->Unit(benchmark::kNanosecond);
+#if HAVE_BULLET
+BENCHMARK(BM_RaycastBulletSphere)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RaycastBulletBox)->Unit(benchmark::kNanosecond);
+#endif

--- a/tests/benchmark/unit/bm_native_collision.cpp
+++ b/tests/benchmark/unit/bm_native_collision.cpp
@@ -1,3 +1,5 @@
+#include <dart/config.hpp>
+
 #include <dart/collision/CollisionDetector.hpp>
 #include <dart/collision/CollisionGroup.hpp>
 #include <dart/collision/DistanceOption.hpp>

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -435,6 +435,23 @@ TEST(NarrowPhaseDispatch, BoxRaycastPreservesBoundaryStartHit)
   EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitX(), 1e-12));
 }
 
+TEST(NarrowPhaseDispatch, MeshRaycastPreservesBoundaryStartHit)
+{
+  MeshShape mesh = makePlaneMesh();
+
+  RaycastResult result;
+  EXPECT_TRUE(NarrowPhase::raycast(
+      Ray(Eigen::Vector3d::Zero(), -Eigen::Vector3d::UnitZ(), 1.0),
+      &mesh,
+      Eigen::Isometry3d::Identity(),
+      RaycastOption::unlimited(),
+      result));
+  EXPECT_TRUE(result.hit);
+  EXPECT_DOUBLE_EQ(0.0, result.distance);
+  EXPECT_TRUE(result.point.isApprox(Eigen::Vector3d::Zero(), 1e-12));
+  EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitZ(), 1e-12));
+}
+
 TEST(NarrowPhaseDispatch, CapsuleRaycastFromInsideExitsCapSurface)
 {
   CapsuleShape capsule(0.5, 2.0);

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -527,6 +527,30 @@ TEST(NarrowPhaseDispatch, ConvexRaycastFromInsideExitsSurface)
   EXPECT_FALSE(result.hit);
 }
 
+TEST(NarrowPhaseDispatch, ConvexRaycastRejectsEntryAfterBoundaryExit)
+{
+  ConvexShape convex(
+      {{-0.5, -0.5, -0.5},
+       {0.5, -0.5, -0.5},
+       {0.5, 0.5, -0.5},
+       {-0.5, 0.5, -0.5},
+       {-0.5, -0.5, 0.5},
+       {0.5, -0.5, 0.5},
+       {0.5, 0.5, 0.5},
+       {-0.5, 0.5, 0.5}});
+
+  RaycastResult result;
+  EXPECT_FALSE(NarrowPhase::raycast(
+      Ray(Eigen::Vector3d(-1.0, 0.5, 0.0),
+          Eigen::Vector3d(1.0, 1.0, 0.0).normalized(),
+          2.0),
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      RaycastOption::unlimited(),
+      result));
+  EXPECT_FALSE(result.hit);
+}
+
 TEST(NarrowPhaseDispatch, ReportsP9SupportedPairs)
 {
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Sphere));

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -418,6 +418,23 @@ TEST(NarrowPhaseDispatch, CompoundRaycastAcceptsEndpointHit)
   EXPECT_TRUE(result.normal.isApprox(-Eigen::Vector3d::UnitX(), 1e-12));
 }
 
+TEST(NarrowPhaseDispatch, BoxRaycastPreservesBoundaryStartHit)
+{
+  BoxShape box(Eigen::Vector3d(0.5, 0.5, 0.5));
+
+  RaycastResult result;
+  EXPECT_TRUE(NarrowPhase::raycast(
+      Ray(Eigen::Vector3d(0.5, 0.0, 0.0), -Eigen::Vector3d::UnitX(), 2.0),
+      &box,
+      Eigen::Isometry3d::Identity(),
+      RaycastOption::unlimited(),
+      result));
+  EXPECT_TRUE(result.hit);
+  EXPECT_DOUBLE_EQ(0.0, result.distance);
+  EXPECT_TRUE(result.point.isApprox(Eigen::Vector3d(0.5, 0.0, 0.0), 1e-12));
+  EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitX(), 1e-12));
+}
+
 TEST(NarrowPhaseDispatch, CapsuleRaycastFromInsideExitsCapSurface)
 {
   CapsuleShape capsule(0.5, 2.0);

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -418,6 +418,25 @@ TEST(NarrowPhaseDispatch, CompoundRaycastAcceptsEndpointHit)
   EXPECT_TRUE(result.normal.isApprox(-Eigen::Vector3d::UnitX(), 1e-12));
 }
 
+TEST(NarrowPhaseDispatch, CapsuleRaycastFromInsideExitsCapSurface)
+{
+  CapsuleShape capsule(0.5, 2.0);
+
+  const Ray ray(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitZ(), 2.0);
+  RaycastResult result;
+
+  EXPECT_TRUE(NarrowPhase::raycast(
+      ray,
+      &capsule,
+      Eigen::Isometry3d::Identity(),
+      RaycastOption::unlimited(),
+      result));
+  EXPECT_TRUE(result.hit);
+  EXPECT_DOUBLE_EQ(1.5, result.distance);
+  EXPECT_TRUE(result.point.isApprox(Eigen::Vector3d(0.0, 0.0, 1.5), 1e-12));
+  EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitZ(), 1e-12));
+}
+
 TEST(NarrowPhaseDispatch, ReportsP9SupportedPairs)
 {
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Sphere));

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -452,6 +452,28 @@ TEST(NarrowPhaseDispatch, MeshRaycastPreservesBoundaryStartHit)
   EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitZ(), 1e-12));
 }
 
+TEST(NarrowPhaseDispatch, CapsuleRaycastPreservesBoundaryStartHit)
+{
+  CapsuleShape capsule(0.5, 2.0);
+
+  auto expectBoundaryHit = [&](const Eigen::Vector3d& direction) {
+    RaycastResult result;
+    EXPECT_TRUE(NarrowPhase::raycast(
+        Ray(Eigen::Vector3d(0.5, 0.0, 0.0), direction, 2.0),
+        &capsule,
+        Eigen::Isometry3d::Identity(),
+        RaycastOption::unlimited(),
+        result));
+    EXPECT_TRUE(result.hit);
+    EXPECT_DOUBLE_EQ(0.0, result.distance);
+    EXPECT_TRUE(result.point.isApprox(Eigen::Vector3d(0.5, 0.0, 0.0), 1e-12));
+    EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitX(), 1e-12));
+  };
+
+  expectBoundaryHit(Eigen::Vector3d::UnitX());
+  expectBoundaryHit(-Eigen::Vector3d::UnitX());
+}
+
 TEST(NarrowPhaseDispatch, CapsuleRaycastFromInsideExitsCapSurface)
 {
   CapsuleShape capsule(0.5, 2.0);

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -37,6 +37,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -395,6 +396,26 @@ TEST(NarrowPhaseDispatch, BatchRejectsNullShapes)
   EXPECT_THROW(
       NarrowPhase::collideBatch(pairs, results, CollisionOption()),
       std::invalid_argument);
+}
+
+TEST(NarrowPhaseDispatch, CompoundRaycastAcceptsEndpointHit)
+{
+  CompoundShape compound;
+  compound.addChild(std::make_unique<SphereShape>(1.0));
+
+  const Ray ray(Eigen::Vector3d(-2.0, 0.0, 0.0), Eigen::Vector3d::UnitX(), 1.0);
+  RaycastResult result;
+
+  EXPECT_TRUE(NarrowPhase::raycast(
+      ray,
+      &compound,
+      Eigen::Isometry3d::Identity(),
+      RaycastOption::unlimited(),
+      result));
+  EXPECT_TRUE(result.hit);
+  EXPECT_DOUBLE_EQ(1.0, result.distance);
+  EXPECT_TRUE(result.point.isApprox(Eigen::Vector3d(-1.0, 0.0, 0.0), 1e-12));
+  EXPECT_TRUE(result.normal.isApprox(-Eigen::Vector3d::UnitX(), 1e-12));
 }
 
 TEST(NarrowPhaseDispatch, ReportsP9SupportedPairs)

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -437,6 +437,40 @@ TEST(NarrowPhaseDispatch, CapsuleRaycastFromInsideExitsCapSurface)
   EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitZ(), 1e-12));
 }
 
+TEST(NarrowPhaseDispatch, ConvexRaycastFromInsideExitsSurface)
+{
+  ConvexShape convex(
+      {{-0.5, -0.5, -0.5},
+       {0.5, -0.5, -0.5},
+       {0.5, 0.5, -0.5},
+       {-0.5, 0.5, -0.5},
+       {-0.5, -0.5, 0.5},
+       {0.5, -0.5, 0.5},
+       {0.5, 0.5, 0.5},
+       {-0.5, 0.5, 0.5}});
+
+  RaycastResult result;
+  EXPECT_TRUE(NarrowPhase::raycast(
+      Ray(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitX(), 2.0),
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      RaycastOption::unlimited(),
+      result));
+  EXPECT_TRUE(result.hit);
+  EXPECT_DOUBLE_EQ(0.5, result.distance);
+  EXPECT_TRUE(result.point.isApprox(Eigen::Vector3d(0.5, 0.0, 0.0), 1e-12));
+  EXPECT_TRUE(result.normal.isApprox(Eigen::Vector3d::UnitX(), 1e-12));
+
+  result.clear();
+  EXPECT_FALSE(NarrowPhase::raycast(
+      Ray(Eigen::Vector3d::Zero(), Eigen::Vector3d::UnitX(), 0.25),
+      &convex,
+      Eigen::Isometry3d::Identity(),
+      RaycastOption::unlimited(),
+      result));
+  EXPECT_FALSE(result.hit);
+}
+
 TEST(NarrowPhaseDispatch, ReportsP9SupportedPairs)
 {
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Sphere, ShapeType::Sphere));

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -1300,6 +1300,11 @@ TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
       static_cast<const native::ConvexShape*>(nativeConvexMesh.get())
           ->getVertices()
           .size());
+  EXPECT_EQ(
+      6u,
+      static_cast<const native::ConvexShape*>(nativeConvexMesh.get())
+          ->getFaces()
+          .size());
 
   const dynamics::MeshShape meshShape(
       Eigen::Vector3d(2.0, 3.0, 4.0), makePlaneTriMesh());
@@ -1320,6 +1325,11 @@ TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
       5u,
       static_cast<const native::ConvexShape*>(nativePyramid.get())
           ->getVertices()
+          .size());
+  EXPECT_EQ(
+      5u,
+      static_cast<const native::ConvexShape*>(nativePyramid.get())
+          ->getFaces()
           .size());
 }
 

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -34,6 +34,8 @@
 #include <dart/collision/CollisionResult.hpp>
 #include <dart/collision/DistanceFilter.hpp>
 #include <dart/collision/DistanceResult.hpp>
+#include <dart/collision/RaycastOption.hpp>
+#include <dart/collision/RaycastResult.hpp>
 #include <dart/collision/dart/DARTCollisionDetector.hpp>
 #include <dart/collision/fcl/FCLCollisionDetector.hpp>
 #include <dart/collision/native/NativeCollisionDetector.hpp>
@@ -977,6 +979,165 @@ TEST(NativeCollisionDetector, DistanceLeavesMeshPrimitivePairsUnsupported)
       = detector->createCollisionGroup(meshFrame.get(), sphereFrame.get());
   EXPECT_NEAR(
       2.0, unsupportedGroup->distance(lowerBoundOption, nullptr), 1e-12);
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, RaycastReportsClosestHit)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto frame1 = makeFrame(
+      std::make_shared<dynamics::SphereShape>(1.0),
+      Eigen::Vector3d(-2.0, 0.0, 0.0));
+  auto frame2 = makeFrame(
+      std::make_shared<dynamics::SphereShape>(1.0),
+      Eigen::Vector3d(2.0, 0.0, 0.0));
+  auto group = detector->createCollisionGroup(frame1.get(), frame2.get());
+
+  collision::RaycastOption option;
+  collision::RaycastResult result;
+  EXPECT_TRUE(group->raycast(
+      Eigen::Vector3d(-5.0, 0.0, 0.0),
+      Eigen::Vector3d(5.0, 0.0, 0.0),
+      option,
+      &result));
+
+  ASSERT_TRUE(result.hasHit());
+  ASSERT_EQ(1u, result.mRayHits.size());
+  const auto& hit = result.mRayHits[0];
+  EXPECT_EQ(frame1.get(), hit.mCollisionObject->getShapeFrame());
+  EXPECT_TRUE(hit.mPoint.isApprox(Eigen::Vector3d(-3.0, 0.0, 0.0), 1e-12));
+  EXPECT_TRUE(hit.mNormal.isApprox(-Eigen::Vector3d::UnitX(), 1e-12));
+  EXPECT_NEAR(0.2, hit.mFraction, 1e-12);
+
+  EXPECT_TRUE(group->raycast(
+      Eigen::Vector3d(-5.0, 0.0, 0.0),
+      Eigen::Vector3d(5.0, 0.0, 0.0),
+      option,
+      nullptr));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, RaycastRespectsAllHitsSortingAndFilters)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto frame1 = makeFrame(
+      std::make_shared<dynamics::SphereShape>(1.0),
+      Eigen::Vector3d(-2.0, 0.0, 0.0));
+  auto frame2 = makeFrame(
+      std::make_shared<dynamics::SphereShape>(1.0),
+      Eigen::Vector3d(2.0, 0.0, 0.0));
+  auto group = detector->createCollisionGroup(frame1.get(), frame2.get());
+
+  collision::RaycastOption allHitsOption(true, true, nullptr);
+  collision::RaycastResult result;
+  EXPECT_TRUE(group->raycast(
+      Eigen::Vector3d(-5.0, 0.0, 0.0),
+      Eigen::Vector3d(5.0, 0.0, 0.0),
+      allHitsOption,
+      &result));
+
+  ASSERT_TRUE(result.hasHit());
+  ASSERT_EQ(2u, result.mRayHits.size());
+  EXPECT_EQ(frame1.get(), result.mRayHits[0].mCollisionObject->getShapeFrame());
+  EXPECT_NEAR(0.2, result.mRayHits[0].mFraction, 1e-12);
+  EXPECT_EQ(frame2.get(), result.mRayHits[1].mCollisionObject->getShapeFrame());
+  EXPECT_NEAR(0.6, result.mRayHits[1].mFraction, 1e-12);
+
+  collision::RaycastOption filteredOption(
+      false, false, [&](const collision::CollisionObject* object) {
+        return object->getShapeFrame() == frame2.get();
+      });
+  result.clear();
+  EXPECT_TRUE(group->raycast(
+      Eigen::Vector3d(-5.0, 0.0, 0.0),
+      Eigen::Vector3d(5.0, 0.0, 0.0),
+      filteredOption,
+      &result));
+
+  ASSERT_TRUE(result.hasHit());
+  ASSERT_EQ(1u, result.mRayHits.size());
+  EXPECT_EQ(frame2.get(), result.mRayHits[0].mCollisionObject->getShapeFrame());
+  EXPECT_TRUE(result.mRayHits[0].mPoint.isApprox(
+      Eigen::Vector3d(1.0, 0.0, 0.0), 1e-12));
+  EXPECT_NEAR(0.6, result.mRayHits[0].mFraction, 1e-12);
+
+  collision::RaycastOption rejectingOption(
+      false, false, [](const collision::CollisionObject*) { return false; });
+  result.clear();
+  EXPECT_FALSE(group->raycast(
+      Eigen::Vector3d(-5.0, 0.0, 0.0),
+      Eigen::Vector3d(5.0, 0.0, 0.0),
+      rejectingOption,
+      &result));
+  EXPECT_FALSE(result.hasHit());
+  EXPECT_FALSE(group->raycast(
+      Eigen::Vector3d(-5.0, 0.0, 0.0),
+      Eigen::Vector3d(5.0, 0.0, 0.0),
+      rejectingOption,
+      nullptr));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, RaycastCoversPrimitiveRows)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  collision::RaycastOption option;
+
+  auto expectHit = [&](const dynamics::ShapePtr& shape,
+                       const Eigen::Vector3d& from,
+                       const Eigen::Vector3d& to,
+                       const Eigen::Vector3d& point,
+                       const Eigen::Vector3d& normal,
+                       double fraction) {
+    auto frame = makeFrame(shape);
+    auto group = detector->createCollisionGroup(frame.get());
+
+    collision::RaycastResult result;
+    ASSERT_TRUE(group->raycast(from, to, option, &result));
+    ASSERT_TRUE(result.hasHit());
+    ASSERT_EQ(1u, result.mRayHits.size());
+    const auto& hit = result.mRayHits[0];
+    EXPECT_EQ(frame.get(), hit.mCollisionObject->getShapeFrame());
+    EXPECT_TRUE(hit.mPoint.isApprox(point, 1e-12));
+    EXPECT_TRUE(hit.mNormal.isApprox(normal, 1e-12));
+    EXPECT_NEAR(fraction, hit.mFraction, 1e-12);
+  };
+
+  expectHit(
+      std::make_shared<dynamics::SphereShape>(1.0),
+      Eigen::Vector3d(-3.0, 0.0, 0.0),
+      Eigen::Vector3d(3.0, 0.0, 0.0),
+      Eigen::Vector3d(-1.0, 0.0, 0.0),
+      -Eigen::Vector3d::UnitX(),
+      1.0 / 3.0);
+  expectHit(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d(2.0, 2.0, 2.0)),
+      Eigen::Vector3d(-3.0, 0.0, 0.0),
+      Eigen::Vector3d(3.0, 0.0, 0.0),
+      Eigen::Vector3d(-1.0, 0.0, 0.0),
+      -Eigen::Vector3d::UnitX(),
+      1.0 / 3.0);
+  expectHit(
+      std::make_shared<dynamics::CapsuleShape>(0.5, 2.0),
+      Eigen::Vector3d(-3.0, 0.0, 0.0),
+      Eigen::Vector3d(3.0, 0.0, 0.0),
+      Eigen::Vector3d(-0.5, 0.0, 0.0),
+      -Eigen::Vector3d::UnitX(),
+      2.5 / 6.0);
+  expectHit(
+      std::make_shared<dynamics::CylinderShape>(0.5, 2.0),
+      Eigen::Vector3d(-3.0, 0.0, 0.0),
+      Eigen::Vector3d(3.0, 0.0, 0.0),
+      Eigen::Vector3d(-0.5, 0.0, 0.0),
+      -Eigen::Vector3d::UnitX(),
+      2.5 / 6.0);
+  expectHit(
+      std::make_shared<dynamics::PlaneShape>(Eigen::Vector3d::UnitZ(), 0.0),
+      Eigen::Vector3d(0.0, 0.0, 1.0),
+      Eigen::Vector3d(0.0, 0.0, -1.0),
+      Eigen::Vector3d::Zero(),
+      Eigen::Vector3d::UnitZ(),
+      0.5);
 }
 
 //==============================================================================

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -1141,6 +1141,60 @@ TEST(NativeCollisionDetector, RaycastCoversPrimitiveRows)
 }
 
 //==============================================================================
+TEST(NativeCollisionDetector, RaycastCoversConvexRows)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  collision::RaycastOption option;
+
+  auto expectHit = [&](const dynamics::ShapePtr& shape,
+                       const Eigen::Vector3d& from,
+                       const Eigen::Vector3d& to,
+                       const Eigen::Vector3d& point,
+                       const Eigen::Vector3d& normal,
+                       double fraction) {
+    auto frame = makeFrame(shape);
+    auto group = detector->createCollisionGroup(frame.get());
+
+    collision::RaycastResult result;
+    ASSERT_TRUE(group->raycast(from, to, option, &result));
+    ASSERT_TRUE(result.hasHit());
+    ASSERT_EQ(1u, result.mRayHits.size());
+    const auto& hit = result.mRayHits[0];
+    EXPECT_EQ(frame.get(), hit.mCollisionObject->getShapeFrame());
+    EXPECT_TRUE(hit.mPoint.isApprox(point, 1e-12));
+    EXPECT_TRUE(hit.mNormal.isApprox(normal, 1e-12));
+    EXPECT_NEAR(fraction, hit.mFraction, 1e-12);
+  };
+
+  const dynamics::ConvexMeshShape::Vertices thinVertices{
+      {-0.001, -0.1, -0.1},
+      {0.001, -0.1, -0.1},
+      {0.001, 0.1, -0.1},
+      {-0.001, 0.1, -0.1},
+      {-0.001, -0.1, 0.1},
+      {0.001, -0.1, 0.1},
+      {0.001, 0.1, 0.1},
+      {-0.001, 0.1, 0.1}};
+
+  expectHit(
+      std::make_shared<dynamics::ConvexMeshShape>(
+          thinVertices, makeCubeTriangles()),
+      Eigen::Vector3d(-1.0, 0.0, 0.0),
+      Eigen::Vector3d(1.0, 0.0, 0.0),
+      Eigen::Vector3d(-0.001, 0.0, 0.0),
+      -Eigen::Vector3d::UnitX(),
+      0.4995);
+
+  expectHit(
+      std::make_shared<dynamics::PyramidShape>(1.0, 1.0, 1.0),
+      Eigen::Vector3d(-2.0, 0.0, 0.0),
+      Eigen::Vector3d(2.0, 0.0, 0.0),
+      Eigen::Vector3d(-0.25, 0.0, 0.0),
+      Eigen::Vector3d(-2.0, 0.0, 1.0).normalized(),
+      0.4375);
+}
+
+//==============================================================================
 TEST(NativeCollisionDetector, CollidesAcrossGroups)
 {
   auto detector = collision::NativeCollisionDetector::create();

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -118,7 +118,7 @@ dynamics::SimpleFramePtr makeFrame(
 }
 
 //==============================================================================
-class ShapeFramePairCollisionFilter : public collision::CollisionFilter
+class ShapeFramePairCollisionFilter final : public collision::CollisionFilter
 {
 public:
   void addIgnoredPair(
@@ -150,7 +150,7 @@ private:
 };
 
 //==============================================================================
-class ShapeFramePairDistanceFilter : public collision::DistanceFilter
+class ShapeFramePairDistanceFilter final : public collision::DistanceFilter
 {
 public:
   void addIgnoredPair(
@@ -182,7 +182,7 @@ private:
 };
 
 //==============================================================================
-class OrderedShapeFrameDistanceFilter : public collision::DistanceFilter
+class OrderedShapeFrameDistanceFilter final : public collision::DistanceFilter
 {
 public:
   OrderedShapeFrameDistanceFilter(


### PR DESCRIPTION
## Summary

- Adds opt-in native `CollisionDetector::raycast()` support for the native detector's supported DART 6 shape rows.
- Preserves the existing DART 6 raycast contract for closest hit, all hits, optional sorting, object filters, and `result == nullptr`.
- Adds native-vs-Bullet raycast benchmark rows, regression coverage, a changelog entry, and refreshed dependency-minimization task state after #3352 merged.

## Motivation / Problem

- Phase 3 D1 wired native distance queries, but raycast still fell back to the base unsupported path for the opt-in native detector.
- Bullet is the incumbent DART 6 raycast backend. This PR moves the native detector closer to capability parity while keeping FCL as the default detector and keeping Bullet available for gz-physics/gz-sim compatibility.
- This keeps the capability wiring, tests, benchmark evidence, and task-status updates in one PR to reduce CI overhead.

## Changes / Key Changes

- Ports the native raycast narrowphase helpers as `dart/collision/native/narrow_phase/Raycast.{hpp,cpp}` using DART 6 PascalCase file naming.
- Adds `NarrowPhase::raycast()` and `NarrowPhase::isRaycastSupported()` for sphere, box, capsule, cylinder, plane, mesh, convex, and native compound shapes.
- Wires `NativeCollisionDetector::raycast()` through the DART 6 `CollisionGroup` API.
- Converts native raycast hits to DART 6 `RayHit` objects with collision object, hit point, normal, and segment fraction.
- Preserves public `RaycastOption` behavior: closest hit by default, all hits when requested, optional sorting, filters, and early boolean return with `result == nullptr`.
- Disables native backface culling in the adapter path because DART 6's public `RaycastOption` has no backface flag and Bullet is the incumbent behavior.
- Adds native detector raycast unit tests for closest hit, all hits, sorting, filters, null-result queries, and primitive coverage.
- Adds `BM_RaycastNative*` and `BM_RaycastBullet*` benchmark rows for sphere and box raycasts.
- Updates `CHANGELOG.md` and the dependency-minimization handoff/dashboard docs for #3352 merged and Phase 3 D2 active.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Native raycast adapter | Public native `raycast()` calls used the base unsupported detector path. | Public native `raycast()` returns hits for supported native rows. |
| Default detector | FCL remained the default detector. | Unchanged: FCL remains the default detector; native raycast is opt-in through the native detector. |
| Bullet/gz compatibility | Bullet remained available and is the incumbent DART 6 raycast backend. | Unchanged: Bullet remains available; native is measured against Bullet for this capability. |
| Performance evidence | No native adapter raycast timing existed because the adapter was unsupported. | Current-head native-vs-Bullet microbenchmarks cover sphere and box raycasts. |

## Performance Evidence

The base branch has no apples-to-apples native adapter timing because public native raycasts were unsupported. The useful comparison for this PR is current native raycast vs incumbent Bullet raycast for the same shape rows.

Command:

```bash
./build/default/cpp/Release/bin/BM_UNIT_native_collision \
  --benchmark_filter='BM_Raycast' \
  --benchmark_min_time=0.05s \
  --benchmark_repetitions=5 \
  --benchmark_report_aggregates_only=true \
  --benchmark_out=.benchmark_results/native-raycast-adapter/current-raycast.json \
  --benchmark_out_format=json
```

Local host caveat: Google Benchmark reported that CPU scaling was enabled, so these numbers are current-head PR evidence from a local workstation rather than a hard regression gate.

| Row | Native CPU mean | Bullet CPU mean | Bullet/native |
| --- | ---: | ---: | ---: |
| Sphere raycast | 78.9 ns | 202 ns | 2.56x |
| Box raycast | 89.5 ns | 406 ns | 4.54x |

## Testing

- `pixi run cmake --build build/default/cpp/Release --target UNIT_collision_native_detector_adapter BM_UNIT_native_collision --parallel 8`
- Debug focused configure/build using `CMAKE_BUILD_TYPE=Debug` for `UNIT_collision_native_detector_adapter` and `BM_UNIT_native_collision`
- `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native_detector_adapter --output-on-failure`
- `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native --output-on-failure` (19/19 passed)
- `ctest --test-dir build/default/cpp/Release -R '^test_Raycast$' --output-on-failure`
- `ctest --test-dir build/default/cpp/Debug -R UNIT_collision_native_detector_adapter --output-on-failure`
- Raycast benchmark command listed above
- `pixi run lint`
- `pixi run check-lint`
- `pixi run check-lint-spell`
- `git diff --check`
- `git diff --check origin/release-6.20..HEAD`
- `rg -n "entt|std::span" dart/collision/native/narrow_phase/Raycast.cpp dart/collision/native/narrow_phase/Raycast.hpp dart/collision/native/NativeCollisionDetector.cpp dart/collision/native/NativeCollisionDetector.hpp tests/unit/collision/test_NativeCollisionDetector.cpp tests/benchmark/unit/bm_native_collision.cpp` (no matches)
- `DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run -e gazebo test-gz`
  - gz-physics: 199/199 tests passed
  - gz-physics performance/symbol checks: 4/4 passed
  - gz-physics plugin link verification passed
  - gz-sim `INTEGRATION_entity_system` passed against the source-built DART plugin

## Breaking Changes

- [x] None for gz-physics/gz-sim compatibility: default detector behavior and public collision component surfaces remain unchanged.

## Related Issues / PRs (backports)

- Tracks native collision dependency-minimization work for https://github.com/dartsim/dart/issues/3056.
- Follows the native detector distance adapter in https://github.com/dartsim/dart/pull/3352.
- Backports: N/A; this targets `release-6.20`.

---

#### Checklist

- [x] Milestone set (`DART 6.20.0`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: no new public method or class names; `NativeCollisionDetector::raycast()` implements the existing virtual API)
- [x] Add Python bindings (dartpy) if applicable (N/A: no Python binding surface change)
