### PR TITLE
Add native voxel grid compound support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,12 @@
     while adding benchmark rows comparing native and Bullet raycast queries:
     [#3056](https://github.com/dartsim/dart/issues/3056)
 
+  * Add opt-in DART-native `VoxelGridShape` support by converting occupied
+    octree leaves into native compound-box children, routing compound collision
+    through the native child-shape dispatcher, and adding benchmark rows
+    comparing native and FCL VoxelGrid collision queries:
+    [#3358](https://github.com/dartsim/dart/pull/3358)
+
   * Fix FCL primitive contact normal orientation and switch default FCL primitive
     handling to `PRIMITIVE` for `FCLCollisionDetector`, the default constraint
     solver, and SKEL parser fallback paths. Users needing legacy mesh

--- a/dart/collision/native/detail/NativeShapeConversion.cpp
+++ b/dart/collision/native/detail/NativeShapeConversion.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/collision/native/shapes/Shape.hpp"
 #include "dart/common/Console.hpp"
+#include "dart/config.hpp"
 #include "dart/dynamics/BoxShape.hpp"
 #include "dart/dynamics/CapsuleShape.hpp"
 #include "dart/dynamics/ConvexMeshShape.hpp"
@@ -43,6 +44,10 @@
 #include "dart/dynamics/PyramidShape.hpp"
 #include "dart/dynamics/Shape.hpp"
 #include "dart/dynamics/SphereShape.hpp"
+
+#if HAVE_OCTOMAP
+  #include "dart/dynamics/VoxelGridShape.hpp"
+#endif
 
 #include <limits>
 #include <set>
@@ -161,6 +166,36 @@ std::vector<Eigen::Vector3d> makePyramidVertices(
       {0.0, 0.0, 0.5 * height}};
 }
 
+#if HAVE_OCTOMAP
+std::unique_ptr<native::Shape> createVoxelGrid(
+    const dynamics::VoxelGridShape& voxelGrid)
+{
+  auto octree = voxelGrid.getOctree();
+  auto compound = std::make_unique<native::CompoundShape>();
+  if (!octree)
+    return compound;
+
+  const double occupancyThreshold = octree->getOccupancyThres();
+  for (auto it = octree->begin_leafs(), end = octree->end_leafs(); it != end;
+       ++it) {
+    if (it->getOccupancy() < occupancyThreshold)
+      continue;
+
+    const auto coordinate = it.getCoordinate();
+    Eigen::Isometry3d voxelTransform = Eigen::Isometry3d::Identity();
+    voxelTransform.translation()
+        = Eigen::Vector3d(coordinate.x(), coordinate.y(), coordinate.z());
+
+    compound->addChild(
+        std::make_unique<native::BoxShape>(
+            Eigen::Vector3d::Constant(0.5 * it.getSize())),
+        voxelTransform);
+  }
+
+  return compound;
+}
+#endif
+
 } // namespace
 
 //==============================================================================
@@ -224,6 +259,13 @@ std::unique_ptr<native::Shape> NativeShapeConversion::create(
             pyramid.getHeight()),
         shapeType);
   }
+
+#if HAVE_OCTOMAP
+  if (shapeType == dynamics::VoxelGridShape::getStaticType()) {
+    const auto& voxelGrid = static_cast<const dynamics::VoxelGridShape&>(shape);
+    return createVoxelGrid(voxelGrid);
+  }
+#endif
 
   static std::set<std::string> warnedShapeTypes;
   if (warnedShapeTypes.insert(shapeType).second) {

--- a/dart/collision/native/narrow_phase/NarrowPhase.cpp
+++ b/dart/collision/native/narrow_phase/NarrowPhase.cpp
@@ -113,6 +113,11 @@ bool isPlaneDistanceShapeType(ShapeType type)
          || type == ShapeType::Convex || type == ShapeType::Mesh;
 }
 
+bool isCompoundCollisionPeer(ShapeType type)
+{
+  return type != ShapeType::Sdf;
+}
+
 bool collideShapes(
     const Shape* shape1,
     const Eigen::Isometry3d& tf1,
@@ -131,6 +136,88 @@ bool collideShapes(
 
   ShapeType type1 = shape1->getType();
   ShapeType type2 = shape2->getType();
+
+  if (type1 == ShapeType::Compound || type2 == ShapeType::Compound) {
+    if (option.enableContact && result.numContacts() >= option.maxNumContacts)
+      return false;
+
+    bool hit = false;
+    auto collideChild = [&](const Shape* childShape1,
+                            const Eigen::Isometry3d& childTf1,
+                            const Shape* childShape2,
+                            const Eigen::Isometry3d& childTf2) {
+      CollisionOption childOption = option;
+      if (option.enableContact) {
+        const std::size_t existingContacts = result.numContacts();
+        if (existingContacts >= option.maxNumContacts)
+          return true;
+
+        childOption.maxNumContacts = option.maxNumContacts - existingContacts;
+      }
+
+      CollisionResult childResult;
+      if (!collideShapes(
+              childShape1,
+              childTf1,
+              childShape2,
+              childTf2,
+              childOption,
+              childResult)) {
+        return false;
+      }
+
+      hit = true;
+      if (!option.enableContact)
+        return true;
+
+      for (const auto& manifold : childResult.getManifolds())
+        result.addManifold(manifold);
+
+      return result.numContacts() >= option.maxNumContacts;
+    };
+
+    if (type1 == ShapeType::Compound && type2 == ShapeType::Compound) {
+      const auto* compound1 = static_cast<const CompoundShape*>(shape1);
+      const auto* compound2 = static_cast<const CompoundShape*>(shape2);
+      for (const auto& child1 : compound1->children()) {
+        if (!child1.shape)
+          continue;
+
+        const Eigen::Isometry3d childTf1 = tf1 * child1.localTransform;
+        for (const auto& child2 : compound2->children()) {
+          if (!child2.shape)
+            continue;
+
+          const Eigen::Isometry3d childTf2 = tf2 * child2.localTransform;
+          if (collideChild(
+                  child1.shape.get(), childTf1, child2.shape.get(), childTf2))
+            return hit;
+        }
+      }
+    } else if (type1 == ShapeType::Compound) {
+      const auto* compound = static_cast<const CompoundShape*>(shape1);
+      for (const auto& child : compound->children()) {
+        if (!child.shape)
+          continue;
+
+        const Eigen::Isometry3d childTf = tf1 * child.localTransform;
+        if (collideChild(child.shape.get(), childTf, shape2, tf2))
+          return hit;
+      }
+    } else {
+      const auto* compound = static_cast<const CompoundShape*>(shape2);
+      for (const auto& child : compound->children()) {
+        if (!child.shape)
+          continue;
+
+        const Eigen::Isometry3d childTf = tf2 * child.localTransform;
+        if (collideChild(shape1, tf1, child.shape.get(), childTf))
+          return hit;
+      }
+    }
+
+    return hit;
+  }
 
   if (type1 == ShapeType::Sphere && type2 == ShapeType::Sphere) {
     const auto* s1 = static_cast<const SphereShape*>(shape1);
@@ -830,6 +917,15 @@ bool NarrowPhase::raycast(
 
 bool NarrowPhase::isSupported(ShapeType type1, ShapeType type2)
 {
+  if (type1 == ShapeType::Compound && type2 == ShapeType::Compound) {
+    return true;
+  }
+  if (type1 == ShapeType::Compound) {
+    return isCompoundCollisionPeer(type2);
+  }
+  if (type2 == ShapeType::Compound) {
+    return isCompoundCollisionPeer(type1);
+  }
   if (type1 == ShapeType::Sphere && type2 == ShapeType::Sphere) {
     return true;
   }

--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1 (#3352) merged; phase 3 D2 active on `feature/native-raycast-adapter` |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1/D2 (#3352, #3355) merged; phase 3 D3 active on `feature/native-voxelgrid-compound` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -56,6 +56,8 @@
 ### ✅ Merged — CI / hygiene
 - **#3120** stop coverage job double-running tests (merged 2026-06-22) — the coverage-job fix
 - **#3102** ignore `.omo` · **#3100** pixi lockfile · **#3074/#3075** plan + AI workflows import
+- **#3348** centralize MSVC toolchain policy for DART 6 LTS (merged
+  2026-07-08).
 
 ### ✅ Merged — native-collision-port lane
 - **#3123** Speed up DART primitive plane collision — **MERGED & PR closed 2026-06-22 19:05**
@@ -94,6 +96,8 @@
   2026-07-08).
 - **#3352** phase-3 D1 native detector distance queries and native basename
   normalization (merged 2026-07-08).
+- **#3355** phase-3 D2 native detector raycast adapter and native-vs-Bullet
+  raycast benchmarks (merged 2026-07-08).
 - **#3283** main-branch dual for the native sphere-sphere binary-check fix
   (merged 2026-07-07).
 
@@ -110,13 +114,12 @@
 
 ### 🔄 Open — monitoring (checked 2026-07-08)
 
-- **Phase 3 D2** `feature/native-raycast-adapter` — active local slice for
-  native `CollisionDetector::raycast()` parity against Bullet plus native-vs-
-  Bullet raycast benchmarks. Keep it one PR to reduce CI overhead.
+- **Phase 3 D3** `feature/native-voxelgrid-compound` — active local slice for
+  native `VoxelGridShape`/octree replacement via compound voxel boxes. Keep it
+  one PR to reduce CI overhead.
 - **#3353** is open on `release-6.20` for the separate performance-generalization
   plan parking lane.
-- **#3348** remains open on `release-6.20` for the separate MSVC/toolchain
-  policy lane.
+- **#3357** is a draft docs/workflow PR on `release-6.20`.
 - The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
   #3324, and #3325 are merged. The perf lane's WP-PG.01 baseline packet
   **#3263** also merged.
@@ -149,11 +152,11 @@ before treating it as an open/active PR.)_
 - **Phase 2 status:** P1-P10 are merged: broadphase, dispatcher, adapter bridge,
   `"native"` registration, sphere/box/capsule/convex/cylinder/mesh/plane
   coverage, distance helpers, mixed-scene parity, and associated parity/
-  performance tests. **Phase 3 D1 is merged (#3352):** native detector distance
-  adapter wiring against the FCL incumbent, bundled with DART 6-style native
-  source/header basenames to avoid another cleanup PR. **Current slice is phase
-  3 D2:** native detector raycast wiring against the Bullet incumbent with
-  native-vs-Bullet raycast benchmark rows.
+  performance tests. **Phase 3 D1/D2 are merged (#3352/#3355):** native detector
+  distance and raycast adapter wiring against the FCL/Bullet incumbents, bundled
+  with DART 6-style native source/header basenames to avoid another cleanup PR.
+  **Current slice is phase 3 D3:** native VoxelGrid/octree replacement via
+  compound voxel boxes and compound collision routing.
 - **Default flip:** still late-phase only. Do not flip defaults until `03`'s full
   A/B packet and gz gate pass.
 - _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
@@ -165,8 +168,8 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `f343528708ef52e520f6f2bdd1a0d371dc38a86b`; `origin/main` =
-     `8b2f3fd941a568bca3e15e9484fba7af5ab0d8d6`.
+     `e3f7f67211e65d88d16834f331bc40b1f0edaead`; `origin/main` =
+     `c6b5152e777ec1b4607b61a97a82f0d588dfb60f`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
    - All remote mutations are owned by the maintainer.
@@ -204,10 +207,10 @@ before treating it as an open/active PR.)_
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
 - **Open queue (2026-07-08):** no open native-collision release PRs remain after
-  #3352. Phase 3 D2 is active locally on `feature/native-raycast-adapter`; the
+  #3355. Phase 3 D3 is active locally on `feature/native-voxelgrid-compound`; the
   former #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319, plus
-  #3321/#3322/#3324/#3325/#3343/#3350/#3352 lane milestones, and main-branch
-  dual #3283 are merged.
+  #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355 lane milestones, main-branch
+  dual #3283, and MSVC policy #3348 are merged.
 - **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE
   optional and eventually drops `fcl` from core. The DART 7 native engine is
   only partially ported to DART 6.20; default-flip is still a late-phase

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -59,11 +59,13 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 - **#3350** phase-2 **P10**: mixed-scene FCL/DART/native parity coverage.
 - **#3352** phase-3 **D1**: native detector distance adapter, DART 6-style
   native basename normalization, and native-vs-FCL distance benchmarks.
+- **#3355** phase-3 **D2**: native detector raycast adapter and native-vs-Bullet
+  raycast benchmarks.
 
-`origin/release-6.20` tip at this refresh: `f343528708e` (moves as the
+`origin/release-6.20` tip at this refresh: `e3f7f67211e` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
-## 4. Phase 2 complete; Phase 3 D2 active
+## 4. Phase 2 complete; Phase 3 VoxelGrid/compound active
 
 Bridge design (see `07` §0–§1): **bypass DART 7's EnTT `CollisionWorld`**; the
 adapter (`NativeCollisionDetector/Group/Object` + `NativeShapeConversion`)
@@ -84,19 +86,19 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **P9** | `plane_sphere` (needs `distance`) → completes primitive+convex+mesh+plane | ✅ **merged (#3343)**, combined with P8 |
 | **P10** | mixed-scene fcl/dart/native parity integration test | ✅ **merged (#3350)** |
 | **D1** | DART 6 `NativeCollisionDetector::distance()` adapter + native basename normalization | ✅ **merged (#3352)** |
-| **D2** | DART 6 `NativeCollisionDetector::raycast()` adapter + native-vs-Bullet raycast benchmarks | 🔄 **active local branch** `feature/native-raycast-adapter` |
+| **D2** | DART 6 `NativeCollisionDetector::raycast()` adapter + native-vs-Bullet raycast benchmarks | ✅ **merged (#3355)** |
+| **D3** | `VoxelGridShape`/octree replacement via native compound boxes + compound collision recursion | 🔄 **active local branch** `feature/native-voxelgrid-compound` |
 
-### Exact next step: finish Phase 3 D2
+### Exact next step: finish Phase 3 VoxelGrid/compound
 
-1. Continue with the **Phase 3 D2** branch `feature/native-raycast-adapter`,
+1. Continue with the **Phase 3 D3** branch `feature/native-voxelgrid-compound`,
    based on the current `origin/release-6.20`.
-2. Keep it as one PR: port the native narrowphase raycast entrypoint, wire
-   `NativeCollisionDetector::raycast()` to the DART 6 `CollisionGroup`
-   contract, and compare native raycasts against the incumbent Bullet path.
-   Preserve DART 6 `RaycastOption` behavior: closest hit, all hits, optional
-   sorting, object filters, and `result == nullptr`.
-3. Leave CCD, persistent manifolds, voxel/octree replacement, Bullet/ODE/FCL
-   facades, and the default flip for later phase-3/phase-5/phase-6 slices.
+2. Keep it as one PR: convert occupied `dynamics::VoxelGridShape` octree leaves
+   into a native `CompoundShape` of voxel `BoxShape` children, route compound
+   collision through the existing narrowphase child pairs, and cover collision,
+   distance/raycast, and shape-version refresh behavior.
+3. Leave CCD, persistent manifolds, Bullet/ODE/FCL facades, and the default
+   flip for later phase-3/phase-5/phase-6 slices.
 4. Gates for **every** native-collision capability PR:
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
@@ -104,20 +106,20 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
    full `pixi run check-lint`; guard-row hashes unchanged;
    `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz` (199 + 4 + 1); portability
    `rg 'entt|std::span'` on new files → empty; scope-diff touches only
-   `dart/collision/native/**` + its CMakeLists + `tests/**`.
+   `dart/collision/native/**` + its CMakeLists + `tests/**`. Include a scoped
+   performance/complexity note in the PR body; full optimization remains phase 4.
 
 ## 5. Open PRs / loose ends
 
-- **Phase 3 D2 native raycast adapter** — active on
-  `feature/native-raycast-adapter` as one PR-sized slice to minimize CI
+- **Phase 3 D3 VoxelGrid/compound native support** — active on
+  `feature/native-voxelgrid-compound` as one PR-sized slice to minimize CI
   overhead.
 - **#3353** is open on `release-6.20` for the separate performance-generalization
   plan parking lane.
-- **#3283 (main sphere-sphere `enableContact` fix)** — MERGED; main and
-  `release-6.20` now agree on the squared binary predicate for the eventual
-  phase-6 diff.
-- **#3348** remains open on `release-6.20` and belongs to the separate
-  MSVC/toolchain policy lane.
+- **#3357** is a draft docs/workflow PR on `release-6.20`; unrelated to this
+  native-collision code slice.
+- **#3283 (main sphere-sphere `enableContact` fix)** and **#3348** (MSVC
+  toolchain policy) are MERGED.
 
 ## 6. Load-bearing invariants (do not violate)
 
@@ -132,10 +134,10 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 - **gz gate every PR** (`pixi run -e gazebo test-gz`); on engine-only slices it
   is a non-regression guard (trivially green), substantive from P3b onward.
 - **`NarrowPhase.{hpp,cpp}` is a bespoke reduced dispatcher** (`07` §2.1): it is
-  hand-trimmed and re-expands in P4–P9. Each dispatcher-touching PR must keep the
-  `git diff origin/main` reduced to {span shim; dropped `CollisionObject`
-  overloads + Compound + non-routed branches; the `enum class ShapeType;` compile
-  fix}; P9 must re-converge to `main` modulo those deltas.
+  hand-trimmed and re-expands capability-by-capability. Each dispatcher-touching
+  PR must keep the `git diff origin/main` explainable: span shim, dropped
+  `CollisionObject` overloads/world-layer branches, DART 6 compile fixes, and
+  only the current routed capability deltas.
 - **Prefer fewer PRs for remaining phases.** Combine cohesive capability wiring,
   parity coverage, and mechanical native-file cleanup in one PR when the local
   validation envelope remains clear; split only when review risk or ownership

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -25,7 +25,7 @@ evidence in `03-native-collision-port-scoping.md` and the dashboard state in
 ## Current Branch State
 
 - `origin/release-6.20` currently points at
-  `f343528708ef52e520f6f2bdd1a0d371dc38a86b`.
+  `e3f7f67211e65d88d16834f331bc40b1f0edaead`.
 - `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x
   package version (`6.19.3` in the current CMake configure output).
 - DART 6.20 intentionally uses the release lane while package version metadata

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -68,18 +68,19 @@ scope-diff-guarded.
   **merged**.
 - **D1** (native detector distance adapter + native basename normalization):
   **#3352** — **merged**.
+- **D2** (native detector raycast adapter + native-vs-Bullet raycast
+  benchmarks): **#3355** — **merged**.
 
-**Next: Phase 3 D2 — native detector raycast adapter** on
-`feature/native-raycast-adapter`. Keep this as one PR: expose
-`NativeCollisionDetector::raycast()` through the existing DART 6
-`CollisionGroup`/`RaycastOption`/`RaycastResult` contract, compare supported
-raycast rows against the incumbent Bullet raycast path, and keep the native
-detector opt-in only. **Do not** add a `CollisionDetectorType::Native` enum or
-touch `World`/`ConstraintSolver`/`WorldConfig`; FCL remains the default until
-phase 6.
+**Next: Phase 3 D3 — native VoxelGrid/compound support** on
+`feature/native-voxelgrid-compound`. Keep this as one PR: convert occupied
+`VoxelGridShape` octree leaves into native compound-box children, route compound
+collision through the existing narrowphase child pairs, and cover collision,
+distance/raycast, and shape-version refresh behavior. Keep the native detector
+opt-in only. **Do not** add a `CollisionDetectorType::Native` enum or touch
+`World`/`ConstraintSolver`/`WorldConfig`; FCL remains the default until phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
-PRs, worktrees, gotchas, and exact Phase 3 D2 next steps).
+PRs, worktrees, gotchas, and exact Phase 3 D3 next steps).
 
 ## Standing constraints
 

--- a/tests/benchmark/unit/bm_native_collision.cpp
+++ b/tests/benchmark/unit/bm_native_collision.cpp
@@ -2,6 +2,8 @@
 
 #include <dart/collision/CollisionDetector.hpp>
 #include <dart/collision/CollisionGroup.hpp>
+#include <dart/collision/CollisionOption.hpp>
+#include <dart/collision/CollisionResult.hpp>
 #include <dart/collision/DistanceOption.hpp>
 #include <dart/collision/DistanceResult.hpp>
 #include <dart/collision/RaycastOption.hpp>
@@ -20,6 +22,9 @@
 #include <dart/dynamics/PlaneShape.hpp>
 #include <dart/dynamics/SimpleFrame.hpp>
 #include <dart/dynamics/SphereShape.hpp>
+#if HAVE_OCTOMAP
+  #include <dart/dynamics/VoxelGridShape.hpp>
+#endif
 
 #include <Eigen/Geometry>
 #include <benchmark/benchmark.h>
@@ -136,6 +141,85 @@ std::shared_ptr<dart::dynamics::SimpleFrame> makeDistanceFrame(
   frame->setTranslation(translation);
   return frame;
 }
+
+#if HAVE_OCTOMAP
+std::shared_ptr<dart::dynamics::VoxelGridShape> makeOccupiedVoxelGrid()
+{
+  auto voxelGrid = std::make_shared<dart::dynamics::VoxelGridShape>(0.1);
+  voxelGrid->updateOccupancy(Eigen::Vector3d::Zero(), true);
+  return voxelGrid;
+}
+#endif
+
+void runDetectorCollision(
+    benchmark::State& state,
+    const dart::collision::CollisionDetectorPtr& detector,
+    const dart::dynamics::ShapePtr& shapeA,
+    const Eigen::Vector3d& translationA,
+    const dart::dynamics::ShapePtr& shapeB,
+    const Eigen::Vector3d& translationB)
+{
+  auto frameA = makeDistanceFrame(shapeA, translationA);
+  auto frameB = makeDistanceFrame(shapeB, translationB);
+  auto group = detector->createCollisionGroup(frameA.get(), frameB.get());
+
+  dart::collision::CollisionOption option(true, 8u);
+  dart::collision::CollisionResult result;
+  std::size_t contactCount = 0u;
+  bool hit = false;
+
+  for (auto _ : state) {
+    result.clear();
+    hit = group->collide(option, &result);
+    benchmark::DoNotOptimize(hit);
+    benchmark::DoNotOptimize(result.getNumContacts());
+    contactCount += result.getNumContacts();
+  }
+
+  if (!hit) {
+    state.SkipWithError("collision benchmark case did not collide");
+  }
+
+  state.counters["contacts/iter"] = benchmark::Counter(
+      static_cast<double>(contactCount)
+      / static_cast<double>(state.iterations()));
+}
+
+#if HAVE_OCTOMAP
+void runNativeDetectorCollision(
+    benchmark::State& state,
+    const dart::dynamics::ShapePtr& shapeA,
+    const Eigen::Vector3d& translationA,
+    const dart::dynamics::ShapePtr& shapeB,
+    const Eigen::Vector3d& translationB)
+{
+  runDetectorCollision(
+      state,
+      dart::collision::NativeCollisionDetector::create(),
+      shapeA,
+      translationA,
+      shapeB,
+      translationB);
+}
+#endif
+
+#if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
+void runFclDetectorCollision(
+    benchmark::State& state,
+    const dart::dynamics::ShapePtr& shapeA,
+    const Eigen::Vector3d& translationA,
+    const dart::dynamics::ShapePtr& shapeB,
+    const Eigen::Vector3d& translationB)
+{
+  runDetectorCollision(
+      state,
+      dart::collision::FCLCollisionDetector::create(),
+      shapeA,
+      translationA,
+      shapeB,
+      translationB);
+}
+#endif
 
 void runDetectorDistance(
     benchmark::State& state,
@@ -540,6 +624,30 @@ void BM_NativeMeshConvex(benchmark::State& state)
       translated(0.0, 0.0, 0.2));
 }
 
+#if HAVE_OCTOMAP
+void BM_CollisionNativeVoxelGridSphere(benchmark::State& state)
+{
+  runNativeDetectorCollision(
+      state,
+      makeOccupiedVoxelGrid(),
+      Eigen::Vector3d::Zero(),
+      std::make_shared<dart::dynamics::SphereShape>(0.01),
+      Eigen::Vector3d::Zero());
+}
+#endif
+
+#if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
+void BM_CollisionFclVoxelGridSphere(benchmark::State& state)
+{
+  runFclDetectorCollision(
+      state,
+      makeOccupiedVoxelGrid(),
+      Eigen::Vector3d::Zero(),
+      std::make_shared<dart::dynamics::SphereShape>(0.01),
+      Eigen::Vector3d::Zero());
+}
+#endif
+
 void BM_DistanceNativeSphereSphere(benchmark::State& state)
 {
   runNativeDetectorDistance(
@@ -682,6 +790,12 @@ BENCHMARK(BM_NativeMeshSphere)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeMeshBox)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeMeshCapsule)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_NativeMeshConvex)->Unit(benchmark::kNanosecond);
+#if HAVE_OCTOMAP
+BENCHMARK(BM_CollisionNativeVoxelGridSphere)->Unit(benchmark::kNanosecond);
+#endif
+#if HAVE_OCTOMAP && FCL_HAVE_OCTOMAP
+BENCHMARK(BM_CollisionFclVoxelGridSphere)->Unit(benchmark::kNanosecond);
+#endif
 BENCHMARK(BM_DistanceNativeSphereSphere)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_DistanceFclSphereSphere)->Unit(benchmark::kNanosecond);
 BENCHMARK(BM_DistanceNativeSphereBox)->Unit(benchmark::kNanosecond);

--- a/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
+++ b/tests/unit/collision/native/test_narrow_phase_dispatch.cpp
@@ -601,7 +601,9 @@ TEST(NarrowPhaseDispatch, ReportsP9SupportedPairs)
   EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Mesh, ShapeType::Convex));
 
   EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Mesh, ShapeType::Sdf));
-  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Compound, ShapeType::Mesh));
+  EXPECT_TRUE(NarrowPhase::isSupported(ShapeType::Compound, ShapeType::Mesh));
+  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Compound, ShapeType::Sdf));
+  EXPECT_FALSE(NarrowPhase::isSupported(ShapeType::Sdf, ShapeType::Compound));
 }
 
 TEST(NarrowPhaseDispatch, ReportsOnlySupportedPlaneDistanceRows)

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -30,9 +30,12 @@
  *   POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <dart/config.hpp>
+
 #include <dart/collision/CollisionFilter.hpp>
 #include <dart/collision/CollisionResult.hpp>
 #include <dart/collision/DistanceFilter.hpp>
+#include <dart/collision/DistanceOption.hpp>
 #include <dart/collision/DistanceResult.hpp>
 #include <dart/collision/RaycastOption.hpp>
 #include <dart/collision/RaycastResult.hpp>
@@ -55,6 +58,10 @@
 #include <dart/dynamics/PyramidShape.hpp>
 #include <dart/dynamics/SimpleFrame.hpp>
 #include <dart/dynamics/SphereShape.hpp>
+
+#if HAVE_OCTOMAP
+  #include <dart/dynamics/VoxelGridShape.hpp>
+#endif
 
 #include <dart/math/TriMesh.hpp>
 
@@ -1332,6 +1339,97 @@ TEST(NativeCollisionDetector, ConvertsSphereAndBoxShapes)
           ->getFaces()
           .size());
 }
+
+//==============================================================================
+#if HAVE_OCTOMAP
+TEST(NativeCollisionDetector, ConvertsVoxelGridToCompoundShape)
+{
+  dynamics::VoxelGridShape voxelGrid(0.1);
+  voxelGrid.updateOccupancy(Eigen::Vector3d::Zero(), true);
+
+  auto nativeVoxelGrid
+      = collision::detail::NativeShapeConversion::create(voxelGrid);
+  ASSERT_NE(nullptr, nativeVoxelGrid);
+  ASSERT_EQ(native::ShapeType::Compound, nativeVoxelGrid->getType());
+
+  const auto* compound
+      = static_cast<const native::CompoundShape*>(nativeVoxelGrid.get());
+  ASSERT_EQ(1u, compound->numChildren());
+  EXPECT_EQ(native::ShapeType::Box, compound->childShape(0).getType());
+
+  const auto& box
+      = static_cast<const native::BoxShape&>(compound->childShape(0));
+  EXPECT_TRUE(
+      box.getHalfExtents().isApprox(Eigen::Vector3d::Constant(0.05), 1e-12));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, VoxelGridOccupancyUpdatesNativeShape)
+{
+  auto detector = std::make_shared<ExposedNativeCollisionDetector>();
+  auto voxelGrid = std::make_shared<dynamics::VoxelGridShape>(0.1);
+  auto voxelFrame = makeFrame(voxelGrid);
+  auto sphereFrame = makeFrame(std::make_shared<dynamics::SphereShape>(0.01));
+
+  auto group
+      = detector->createCollisionGroup(voxelFrame.get(), sphereFrame.get());
+  auto raycastGroup = detector->createCollisionGroup(voxelFrame.get());
+
+  collision::CollisionOption option(true, 10u);
+  collision::CollisionResult result;
+
+  EXPECT_FALSE(group->collide(option, &result));
+  EXPECT_EQ(0u, result.getNumContacts());
+
+  auto object = detector->claimCollisionObject(voxelFrame.get());
+  auto* nativeObject
+      = dynamic_cast<ExposedNativeCollisionObject*>(object.get());
+  ASSERT_NE(nullptr, nativeObject);
+  ASSERT_NE(nullptr, nativeObject->getNativeShape());
+  ASSERT_EQ(
+      native::ShapeType::Compound, nativeObject->getNativeShape()->getType());
+  const auto* emptyCompound = static_cast<const native::CompoundShape*>(
+      nativeObject->getNativeShape());
+  ASSERT_EQ(0u, emptyCompound->numChildren());
+
+  voxelGrid->updateOccupancy(Eigen::Vector3d::Zero(), true);
+  nativeObject->updateEngineData();
+  ASSERT_NE(nullptr, nativeObject->getNativeShape());
+  ASSERT_EQ(
+      native::ShapeType::Compound, nativeObject->getNativeShape()->getType());
+  const auto* occupiedCompound = static_cast<const native::CompoundShape*>(
+      nativeObject->getNativeShape());
+  ASSERT_EQ(1u, occupiedCompound->numChildren());
+  const Eigen::Vector3d voxelCenter
+      = occupiedCompound->childTransform(0).translation();
+
+  sphereFrame->setTranslation(voxelCenter + Eigen::Vector3d(0.2, 0.0, 0.0));
+  collision::DistanceOption distanceOption(true, 0.0, nullptr);
+  collision::DistanceResult distanceResult;
+  const double distance = group->distance(distanceOption, &distanceResult);
+  ASSERT_TRUE(distanceResult.found());
+  EXPECT_NEAR(0.14, distance, 1e-12);
+  EXPECT_NEAR(0.14, distanceResult.minDistance, 1e-12);
+  EXPECT_EQ(voxelFrame.get(), distanceResult.shapeFrame1);
+  EXPECT_EQ(sphereFrame.get(), distanceResult.shapeFrame2);
+
+  sphereFrame->setTranslation(voxelCenter);
+  result.clear();
+  EXPECT_TRUE(group->collide(option, &result));
+  EXPECT_GE(result.getNumContacts(), 1u);
+
+  collision::RaycastResult raycastResult;
+  EXPECT_TRUE(raycastGroup->raycast(
+      Eigen::Vector3d(-0.2, voxelCenter.y(), voxelCenter.z()),
+      Eigen::Vector3d(0.2, voxelCenter.y(), voxelCenter.z()),
+      collision::RaycastOption(),
+      &raycastResult));
+  ASSERT_EQ(1u, raycastResult.mRayHits.size());
+  EXPECT_EQ(
+      voxelFrame.get(),
+      raycastResult.mRayHits[0].mCollisionObject->getShapeFrame());
+}
+#endif
 
 //==============================================================================
 TEST(NativeCollisionDetector, LeavesUnsupportedShapesNull)


### PR DESCRIPTION
## Summary

- Adds opt-in native `VoxelGridShape` support by converting occupied octree leaves into native compound-box children.
- Routes native compound collision through existing narrowphase child pairs so voxel grids participate in collision, distance, and raycast queries through the native detector.
- Adds native-vs-FCL VoxelGrid collision benchmark rows, regression coverage, a changelog entry, and refreshed dependency-minimization task state after #3355 merged.

## Motivation / Problem

- The native detector can now handle direct primitive, mesh, distance, and raycast rows, but `VoxelGridShape` still converted to `nullptr` and remained unusable through the native detector.
- DART 6 keeps FCL as the default detector until the late default-flip phase, but the opt-in native detector needs a clean native octree replacement path to continue reducing dependency pressure.
- This keeps the conversion, compound routing, tests, benchmark evidence, changelog, and task-status updates in one PR to minimize CI overhead.

## Changes / Key Changes

- Converts `dynamics::VoxelGridShape` to a native `CompoundShape` containing one native `BoxShape` child per occupied octree leaf.
- Preserves empty voxel grids as empty native compounds and refreshes native shape data when voxel occupancy changes.
- Adds compound-vs-compound, compound-vs-shape, and shape-vs-compound collision recursion in `NarrowPhase` while preserving the caller's contact budget.
- Keeps compound support table routing precise for collision: compound rows are routable except SDF collision rows, which remain unsupported.
- Adds adapter tests for VoxelGrid conversion, occupancy refresh, collision, distance, and raycast behavior.
- Adds `BM_CollisionNativeVoxelGridSphere` and `BM_CollisionFclVoxelGridSphere` benchmark rows when OctoMap support is available.
- Updates `CHANGELOG.md` and the dependency-minimization handoff/dashboard docs for #3355 merged and Phase 3 D3 active.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Native VoxelGrid conversion | `VoxelGridShape` was unsupported and converted to `nullptr`. | Occupied voxels convert to native compound-box children; empty grids convert to empty compounds. |
| Native compound collision | Compound shapes were available for bounds/distance/raycast but not collision-routed. | Compound collision recursively dispatches each child pair through existing native narrowphase rows. |
| Default detector | FCL remained the default detector. | Unchanged: native VoxelGrid support is opt-in through the native detector. |
| Performance evidence | No native VoxelGrid collision row existed for the adapter path. | Native-vs-FCL VoxelGrid/sphere microbenchmarks cover the new workload. |

## Performance Evidence

The useful comparison for this PR is current native VoxelGrid collision vs the incumbent FCL OctoMap-backed VoxelGrid collision for the same one-occupied-voxel/sphere public workload.

Command:

```bash
./build/default/cpp/Release/bin/BM_UNIT_native_collision \
  --benchmark_filter='BM_Collision.*VoxelGridSphere' \
  --benchmark_min_time=0.20s \
  --benchmark_repetitions=5 \
  --benchmark_out=/tmp/native_voxelgrid_compound_benchmark.json \
  --benchmark_out_format=json
```

Local host caveats: Google Benchmark reported CPU scaling enabled and the FCL row was noisy, so these are scoped PR evidence for the new workload rather than a hard regression gate.

| Row | CPU mean | CPU median | Contacts/iter |
| --- | ---: | ---: | ---: |
| Native VoxelGridSphere | 320 ns | 320 ns | 1.0 |
| FCL VoxelGridSphere | 3313 ns | 3535 ns | 1.0 |

Native was about 10.3x faster by mean and 11.0x faster by median for this single-occupied-voxel workload.

## Testing

- `cmake --build build/default/cpp/Release --target UNIT_collision_native_detector_adapter UNIT_collision_native_narrow_phase_dispatch BM_UNIT_native_collision --parallel 8`
- `cmake --build build/default/cpp/Debug --target UNIT_collision_native_detector_adapter UNIT_collision_native_narrow_phase_dispatch --parallel 8`
- `ctest --test-dir build/default/cpp/Release -R '^UNIT_collision_native' --output-on-failure` (19/19 passed)
- `ctest --test-dir build/default/cpp/Debug -R '^UNIT_collision_native_(detector_adapter|narrow_phase_dispatch)$' --output-on-failure` (2/2 passed)
- VoxelGrid benchmark command listed above
- `pixi run lint`
- `pixi run check-lint`
- `pixi run build`
- `git diff --check`
- `git diff --check origin/release-6.20..HEAD`
- `rg -n "entt|EnTT|#include <span>|std::span" dart/collision/native/detail/NativeShapeConversion.cpp dart/collision/native/narrow_phase/NarrowPhase.cpp tests/unit/collision/test_NativeCollisionDetector.cpp tests/unit/collision/native/test_narrow_phase_dispatch.cpp tests/benchmark/unit/bm_native_collision.cpp` (no matches)
- `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz`
  - gz-physics: 199/199 tests passed
  - gz-physics performance/symbol checks: 4/4 passed
  - gz-physics plugin link verification passed
  - gz-sim `INTEGRATION_entity_system` passed against the source-built DART plugin

## Breaking Changes

- [x] None for gz-physics/gz-sim compatibility: the default detector and public collision component surfaces remain unchanged.

## Related Issues / PRs (backports)

- Tracks native collision dependency-minimization work for https://github.com/dartsim/dart/issues/3056.
- Follows the native detector raycast adapter in https://github.com/dartsim/dart/pull/3355.
- Backports: N/A; this targets `release-6.20`.

---

#### Checklist

- [x] Milestone set (`DART 6.20.0`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (N/A: no new public method or class names; this implements existing native detector shape support)
- [x] Add Python bindings (dartpy) if applicable (N/A: no Python binding surface change)
