### PR TITLE
Add native CCD support

### DIFF
--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -30,12 +30,14 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CapsuleBox.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CapsuleCapsule.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CapsuleSphere.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Ccd.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/ConvexConvex.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CylinderCollision.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Distance.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/MeshMesh.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/PlaneSphere.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Raycast.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/PrimitiveCcd.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereBox.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereSphere.hpp
 )
@@ -88,12 +90,14 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CapsuleBox.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CapsuleCapsule.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CapsuleSphere.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Ccd.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/ConvexConvex.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/CylinderCollision.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Distance.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/MeshMesh.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/PlaneSphere.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Raycast.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/PrimitiveCcd.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereBox.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereSphere.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/BruteForce.cpp

--- a/dart/collision/native/narrow_phase/Ccd.cpp
+++ b/dart/collision/native/narrow_phase/Ccd.cpp
@@ -333,7 +333,7 @@ bool sphereCastSphere(
   const double b = 2.0 * f.dot(d);
   const double c = f.squaredNorm() - combinedRadius * combinedRadius;
 
-  if (c < 0.0) {
+  if (c <= 0.0) {
     result.hit = true;
     result.timeOfImpact = 0.0;
     result.point = sphereStart;

--- a/dart/collision/native/narrow_phase/Ccd.cpp
+++ b/dart/collision/native/narrow_phase/Ccd.cpp
@@ -96,6 +96,208 @@ void updateBestCcdResult(
   }
 }
 
+Eigen::Vector3d normalizedOr(
+    const Eigen::Vector3d& value, const Eigen::Vector3d& fallback)
+{
+  if (value.squaredNorm() < kEpsilon) {
+    return fallback;
+  }
+  return value.normalized();
+}
+
+Eigen::Vector3d getCapsuleEndpoint(
+    const Eigen::Isometry3d& transform, double halfHeight, bool top)
+{
+  Eigen::Vector3d localPoint(0, 0, top ? halfHeight : -halfHeight);
+  return transform * localPoint;
+}
+
+// Samples a rigid motion start -> end at parameter t in [0, 1]. Endpoint
+// quaternions are built once at construction so the conservative-advancement
+// loop pays only a slerp (or nothing, for translation) per iteration instead of
+// reconstructing quaternions from rotation matrices every step.
+class MotionSample
+{
+public:
+  MotionSample(const Eigen::Isometry3d& start, const Eigen::Isometry3d& end)
+    : startTranslation_(start.translation()),
+      endTranslation_(end.translation()),
+      startRotation_(start.rotation()),
+      rotates_(!startRotation_.isApprox(end.rotation())),
+      qStart_(startRotation_),
+      qEnd_(end.rotation())
+  {
+  }
+
+  [[nodiscard]] Eigen::Isometry3d at(double t) const
+  {
+    Eigen::Isometry3d result = Eigen::Isometry3d::Identity();
+    result.translation() = (1.0 - t) * startTranslation_ + t * endTranslation_;
+    // Translation-only motion skips the slerp; rotational motion reuses the
+    // cached endpoint quaternions.
+    result.linear() = rotates_ ? qStart_.slerp(t, qEnd_).toRotationMatrix()
+                               : startRotation_;
+    return result;
+  }
+
+private:
+  Eigen::Vector3d startTranslation_;
+  Eigen::Vector3d endTranslation_;
+  Eigen::Matrix3d startRotation_;
+  bool rotates_;
+  Eigen::Quaterniond qStart_;
+  Eigen::Quaterniond qEnd_;
+};
+
+double computeCapsuleMotionBound(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& transformStart,
+    const Eigen::Isometry3d& transformEnd)
+{
+  const double linearVelocity
+      = (transformEnd.translation() - transformStart.translation()).norm();
+
+  const Eigen::Quaterniond qStart(transformStart.rotation());
+  const Eigen::Quaterniond qEnd(transformEnd.rotation());
+  const double angle = qStart.angularDistance(qEnd);
+
+  const double maxRadius = capsule.getHeight() / 2.0 + capsule.getRadius();
+  return linearVelocity + angle * maxRadius;
+}
+
+// World-space support functions for the convex primitive targets (the shape
+// classes do not expose support(), so they are provided analytically here).
+Eigen::Vector3d sphereSupport(
+    const Eigen::Vector3d& center,
+    double radius,
+    const Eigen::Vector3d& direction)
+{
+  return center + radius * normalizedOr(direction, Eigen::Vector3d::UnitX());
+}
+
+Eigen::Vector3d boxSupport(
+    const Eigen::Isometry3d& transform,
+    const Eigen::Vector3d& halfExtents,
+    const Eigen::Vector3d& direction)
+{
+  const Eigen::Vector3d localDir = transform.rotation().transpose() * direction;
+  const Eigen::Vector3d localPoint(
+      std::copysign(halfExtents.x(), localDir.x()),
+      std::copysign(halfExtents.y(), localDir.y()),
+      std::copysign(halfExtents.z(), localDir.z()));
+  return transform * localPoint;
+}
+
+Eigen::Vector3d getCapsuleSupport(
+    const Eigen::Isometry3d& transform,
+    const CapsuleShape& capsule,
+    const Eigen::Vector3d& direction)
+{
+  const Eigen::Vector3d worldDir
+      = normalizedOr(direction, Eigen::Vector3d::UnitZ());
+  const Eigen::Vector3d localDir = transform.rotation().transpose() * worldDir;
+  const double halfHeight = capsule.getHeight() / 2.0;
+  const Eigen::Vector3d localEndpoint(
+      0.0, 0.0, localDir.z() >= 0.0 ? halfHeight : -halfHeight);
+  return transform * localEndpoint + capsule.getRadius() * worldDir;
+}
+
+Eigen::Vector3d cylinderSupport(
+    const Eigen::Isometry3d& transform,
+    double radius,
+    double halfHeight,
+    const Eigen::Vector3d& direction)
+{
+  const Eigen::Vector3d localDir = transform.rotation().transpose() * direction;
+  Eigen::Vector3d localPoint(0.0, 0.0, std::copysign(halfHeight, localDir.z()));
+  const double radial
+      = std::sqrt(localDir.x() * localDir.x() + localDir.y() * localDir.y());
+  if (radial > kEpsilon) {
+    localPoint.x() = radius * localDir.x() / radial;
+    localPoint.y() = radius * localDir.y() / radial;
+  }
+  return transform * localPoint;
+}
+
+// Conservative advancement of a moving sphere against any static convex target
+// supplied as a world-space support function. This mirrors the ConvexShape
+// sphere cast but also lets primitive targets with analytic support (cylinders,
+// capsules) cover rounded edge cases that slab/quadratic decompositions miss.
+template <typename TargetSupport>
+bool sphereCastConvexTarget(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const TargetSupport& targetSupport,
+    const Eigen::Vector3d& targetSeed,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  double motionBound = (sphereEnd - sphereStart).norm();
+  if (motionBound < option.tolerance) {
+    motionBound = option.tolerance;
+  }
+
+  double t = 0.0;
+
+  Eigen::Vector3d initialDir = targetSeed - sphereStart;
+  if (initialDir.squaredNorm() < kEpsilon) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
+    const Eigen::Vector3d currentCenter
+        = sphereStart + t * (sphereEnd - sphereStart);
+
+    auto supportA = [&](const Eigen::Vector3d& dir) {
+      return sphereSupport(currentCenter, sphereRadius, dir);
+    };
+
+    GjkResult gjkResult = detail::queryT(supportA, targetSupport, initialDir);
+
+    if (gjkResult.intersecting) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = targetSupport(Eigen::Vector3d::UnitX());
+      result.normal = normalizedOr(
+          currentCenter - result.point, Eigen::Vector3d::UnitZ());
+      return true;
+    }
+
+    const Eigen::Vector3d pointA = gjkResult.closestPointA;
+    const Eigen::Vector3d pointB = gjkResult.closestPointB;
+    const double distance = gjkResult.distance;
+
+    Eigen::Vector3d sepAxis = gjkResult.separationAxis;
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = pointB - pointA;
+    }
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = Eigen::Vector3d::UnitX();
+    }
+    sepAxis.normalize();
+
+    if (distance < option.tolerance) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = pointB;
+      result.normal = sepAxis;
+      return true;
+    }
+
+    t += distance / motionBound;
+    if (t > 1.0) {
+      return false;
+    }
+
+    initialDir = sepAxis;
+  }
+
+  return false;
+}
+
 } // namespace
 
 bool sphereCastSphere(
@@ -264,6 +466,28 @@ bool sphereCastCapsule(
   const Eigen::Vector3d localEnd = invTransform * sphereEnd;
   const Eigen::Vector3d localDir = localEnd - localStart;
 
+  const double closestZ = std::clamp(localStart.z(), -halfHeight, halfHeight);
+  const Eigen::Vector3d closestAxisPoint(0.0, 0.0, closestZ);
+  const Eigen::Vector3d initialDelta = localStart - closestAxisPoint;
+  if (initialDelta.squaredNorm() <= combinedRadius * combinedRadius) {
+    Eigen::Vector3d localNormal
+        = normalizedOr(initialDelta, Eigen::Vector3d::UnitX());
+    if (initialDelta.squaredNorm() < kEpsilon) {
+      if (localStart.z() >= halfHeight) {
+        localNormal = Eigen::Vector3d::UnitZ();
+      } else if (localStart.z() <= -halfHeight) {
+        localNormal = -Eigen::Vector3d::UnitZ();
+      }
+    }
+
+    result.hit = true;
+    result.timeOfImpact = 0.0;
+    result.normal = targetTransform.rotation() * localNormal;
+    result.point
+        = targetTransform * (closestAxisPoint + capsuleRadius * localNormal);
+    return true;
+  }
+
   double bestT = 2.0;
   Eigen::Vector3d bestNormal = Eigen::Vector3d::UnitZ();
   Eigen::Vector3d bestPoint = Eigen::Vector3d::Zero();
@@ -278,7 +502,8 @@ bool sphereCastCapsule(
     if (t >= 0.0 && t <= 1.0 && t < bestT) {
       bestT = t;
       Eigen::Vector3d hitCenter = localStart + t * localDir;
-      bestNormal = (hitCenter - capCenter).normalized();
+      bestNormal
+          = normalizedOr(hitCenter - capCenter, Eigen::Vector3d::UnitZ());
       bestPoint = capCenter + capsuleRadius * bestNormal;
     }
   };
@@ -377,7 +602,6 @@ bool sphereCastCylinder(
     const CcdOption& option,
     CcdResult& result)
 {
-  (void)option;
   result.clear();
 
   const double cylinderRadius = target.getRadius();
@@ -388,6 +612,59 @@ bool sphereCastCylinder(
   const Eigen::Vector3d localStart = invTransform * sphereStart;
   const Eigen::Vector3d localEnd = invTransform * sphereEnd;
   const Eigen::Vector3d localDir = localEnd - localStart;
+
+  const double startRadial = std::sqrt(
+      localStart.x() * localStart.x() + localStart.y() * localStart.y());
+  const double closestRadius = std::min(startRadial, cylinderRadius);
+  const double closestZ = std::clamp(localStart.z(), -halfHeight, halfHeight);
+  Eigen::Vector3d closestOnCylinder(0.0, 0.0, closestZ);
+  if (startRadial > kEpsilon) {
+    closestOnCylinder.x() = closestRadius * localStart.x() / startRadial;
+    closestOnCylinder.y() = closestRadius * localStart.y() / startRadial;
+  }
+
+  const Eigen::Vector3d initialDelta = localStart - closestOnCylinder;
+  if (initialDelta.squaredNorm() <= sphereRadius * sphereRadius) {
+    Eigen::Vector3d localNormal
+        = normalizedOr(initialDelta, Eigen::Vector3d::UnitX());
+    Eigen::Vector3d localPoint = closestOnCylinder;
+
+    if (initialDelta.squaredNorm() < kEpsilon) {
+      Eigen::Vector3d radialNormal = Eigen::Vector3d::UnitX();
+      if (startRadial > kEpsilon) {
+        radialNormal = Eigen::Vector3d(
+            localStart.x() / startRadial, localStart.y() / startRadial, 0.0);
+      }
+
+      double nearestDistance = cylinderRadius - startRadial;
+      localNormal = radialNormal;
+      localPoint = Eigen::Vector3d(
+          cylinderRadius * radialNormal.x(),
+          cylinderRadius * radialNormal.y(),
+          localStart.z());
+
+      const double topDistance = halfHeight - localStart.z();
+      if (topDistance < nearestDistance) {
+        nearestDistance = topDistance;
+        localNormal = Eigen::Vector3d::UnitZ();
+        localPoint
+            = Eigen::Vector3d(localStart.x(), localStart.y(), halfHeight);
+      }
+
+      const double bottomDistance = localStart.z() + halfHeight;
+      if (bottomDistance < nearestDistance) {
+        localNormal = -Eigen::Vector3d::UnitZ();
+        localPoint
+            = Eigen::Vector3d(localStart.x(), localStart.y(), -halfHeight);
+      }
+    }
+
+    result.hit = true;
+    result.timeOfImpact = 0.0;
+    result.normal = targetTransform.rotation() * localNormal;
+    result.point = targetTransform * localPoint;
+    return true;
+  }
 
   double bestT = 2.0;
   Eigen::Vector3d bestNormal = Eigen::Vector3d::UnitZ();
@@ -438,6 +715,24 @@ bool sphereCastCylinder(
     }
   }
 
+  CcdResult supportResult;
+  if (sphereCastConvexTarget(
+          sphereStart,
+          sphereEnd,
+          sphereRadius,
+          [&](const Eigen::Vector3d& dir) {
+            return cylinderSupport(
+                targetTransform, cylinderRadius, halfHeight, dir);
+          },
+          targetTransform.translation(),
+          option,
+          supportResult)
+      && (bestT > 1.0
+          || supportResult.timeOfImpact + option.tolerance < bestT)) {
+    result = supportResult;
+    return true;
+  }
+
   if (bestT > 1.0) {
     return false;
   }
@@ -459,98 +754,17 @@ bool sphereCastConvex(
     const CcdOption& option,
     CcdResult& result)
 {
-  result.clear();
-
-  Eigen::Isometry3d sphereTransformStart = Eigen::Isometry3d::Identity();
-  sphereTransformStart.translation() = sphereStart;
-  Eigen::Isometry3d sphereTransformEnd = Eigen::Isometry3d::Identity();
-  sphereTransformEnd.translation() = sphereEnd;
-
-  double motionBound = (sphereEnd - sphereStart).norm();
-  if (motionBound < option.tolerance) {
-    motionBound = option.tolerance;
-  }
-
-  double t = 0.0;
-
-  Eigen::Vector3d initialDir = targetTransform.translation() - sphereStart;
-  if (initialDir.squaredNorm() < kEpsilon) {
-    initialDir = Eigen::Vector3d::UnitX();
-  }
-
-  // Clamp to >= 1 so a zero/negative budget still tests the t = 0 overlap.
-  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
-    Eigen::Vector3d currentCenter = sphereStart + t * (sphereEnd - sphereStart);
-
-    const double centerX = currentCenter.x();
-    const double centerY = currentCenter.y();
-    const double centerZ = currentCenter.z();
-    auto supportA =
-        [centerX, centerY, centerZ, sphereRadius](const Eigen::Vector3d& dir) {
-          Eigen::Vector3d worldDir = dir;
-          if (worldDir.squaredNorm() < kEpsilon) {
-            worldDir = Eigen::Vector3d::UnitZ();
-          } else {
-            worldDir.normalize();
-          }
-          return Eigen::Vector3d(
-              centerX + sphereRadius * worldDir.x(),
-              centerY + sphereRadius * worldDir.y(),
-              centerZ + sphereRadius * worldDir.z());
-        };
-    auto supportB = [&](const Eigen::Vector3d& dir) {
-      return targetTransform
-             * target.support(targetTransform.rotation().transpose() * dir);
-    };
-
-    GjkResult gjkResult = detail::queryT(supportA, supportB, initialDir);
-
-    if (gjkResult.intersecting) {
-      result.hit = true;
-      result.timeOfImpact = t;
-      Eigen::Vector3d pointB = supportB(Eigen::Vector3d::UnitX());
-      result.point = pointB;
-      const Eigen::Vector3d normal = currentCenter - pointB;
-      if (normal.squaredNorm() < kEpsilon) {
-        result.normal = Eigen::Vector3d::UnitZ();
-      } else {
-        result.normal = normal.normalized();
-      }
-      return true;
-    }
-
-    Eigen::Vector3d pointA = gjkResult.closestPointA;
-    Eigen::Vector3d pointB = gjkResult.closestPointB;
-    double distance = gjkResult.distance;
-
-    Eigen::Vector3d sepAxis = gjkResult.separationAxis;
-    if (sepAxis.squaredNorm() < kEpsilon) {
-      sepAxis = pointB - pointA;
-    }
-    if (sepAxis.squaredNorm() < kEpsilon) {
-      sepAxis = Eigen::Vector3d::UnitX();
-    }
-    sepAxis.normalize();
-
-    if (distance < option.tolerance) {
-      result.hit = true;
-      result.timeOfImpact = t;
-      result.point = pointB;
-      result.normal = sepAxis;
-      return true;
-    }
-
-    double dt = distance / motionBound;
-    t += dt;
-
-    if (t > 1.0) {
-      return false;
-    }
-
-    initialDir = sepAxis;
-  }
-
-  return false;
+  return sphereCastConvexTarget(
+      sphereStart,
+      sphereEnd,
+      sphereRadius,
+      [&](const Eigen::Vector3d& dir) {
+        return targetTransform
+               * target.support(targetTransform.rotation().transpose() * dir);
+      },
+      targetTransform.translation(),
+      option,
+      result);
 }
 
 bool sphereCastMesh(
@@ -592,85 +806,6 @@ bool sphereCastMesh(
 }
 
 namespace {
-
-Eigen::Vector3d getCapsuleEndpoint(
-    const Eigen::Isometry3d& transform, double halfHeight, bool top)
-{
-  Eigen::Vector3d localPoint(0, 0, top ? halfHeight : -halfHeight);
-  return transform * localPoint;
-}
-
-// Samples a rigid motion start -> end at parameter t in [0, 1]. Endpoint
-// quaternions are built once at construction so the conservative-advancement
-// loop pays only a slerp (or nothing, for translation) per iteration instead of
-// reconstructing quaternions from rotation matrices every step.
-class MotionSample
-{
-public:
-  MotionSample(const Eigen::Isometry3d& start, const Eigen::Isometry3d& end)
-    : startTranslation_(start.translation()),
-      endTranslation_(end.translation()),
-      startRotation_(start.rotation()),
-      rotates_(!startRotation_.isApprox(end.rotation())),
-      qStart_(startRotation_),
-      qEnd_(end.rotation())
-  {
-  }
-
-  [[nodiscard]] Eigen::Isometry3d at(double t) const
-  {
-    Eigen::Isometry3d result = Eigen::Isometry3d::Identity();
-    result.translation() = (1.0 - t) * startTranslation_ + t * endTranslation_;
-    // Translation-only motion skips the slerp; rotational motion reuses the
-    // cached endpoint quaternions.
-    result.linear() = rotates_ ? qStart_.slerp(t, qEnd_).toRotationMatrix()
-                               : startRotation_;
-    return result;
-  }
-
-private:
-  Eigen::Vector3d startTranslation_;
-  Eigen::Vector3d endTranslation_;
-  Eigen::Matrix3d startRotation_;
-  bool rotates_;
-  Eigen::Quaterniond qStart_;
-  Eigen::Quaterniond qEnd_;
-};
-
-double computeCapsuleMotionBound(
-    const CapsuleShape& capsule,
-    const Eigen::Isometry3d& transformStart,
-    const Eigen::Isometry3d& transformEnd)
-{
-  const double linearVelocity
-      = (transformEnd.translation() - transformStart.translation()).norm();
-
-  const Eigen::Quaterniond qStart(transformStart.rotation());
-  const Eigen::Quaterniond qEnd(transformEnd.rotation());
-  const double angle = qStart.angularDistance(qEnd);
-
-  const double maxRadius = capsule.getHeight() / 2.0 + capsule.getRadius();
-  return linearVelocity + angle * maxRadius;
-}
-
-Eigen::Vector3d getCapsuleSupport(
-    const Eigen::Isometry3d& transform,
-    const CapsuleShape& capsule,
-    const Eigen::Vector3d& direction)
-{
-  Eigen::Vector3d worldDir = direction;
-  if (worldDir.squaredNorm() < kEpsilon) {
-    worldDir = Eigen::Vector3d::UnitZ();
-  } else {
-    worldDir.normalize();
-  }
-
-  const Eigen::Vector3d localDir = transform.rotation().transpose() * worldDir;
-  const double halfHeight = capsule.getHeight() / 2.0;
-  const Eigen::Vector3d localEndpoint(
-      0.0, 0.0, localDir.z() >= 0.0 ? halfHeight : -halfHeight);
-  return transform * localEndpoint + capsule.getRadius() * worldDir;
-}
 
 // Conservative advancement of a moving capsule against any static convex
 // target, given the target's world-space support function. Uses the full
@@ -761,52 +896,6 @@ bool capsuleCastConvexTarget(
   return false;
 }
 
-// World-space support functions for the convex primitive targets (the shape
-// classes do not expose support(), so they are provided analytically here).
-Eigen::Vector3d sphereSupport(
-    const Eigen::Vector3d& center,
-    double radius,
-    const Eigen::Vector3d& direction)
-{
-  Eigen::Vector3d n = direction;
-  if (n.squaredNorm() < kEpsilon) {
-    n = Eigen::Vector3d::UnitX();
-  } else {
-    n.normalize();
-  }
-  return center + radius * n;
-}
-
-Eigen::Vector3d boxSupport(
-    const Eigen::Isometry3d& transform,
-    const Eigen::Vector3d& halfExtents,
-    const Eigen::Vector3d& direction)
-{
-  const Eigen::Vector3d localDir = transform.rotation().transpose() * direction;
-  const Eigen::Vector3d localPoint(
-      std::copysign(halfExtents.x(), localDir.x()),
-      std::copysign(halfExtents.y(), localDir.y()),
-      std::copysign(halfExtents.z(), localDir.z()));
-  return transform * localPoint;
-}
-
-Eigen::Vector3d cylinderSupport(
-    const Eigen::Isometry3d& transform,
-    double radius,
-    double halfHeight,
-    const Eigen::Vector3d& direction)
-{
-  const Eigen::Vector3d localDir = transform.rotation().transpose() * direction;
-  Eigen::Vector3d localPoint(0.0, 0.0, std::copysign(halfHeight, localDir.z()));
-  const double radial
-      = std::sqrt(localDir.x() * localDir.x() + localDir.y() * localDir.y());
-  if (radial > kEpsilon) {
-    localPoint.x() = radius * localDir.x() / radial;
-    localPoint.y() = radius * localDir.y() / radial;
-  }
-  return transform * localPoint;
-}
-
 } // namespace
 
 bool capsuleCastSphere(
@@ -888,37 +977,51 @@ bool capsuleCastPlane(
 
   const double capsuleRadius = capsule.getRadius();
   const double halfHeight = capsule.getHeight() / 2.0;
+  const Eigen::Vector3d worldNormal
+      = targetTransform.rotation() * target.getNormal();
+  const Eigen::Vector3d worldPoint
+      = targetTransform.translation() + target.getOffset() * worldNormal;
 
-  double bestT = 2.0;
-  CcdResult bestResult;
-
-  auto testEndpoint = [&](bool top) {
-    Eigen::Vector3d startPos
-        = getCapsuleEndpoint(capsuleStart, halfHeight, top);
-    Eigen::Vector3d endPos = getCapsuleEndpoint(capsuleEnd, halfHeight, top);
-
-    CcdResult localResult;
-    if (sphereCastPlane(
-            startPos,
-            endPos,
-            capsuleRadius,
-            target,
-            targetTransform,
-            option,
-            localResult)) {
-      updateBestCcdResult(localResult, bestT, bestResult);
-    }
-  };
-
-  testEndpoint(true);
-  testEndpoint(false);
-
-  if (bestT > 1.0) {
-    return false;
+  double motionBound
+      = computeCapsuleMotionBound(capsule, capsuleStart, capsuleEnd);
+  if (motionBound < option.tolerance) {
+    motionBound = option.tolerance;
   }
 
-  result = bestResult;
-  return true;
+  const MotionSample capsuleMotion(capsuleStart, capsuleEnd);
+  double t = 0.0;
+
+  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
+    const Eigen::Isometry3d currentCapsuleTransform = capsuleMotion.at(t);
+    const Eigen::Vector3d topEndpoint
+        = getCapsuleEndpoint(currentCapsuleTransform, halfHeight, true);
+    const Eigen::Vector3d bottomEndpoint
+        = getCapsuleEndpoint(currentCapsuleTransform, halfHeight, false);
+
+    const double topDistance = (topEndpoint - worldPoint).dot(worldNormal);
+    const double bottomDistance
+        = (bottomEndpoint - worldPoint).dot(worldNormal);
+    const bool useTop = topDistance < bottomDistance;
+    const Eigen::Vector3d closestEndpoint
+        = useTop ? topEndpoint : bottomEndpoint;
+    const double clearance
+        = (useTop ? topDistance : bottomDistance) - capsuleRadius;
+
+    if (clearance <= option.tolerance) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = closestEndpoint - capsuleRadius * worldNormal;
+      result.normal = worldNormal;
+      return true;
+    }
+
+    t += clearance / motionBound;
+    if (t > 1.0) {
+      return false;
+    }
+  }
+
+  return false;
 }
 
 bool capsuleCastCylinder(

--- a/dart/collision/native/narrow_phase/Ccd.cpp
+++ b/dart/collision/native/narrow_phase/Ccd.cpp
@@ -188,6 +188,16 @@ Eigen::Vector3d boxSupport(
   return transform * localPoint;
 }
 
+Eigen::Vector3d closestPointOnBox(
+    const Eigen::Vector3d& localPoint, const Eigen::Vector3d& halfExtents)
+{
+  Eigen::Vector3d closest;
+  for (int i = 0; i < 3; ++i) {
+    closest[i] = std::clamp(localPoint[i], -halfExtents[i], halfExtents[i]);
+  }
+  return closest;
+}
+
 Eigen::Vector3d getCapsuleSupport(
     const Eigen::Isometry3d& transform,
     const CapsuleShape& capsule,
@@ -361,7 +371,6 @@ bool sphereCastBox(
     const CcdOption& option,
     CcdResult& result)
 {
-  (void)option;
   result.clear();
 
   const Eigen::Isometry3d invTransform = targetTransform.inverse();
@@ -372,6 +381,21 @@ bool sphereCastBox(
   const Eigen::Vector3d& halfExtents = target.getHalfExtents();
   const Eigen::Vector3d expandedHalf
       = halfExtents + Eigen::Vector3d::Constant(sphereRadius);
+  const double expandedRadius = sphereRadius + option.tolerance;
+  const double expandedRadiusSq = expandedRadius * expandedRadius;
+
+  auto runSupportFallback = [&]() {
+    return sphereCastConvexTarget(
+        sphereStart,
+        sphereEnd,
+        sphereRadius,
+        [&](const Eigen::Vector3d& dir) {
+          return boxSupport(targetTransform, halfExtents, dir);
+        },
+        targetTransform.translation(),
+        option,
+        result);
+  };
 
   double tMin = 0.0;
   double tMax = 1.0;
@@ -408,16 +432,17 @@ bool sphereCastBox(
   }
 
   if (hitAxis < 0 || tMin <= 0.0) {
+    const Eigen::Vector3d closestOnBox
+        = closestPointOnBox(localStart, halfExtents);
+    Eigen::Vector3d localNormal = localStart - closestOnBox;
+    if (localNormal.squaredNorm() > expandedRadiusSq) {
+      return runSupportFallback();
+    }
+
     result.hit = true;
     result.timeOfImpact = 0.0;
-    result.point = sphereStart;
+    result.point = targetTransform * closestOnBox;
 
-    Eigen::Vector3d closestOnBox;
-    for (int i = 0; i < 3; ++i) {
-      closestOnBox[i]
-          = std::clamp(localStart[i], -halfExtents[i], halfExtents[i]);
-    }
-    Eigen::Vector3d localNormal = localStart - closestOnBox;
     if (localNormal.squaredNorm() < kEpsilon) {
       localNormal = Eigen::Vector3d::UnitZ();
     } else {
@@ -431,12 +456,18 @@ bool sphereCastBox(
   result.timeOfImpact = tMin;
 
   Eigen::Vector3d hitCenter = localStart + tMin * localDir;
-  Eigen::Vector3d localNormal = Eigen::Vector3d::Zero();
-  localNormal[hitAxis] = static_cast<double>(hitSign);
+  const Eigen::Vector3d closestOnBox
+      = closestPointOnBox(hitCenter, halfExtents);
+  Eigen::Vector3d localNormal = hitCenter - closestOnBox;
+  if (localNormal.squaredNorm() > expandedRadiusSq) {
+    return runSupportFallback();
+  }
 
-  Eigen::Vector3d closestOnBox;
-  for (int i = 0; i < 3; ++i) {
-    closestOnBox[i] = std::clamp(hitCenter[i], -halfExtents[i], halfExtents[i]);
+  if (localNormal.squaredNorm() < kEpsilon) {
+    localNormal = Eigen::Vector3d::Zero();
+    localNormal[hitAxis] = static_cast<double>(hitSign);
+  } else {
+    localNormal.normalize();
   }
 
   result.point = targetTransform * closestOnBox;

--- a/dart/collision/native/narrow_phase/Ccd.cpp
+++ b/dart/collision/native/narrow_phase/Ccd.cpp
@@ -1,0 +1,1645 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/Ccd.hpp>
+#include <dart/collision/native/narrow_phase/Gjk-impl.hpp>
+#include <dart/collision/native/narrow_phase/Gjk.hpp>
+
+#include <algorithm>
+#include <array>
+
+#include <cmath>
+
+namespace dart::collision::native {
+
+namespace {
+
+constexpr double kEpsilon = 1e-10;
+
+double solveQuadraticSmallestPositive(double a, double b, double c)
+{
+  if (std::abs(a) < kEpsilon) {
+    if (std::abs(b) < kEpsilon) {
+      return -1.0;
+    }
+    double t = -c / b;
+    return (t >= 0.0) ? t : -1.0;
+  }
+
+  double discriminant = b * b - 4.0 * a * c;
+  if (discriminant < 0.0) {
+    return -1.0;
+  }
+
+  double sqrtDisc = std::sqrt(discriminant);
+  double t0 = (-b - sqrtDisc) / (2.0 * a);
+  double t1 = (-b + sqrtDisc) / (2.0 * a);
+
+  if (t0 > t1) {
+    std::swap(t0, t1);
+  }
+
+  if (t0 >= 0.0) {
+    return t0;
+  }
+  if (t1 >= 0.0) {
+    return t1;
+  }
+  return -1.0;
+}
+
+ConvexShape makeTriangleConvex(
+    const MeshShape& mesh, const MeshShape::Triangle& triangle)
+{
+  const auto& vertices = mesh.getVertices();
+  return ConvexShape(
+      {vertices[static_cast<std::size_t>(triangle[0])],
+       vertices[static_cast<std::size_t>(triangle[1])],
+       vertices[static_cast<std::size_t>(triangle[2])]});
+}
+
+void updateBestCcdResult(
+    const CcdResult& candidate, double& bestT, CcdResult& bestResult)
+{
+  if (candidate.timeOfImpact < bestT) {
+    bestT = candidate.timeOfImpact;
+    bestResult = candidate;
+  }
+}
+
+} // namespace
+
+bool sphereCastSphere(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const SphereShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  (void)option;
+  result.clear();
+
+  const Eigen::Vector3d targetCenter = targetTransform.translation();
+  const double targetRadius = target.getRadius();
+  const double combinedRadius = sphereRadius + targetRadius;
+
+  const Eigen::Vector3d d = sphereEnd - sphereStart;
+  const Eigen::Vector3d f = sphereStart - targetCenter;
+
+  const double a = d.squaredNorm();
+  const double b = 2.0 * f.dot(d);
+  const double c = f.squaredNorm() - combinedRadius * combinedRadius;
+
+  if (c < 0.0) {
+    result.hit = true;
+    result.timeOfImpact = 0.0;
+    result.point = sphereStart;
+    const Eigen::Vector3d normal = sphereStart - targetCenter;
+    if (normal.squaredNorm() < kEpsilon) {
+      result.normal = Eigen::Vector3d::UnitZ();
+    } else {
+      result.normal = normal.normalized();
+    }
+    return true;
+  }
+
+  double t = solveQuadraticSmallestPositive(a, b, c);
+
+  if (t < 0.0 || t > 1.0) {
+    return false;
+  }
+
+  result.hit = true;
+  result.timeOfImpact = t;
+
+  Eigen::Vector3d hitSphereCenter = sphereStart + t * d;
+  result.normal = (hitSphereCenter - targetCenter).normalized();
+  result.point = targetCenter + targetRadius * result.normal;
+
+  return true;
+}
+
+bool sphereCastBox(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const BoxShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  (void)option;
+  result.clear();
+
+  const Eigen::Isometry3d invTransform = targetTransform.inverse();
+  const Eigen::Vector3d localStart = invTransform * sphereStart;
+  const Eigen::Vector3d localEnd = invTransform * sphereEnd;
+  const Eigen::Vector3d localDir = localEnd - localStart;
+
+  const Eigen::Vector3d& halfExtents = target.getHalfExtents();
+  const Eigen::Vector3d expandedHalf
+      = halfExtents + Eigen::Vector3d::Constant(sphereRadius);
+
+  double tMin = 0.0;
+  double tMax = 1.0;
+  int hitAxis = -1;
+  int hitSign = 1;
+
+  for (int i = 0; i < 3; ++i) {
+    if (std::abs(localDir[i]) < kEpsilon) {
+      if (localStart[i] < -expandedHalf[i] || localStart[i] > expandedHalf[i]) {
+        return false;
+      }
+    } else {
+      double invD = 1.0 / localDir[i];
+      double t1 = (-expandedHalf[i] - localStart[i]) * invD;
+      double t2 = (expandedHalf[i] - localStart[i]) * invD;
+
+      int sign = -1;
+      if (t1 > t2) {
+        std::swap(t1, t2);
+        sign = 1;
+      }
+
+      if (t1 > tMin) {
+        tMin = t1;
+        hitAxis = i;
+        hitSign = sign;
+      }
+      tMax = std::min(tMax, t2);
+
+      if (tMin > tMax) {
+        return false;
+      }
+    }
+  }
+
+  if (hitAxis < 0 || tMin <= 0.0) {
+    result.hit = true;
+    result.timeOfImpact = 0.0;
+    result.point = sphereStart;
+
+    Eigen::Vector3d closestOnBox;
+    for (int i = 0; i < 3; ++i) {
+      closestOnBox[i]
+          = std::clamp(localStart[i], -halfExtents[i], halfExtents[i]);
+    }
+    Eigen::Vector3d localNormal = localStart - closestOnBox;
+    if (localNormal.squaredNorm() < kEpsilon) {
+      localNormal = Eigen::Vector3d::UnitZ();
+    } else {
+      localNormal.normalize();
+    }
+    result.normal = targetTransform.rotation() * localNormal;
+    return true;
+  }
+
+  result.hit = true;
+  result.timeOfImpact = tMin;
+
+  Eigen::Vector3d hitCenter = localStart + tMin * localDir;
+  Eigen::Vector3d localNormal = Eigen::Vector3d::Zero();
+  localNormal[hitAxis] = static_cast<double>(hitSign);
+
+  Eigen::Vector3d closestOnBox;
+  for (int i = 0; i < 3; ++i) {
+    closestOnBox[i] = std::clamp(hitCenter[i], -halfExtents[i], halfExtents[i]);
+  }
+
+  result.point = targetTransform * closestOnBox;
+  result.normal = targetTransform.rotation() * localNormal;
+
+  return true;
+}
+
+bool sphereCastCapsule(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const CapsuleShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  (void)option;
+  result.clear();
+
+  const double capsuleRadius = target.getRadius();
+  const double halfHeight = target.getHeight() / 2.0;
+  const double combinedRadius = sphereRadius + capsuleRadius;
+
+  const Eigen::Isometry3d invTransform = targetTransform.inverse();
+  const Eigen::Vector3d localStart = invTransform * sphereStart;
+  const Eigen::Vector3d localEnd = invTransform * sphereEnd;
+  const Eigen::Vector3d localDir = localEnd - localStart;
+
+  double bestT = 2.0;
+  Eigen::Vector3d bestNormal = Eigen::Vector3d::UnitZ();
+  Eigen::Vector3d bestPoint = Eigen::Vector3d::Zero();
+
+  auto testSphereCap = [&](const Eigen::Vector3d& capCenter) {
+    Eigen::Vector3d f = localStart - capCenter;
+    double a = localDir.squaredNorm();
+    double b = 2.0 * f.dot(localDir);
+    double c = f.squaredNorm() - combinedRadius * combinedRadius;
+
+    double t = solveQuadraticSmallestPositive(a, b, c);
+    if (t >= 0.0 && t <= 1.0 && t < bestT) {
+      bestT = t;
+      Eigen::Vector3d hitCenter = localStart + t * localDir;
+      bestNormal = (hitCenter - capCenter).normalized();
+      bestPoint = capCenter + capsuleRadius * bestNormal;
+    }
+  };
+
+  testSphereCap(Eigen::Vector3d(0, 0, halfHeight));
+  testSphereCap(Eigen::Vector3d(0, 0, -halfHeight));
+
+  double dx = localDir.x();
+  double dy = localDir.y();
+  double ox = localStart.x();
+  double oy = localStart.y();
+
+  double a = dx * dx + dy * dy;
+  double b = 2.0 * (ox * dx + oy * dy);
+  double c = ox * ox + oy * oy - combinedRadius * combinedRadius;
+
+  if (a > kEpsilon) {
+    double t = solveQuadraticSmallestPositive(a, b, c);
+    if (t >= 0.0 && t <= 1.0 && t < bestT) {
+      Eigen::Vector3d hitCenter = localStart + t * localDir;
+      double z = hitCenter.z();
+      if (z >= -halfHeight && z <= halfHeight) {
+        bestT = t;
+        bestNormal
+            = Eigen::Vector3d(hitCenter.x(), hitCenter.y(), 0.0).normalized();
+        bestPoint = Eigen::Vector3d(
+            capsuleRadius * bestNormal.x(), capsuleRadius * bestNormal.y(), z);
+      }
+    }
+  }
+
+  if (bestT > 1.0) {
+    return false;
+  }
+
+  result.hit = true;
+  result.timeOfImpact = bestT;
+  result.normal = targetTransform.rotation() * bestNormal;
+  result.point = targetTransform * bestPoint;
+
+  return true;
+}
+
+bool sphereCastPlane(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const PlaneShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  (void)option;
+  result.clear();
+
+  const Eigen::Vector3d worldNormal
+      = targetTransform.rotation() * target.getNormal();
+  const Eigen::Vector3d worldPoint
+      = targetTransform.translation() + target.getOffset() * worldNormal;
+
+  double startDist = (sphereStart - worldPoint).dot(worldNormal);
+  double endDist = (sphereEnd - worldPoint).dot(worldNormal);
+
+  double effectiveStartDist = startDist - sphereRadius;
+  double effectiveEndDist = endDist - sphereRadius;
+
+  if (effectiveStartDist <= 0.0) {
+    result.hit = true;
+    result.timeOfImpact = 0.0;
+    result.point = sphereStart - sphereRadius * worldNormal;
+    result.normal = worldNormal;
+    return true;
+  }
+
+  if (effectiveEndDist >= 0.0) {
+    return false;
+  }
+
+  double t = effectiveStartDist / (effectiveStartDist - effectiveEndDist);
+
+  result.hit = true;
+  result.timeOfImpact = t;
+  Eigen::Vector3d hitCenter = sphereStart + t * (sphereEnd - sphereStart);
+  result.point = hitCenter - sphereRadius * worldNormal;
+  result.normal = worldNormal;
+
+  return true;
+}
+
+bool sphereCastCylinder(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const CylinderShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  (void)option;
+  result.clear();
+
+  const double cylinderRadius = target.getRadius();
+  const double halfHeight = target.getHeight() / 2.0;
+  const double combinedRadius = sphereRadius + cylinderRadius;
+
+  const Eigen::Isometry3d invTransform = targetTransform.inverse();
+  const Eigen::Vector3d localStart = invTransform * sphereStart;
+  const Eigen::Vector3d localEnd = invTransform * sphereEnd;
+  const Eigen::Vector3d localDir = localEnd - localStart;
+
+  double bestT = 2.0;
+  Eigen::Vector3d bestNormal = Eigen::Vector3d::UnitZ();
+  Eigen::Vector3d bestPoint = Eigen::Vector3d::Zero();
+
+  double dx = localDir.x();
+  double dy = localDir.y();
+  double ox = localStart.x();
+  double oy = localStart.y();
+
+  double a = dx * dx + dy * dy;
+  double b = 2.0 * (ox * dx + oy * dy);
+  double c = ox * ox + oy * oy - combinedRadius * combinedRadius;
+
+  if (a > kEpsilon) {
+    double t = solveQuadraticSmallestPositive(a, b, c);
+    if (t >= 0.0 && t <= 1.0 && t < bestT) {
+      Eigen::Vector3d hitCenter = localStart + t * localDir;
+      double z = hitCenter.z();
+      if (z >= -halfHeight && z <= halfHeight) {
+        bestT = t;
+        bestNormal
+            = Eigen::Vector3d(hitCenter.x(), hitCenter.y(), 0.0).normalized();
+        bestPoint = Eigen::Vector3d(
+            cylinderRadius * bestNormal.x(),
+            cylinderRadius * bestNormal.y(),
+            z);
+      }
+    }
+  }
+
+  double expandedHalfHeight = halfHeight + sphereRadius;
+  if (std::abs(localDir.z()) > kEpsilon) {
+    for (double capZ : {-expandedHalfHeight, expandedHalfHeight}) {
+      double t = (capZ - localStart.z()) / localDir.z();
+      if (t >= 0.0 && t <= 1.0 && t < bestT) {
+        Eigen::Vector3d hitCenter = localStart + t * localDir;
+        double distSq
+            = hitCenter.x() * hitCenter.x() + hitCenter.y() * hitCenter.y();
+        if (distSq <= cylinderRadius * cylinderRadius) {
+          bestT = t;
+          bestNormal = (capZ > 0.0) ? Eigen::Vector3d(0, 0, 1)
+                                    : Eigen::Vector3d(0, 0, -1);
+          double actualCapZ = (capZ > 0.0) ? halfHeight : -halfHeight;
+          bestPoint = Eigen::Vector3d(hitCenter.x(), hitCenter.y(), actualCapZ);
+        }
+      }
+    }
+  }
+
+  if (bestT > 1.0) {
+    return false;
+  }
+
+  result.hit = true;
+  result.timeOfImpact = bestT;
+  result.normal = targetTransform.rotation() * bestNormal;
+  result.point = targetTransform * bestPoint;
+
+  return true;
+}
+
+bool sphereCastConvex(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const ConvexShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  Eigen::Isometry3d sphereTransformStart = Eigen::Isometry3d::Identity();
+  sphereTransformStart.translation() = sphereStart;
+  Eigen::Isometry3d sphereTransformEnd = Eigen::Isometry3d::Identity();
+  sphereTransformEnd.translation() = sphereEnd;
+
+  double motionBound = (sphereEnd - sphereStart).norm();
+  if (motionBound < option.tolerance) {
+    motionBound = option.tolerance;
+  }
+
+  double t = 0.0;
+
+  Eigen::Vector3d initialDir = targetTransform.translation() - sphereStart;
+  if (initialDir.squaredNorm() < kEpsilon) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  // Clamp to >= 1 so a zero/negative budget still tests the t = 0 overlap.
+  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
+    Eigen::Vector3d currentCenter = sphereStart + t * (sphereEnd - sphereStart);
+
+    const double centerX = currentCenter.x();
+    const double centerY = currentCenter.y();
+    const double centerZ = currentCenter.z();
+    auto supportA =
+        [centerX, centerY, centerZ, sphereRadius](const Eigen::Vector3d& dir) {
+          Eigen::Vector3d worldDir = dir;
+          if (worldDir.squaredNorm() < kEpsilon) {
+            worldDir = Eigen::Vector3d::UnitZ();
+          } else {
+            worldDir.normalize();
+          }
+          return Eigen::Vector3d(
+              centerX + sphereRadius * worldDir.x(),
+              centerY + sphereRadius * worldDir.y(),
+              centerZ + sphereRadius * worldDir.z());
+        };
+    auto supportB = [&](const Eigen::Vector3d& dir) {
+      return targetTransform
+             * target.support(targetTransform.rotation().transpose() * dir);
+    };
+
+    GjkResult gjkResult = detail::queryT(supportA, supportB, initialDir);
+
+    if (gjkResult.intersecting) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      Eigen::Vector3d pointB = supportB(Eigen::Vector3d::UnitX());
+      result.point = pointB;
+      const Eigen::Vector3d normal = currentCenter - pointB;
+      if (normal.squaredNorm() < kEpsilon) {
+        result.normal = Eigen::Vector3d::UnitZ();
+      } else {
+        result.normal = normal.normalized();
+      }
+      return true;
+    }
+
+    Eigen::Vector3d pointA = gjkResult.closestPointA;
+    Eigen::Vector3d pointB = gjkResult.closestPointB;
+    double distance = gjkResult.distance;
+
+    Eigen::Vector3d sepAxis = gjkResult.separationAxis;
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = pointB - pointA;
+    }
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = Eigen::Vector3d::UnitX();
+    }
+    sepAxis.normalize();
+
+    if (distance < option.tolerance) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = pointB;
+      result.normal = sepAxis;
+      return true;
+    }
+
+    double dt = distance / motionBound;
+    t += dt;
+
+    if (t > 1.0) {
+      return false;
+    }
+
+    initialDir = sepAxis;
+  }
+
+  return false;
+}
+
+bool sphereCastMesh(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const MeshShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  double bestT = 2.0;
+  CcdResult bestResult;
+
+  for (const auto& triangle : target.getTriangles()) {
+    const ConvexShape triangleTarget = makeTriangleConvex(target, triangle);
+
+    CcdResult localResult;
+    if (sphereCastConvex(
+            sphereStart,
+            sphereEnd,
+            sphereRadius,
+            triangleTarget,
+            targetTransform,
+            option,
+            localResult)) {
+      updateBestCcdResult(localResult, bestT, bestResult);
+    }
+  }
+
+  if (bestT > 1.0) {
+    return false;
+  }
+
+  result = bestResult;
+  return true;
+}
+
+namespace {
+
+Eigen::Vector3d getCapsuleEndpoint(
+    const Eigen::Isometry3d& transform, double halfHeight, bool top)
+{
+  Eigen::Vector3d localPoint(0, 0, top ? halfHeight : -halfHeight);
+  return transform * localPoint;
+}
+
+// Samples a rigid motion start -> end at parameter t in [0, 1]. Endpoint
+// quaternions are built once at construction so the conservative-advancement
+// loop pays only a slerp (or nothing, for translation) per iteration instead of
+// reconstructing quaternions from rotation matrices every step.
+class MotionSample
+{
+public:
+  MotionSample(const Eigen::Isometry3d& start, const Eigen::Isometry3d& end)
+    : startTranslation_(start.translation()),
+      endTranslation_(end.translation()),
+      startRotation_(start.rotation()),
+      rotates_(!startRotation_.isApprox(end.rotation())),
+      qStart_(startRotation_),
+      qEnd_(end.rotation())
+  {
+  }
+
+  [[nodiscard]] Eigen::Isometry3d at(double t) const
+  {
+    Eigen::Isometry3d result = Eigen::Isometry3d::Identity();
+    result.translation() = (1.0 - t) * startTranslation_ + t * endTranslation_;
+    // Translation-only motion skips the slerp; rotational motion reuses the
+    // cached endpoint quaternions.
+    result.linear() = rotates_ ? qStart_.slerp(t, qEnd_).toRotationMatrix()
+                               : startRotation_;
+    return result;
+  }
+
+private:
+  Eigen::Vector3d startTranslation_;
+  Eigen::Vector3d endTranslation_;
+  Eigen::Matrix3d startRotation_;
+  bool rotates_;
+  Eigen::Quaterniond qStart_;
+  Eigen::Quaterniond qEnd_;
+};
+
+double computeCapsuleMotionBound(
+    const CapsuleShape& capsule,
+    const Eigen::Isometry3d& transformStart,
+    const Eigen::Isometry3d& transformEnd)
+{
+  const double linearVelocity
+      = (transformEnd.translation() - transformStart.translation()).norm();
+
+  const Eigen::Quaterniond qStart(transformStart.rotation());
+  const Eigen::Quaterniond qEnd(transformEnd.rotation());
+  const double angle = qStart.angularDistance(qEnd);
+
+  const double maxRadius = capsule.getHeight() / 2.0 + capsule.getRadius();
+  return linearVelocity + angle * maxRadius;
+}
+
+Eigen::Vector3d getCapsuleSupport(
+    const Eigen::Isometry3d& transform,
+    const CapsuleShape& capsule,
+    const Eigen::Vector3d& direction)
+{
+  Eigen::Vector3d worldDir = direction;
+  if (worldDir.squaredNorm() < kEpsilon) {
+    worldDir = Eigen::Vector3d::UnitZ();
+  } else {
+    worldDir.normalize();
+  }
+
+  const Eigen::Vector3d localDir = transform.rotation().transpose() * worldDir;
+  const double halfHeight = capsule.getHeight() / 2.0;
+  const Eigen::Vector3d localEndpoint(
+      0.0, 0.0, localDir.z() >= 0.0 ? halfHeight : -halfHeight);
+  return transform * localEndpoint + capsule.getRadius() * worldDir;
+}
+
+// Conservative advancement of a moving capsule against any static convex
+// target, given the target's world-space support function. Uses the full
+// capsule support (caps AND cylindrical body), so it catches side-of-capsule
+// contacts that a caps-only endpoint sweep misses. `targetSeed` is a point
+// on/near the target used to seed the first search direction.
+template <typename TargetSupport>
+bool capsuleCastConvexTarget(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const TargetSupport& targetSupport,
+    const Eigen::Vector3d& targetSeed,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  double motionBound
+      = computeCapsuleMotionBound(capsule, capsuleStart, capsuleEnd);
+  if (motionBound < option.tolerance) {
+    motionBound = option.tolerance;
+  }
+
+  double t = 0.0;
+
+  Eigen::Vector3d initialDir = targetSeed - capsuleStart.translation();
+  if (initialDir.squaredNorm() < kEpsilon) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  const MotionSample capsuleMotion(capsuleStart, capsuleEnd);
+
+  // Clamp to >= 1 so a zero/negative budget still tests the t = 0 overlap.
+  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
+    const Eigen::Isometry3d currentCapsuleTransform = capsuleMotion.at(t);
+
+    auto supportA = [&](const Eigen::Vector3d& dir) {
+      return getCapsuleSupport(currentCapsuleTransform, capsule, dir);
+    };
+
+    GjkResult gjkResult = detail::queryT(supportA, targetSupport, initialDir);
+
+    if (gjkResult.intersecting) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = targetSupport(Eigen::Vector3d::UnitX());
+      Eigen::Vector3d normal
+          = supportA(Eigen::Vector3d::UnitX()) - result.point;
+      if (normal.squaredNorm() < kEpsilon) {
+        normal = Eigen::Vector3d::UnitZ();
+      } else {
+        normal.normalize();
+      }
+      result.normal = normal;
+      return true;
+    }
+
+    const Eigen::Vector3d pointA = gjkResult.closestPointA;
+    const Eigen::Vector3d pointB = gjkResult.closestPointB;
+    const double distance = gjkResult.distance;
+
+    Eigen::Vector3d sepAxis = gjkResult.separationAxis;
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = pointB - pointA;
+    }
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = Eigen::Vector3d::UnitX();
+    }
+    sepAxis.normalize();
+
+    if (distance < option.tolerance) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = pointB;
+      result.normal = sepAxis;
+      return true;
+    }
+
+    t += distance / motionBound;
+    if (t > 1.0) {
+      return false;
+    }
+
+    initialDir = sepAxis;
+  }
+
+  return false;
+}
+
+// World-space support functions for the convex primitive targets (the shape
+// classes do not expose support(), so they are provided analytically here).
+Eigen::Vector3d sphereSupport(
+    const Eigen::Vector3d& center,
+    double radius,
+    const Eigen::Vector3d& direction)
+{
+  Eigen::Vector3d n = direction;
+  if (n.squaredNorm() < kEpsilon) {
+    n = Eigen::Vector3d::UnitX();
+  } else {
+    n.normalize();
+  }
+  return center + radius * n;
+}
+
+Eigen::Vector3d boxSupport(
+    const Eigen::Isometry3d& transform,
+    const Eigen::Vector3d& halfExtents,
+    const Eigen::Vector3d& direction)
+{
+  const Eigen::Vector3d localDir = transform.rotation().transpose() * direction;
+  const Eigen::Vector3d localPoint(
+      std::copysign(halfExtents.x(), localDir.x()),
+      std::copysign(halfExtents.y(), localDir.y()),
+      std::copysign(halfExtents.z(), localDir.z()));
+  return transform * localPoint;
+}
+
+Eigen::Vector3d cylinderSupport(
+    const Eigen::Isometry3d& transform,
+    double radius,
+    double halfHeight,
+    const Eigen::Vector3d& direction)
+{
+  const Eigen::Vector3d localDir = transform.rotation().transpose() * direction;
+  Eigen::Vector3d localPoint(0.0, 0.0, std::copysign(halfHeight, localDir.z()));
+  const double radial
+      = std::sqrt(localDir.x() * localDir.x() + localDir.y() * localDir.y());
+  if (radial > kEpsilon) {
+    localPoint.x() = radius * localDir.x() / radial;
+    localPoint.y() = radius * localDir.y() / radial;
+  }
+  return transform * localPoint;
+}
+
+} // namespace
+
+bool capsuleCastSphere(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const SphereShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  const Eigen::Vector3d center = targetTransform.translation();
+  const double radius = target.getRadius();
+  return capsuleCastConvexTarget(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      [&](const Eigen::Vector3d& dir) {
+        return sphereSupport(center, radius, dir);
+      },
+      center,
+      option,
+      result);
+}
+
+bool capsuleCastBox(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const BoxShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  const Eigen::Vector3d halfExtents = target.getHalfExtents();
+  return capsuleCastConvexTarget(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      [&](const Eigen::Vector3d& dir) {
+        return boxSupport(targetTransform, halfExtents, dir);
+      },
+      targetTransform.translation(),
+      option,
+      result);
+}
+
+bool capsuleCastCapsule(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const CapsuleShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  return capsuleCastConvexTarget(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      [&](const Eigen::Vector3d& dir) {
+        return getCapsuleSupport(targetTransform, target, dir);
+      },
+      targetTransform.translation(),
+      option,
+      result);
+}
+
+bool capsuleCastPlane(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const PlaneShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  const double capsuleRadius = capsule.getRadius();
+  const double halfHeight = capsule.getHeight() / 2.0;
+
+  double bestT = 2.0;
+  CcdResult bestResult;
+
+  auto testEndpoint = [&](bool top) {
+    Eigen::Vector3d startPos
+        = getCapsuleEndpoint(capsuleStart, halfHeight, top);
+    Eigen::Vector3d endPos = getCapsuleEndpoint(capsuleEnd, halfHeight, top);
+
+    CcdResult localResult;
+    if (sphereCastPlane(
+            startPos,
+            endPos,
+            capsuleRadius,
+            target,
+            targetTransform,
+            option,
+            localResult)) {
+      updateBestCcdResult(localResult, bestT, bestResult);
+    }
+  };
+
+  testEndpoint(true);
+  testEndpoint(false);
+
+  if (bestT > 1.0) {
+    return false;
+  }
+
+  result = bestResult;
+  return true;
+}
+
+bool capsuleCastCylinder(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const CylinderShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  const double radius = target.getRadius();
+  const double halfHeight = target.getHeight() / 2.0;
+  return capsuleCastConvexTarget(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      [&](const Eigen::Vector3d& dir) {
+        return cylinderSupport(targetTransform, radius, halfHeight, dir);
+      },
+      targetTransform.translation(),
+      option,
+      result);
+}
+
+bool capsuleCastConvex(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const ConvexShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  return capsuleCastConvexTarget(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      [&](const Eigen::Vector3d& dir) {
+        return targetTransform
+               * target.support(targetTransform.rotation().transpose() * dir);
+      },
+      targetTransform.translation(),
+      option,
+      result);
+}
+
+bool capsuleCastMesh(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const MeshShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  const double capsuleRadius = capsule.getRadius();
+  const double halfHeight = capsule.getHeight() / 2.0;
+
+  double bestT = 2.0;
+  CcdResult bestResult;
+
+  auto testEndpoint = [&](bool top) {
+    Eigen::Vector3d startPos
+        = getCapsuleEndpoint(capsuleStart, halfHeight, top);
+    Eigen::Vector3d endPos = getCapsuleEndpoint(capsuleEnd, halfHeight, top);
+
+    CcdResult localResult;
+    if (sphereCastMesh(
+            startPos,
+            endPos,
+            capsuleRadius,
+            target,
+            targetTransform,
+            option,
+            localResult)) {
+      updateBestCcdResult(localResult, bestT, bestResult);
+    }
+  };
+
+  testEndpoint(true);
+  testEndpoint(false);
+
+  for (const auto& triangle : target.getTriangles()) {
+    const ConvexShape triangleTarget = makeTriangleConvex(target, triangle);
+
+    CcdResult localResult;
+    if (capsuleCastConvex(
+            capsuleStart,
+            capsuleEnd,
+            capsule,
+            triangleTarget,
+            targetTransform,
+            option,
+            localResult)) {
+      updateBestCcdResult(localResult, bestT, bestResult);
+    }
+  }
+
+  if (bestT > 1.0) {
+    return false;
+  }
+
+  result = bestResult;
+  return true;
+}
+
+namespace {
+
+// Precomputed rotational data for a shape's motion, used to evaluate a directed
+// (closest-direction-aware) conservative-advancement bound each step. The
+// rotation contributes to the closest-distance rate only through its component
+// perpendicular to the closest direction n: (omega x r).n <= |omega| * r_perp *
+// |n x axis|. So the angular term carries a |n x axis| factor that vanishes
+// when the rotation axis is parallel to n (e.g. a coaxial screw, where the spin
+// does not close the gap) and is maximal when the axis is perpendicular to n
+// (an ordinary rotational sweep). This is a C2A-style directed bound (Tang/Kim/
+// Manocha, ICRA 2009) restricted to the angular term; the linear term stays
+// undirected (|v|) so translation remains strictly conservative.
+struct RotationBoundData
+{
+  Eigen::Vector3d axis = Eigen::Vector3d::UnitX();
+  double angle = 0.0;
+  double maxPerpRadius = 0.0;
+
+  [[nodiscard]] double angularBound(const Eigen::Vector3d& direction) const
+  {
+    if (angle < kEpsilon) {
+      return 0.0;
+    }
+    return angle * maxPerpRadius * direction.cross(axis).norm();
+  }
+};
+
+RotationBoundData makeRotationBoundData(
+    const ConvexShape& shape,
+    const Eigen::Isometry3d& transformStart,
+    const Eigen::Isometry3d& transformEnd)
+{
+  RotationBoundData data;
+
+  const Eigen::Quaterniond qStart(transformStart.rotation());
+  const Eigen::Quaterniond qEnd(transformEnd.rotation());
+  data.angle = qStart.angularDistance(qEnd);
+  if (data.angle < kEpsilon) {
+    return data;
+  }
+
+  data.axis = Eigen::AngleAxisd(qEnd * qStart.conjugate()).axis();
+  const Eigen::Matrix3d rotStart = transformStart.rotation();
+
+  // Perpendicular distance from the (world) rotation axis is invariant along
+  // the sweep, so it is evaluated once at the start configuration.
+  for (const auto& vertex : shape.getVertices()) {
+    const Eigen::Vector3d p = rotStart * vertex;
+    const double perp = (p - p.dot(data.axis) * data.axis).norm();
+    data.maxPerpRadius = std::max(data.maxPerpRadius, perp);
+  }
+  return data;
+}
+
+// Samples a cubic-Bezier (spline) motion and supplies the ingredients for a
+// closed-form conservative advancement step over a remaining interval [t, 1].
+// Translation follows the cubic Bezier of the four translation control points;
+// orientation is the exponential of the cubic Bezier of the four
+// rotation-vector control points -- the same curve the reference spline-motion
+// model traces.
+//
+// The step uses an acceleration-bounded speed model: |T'(t+s)| <= |T'(t)| +
+// s*A, where A bounds |T''| over the step. This is far tighter than a flat
+// max-speed bound when the curve is slow now but fast later (a curve whose tail
+// accelerates away), turning the conservative-advancement step from
+// distance/max_speed into the larger root of a quadratic -- fewer GJK
+// evaluations to reach the time of impact, with no loss of conservativeness.
+class SplineSample
+{
+public:
+  SplineSample(
+      const std::array<Eigen::Vector3d, 4>& translation,
+      const std::array<Eigen::Vector3d, 4>& rotation)
+    : translation_(translation),
+      rotation_(rotation),
+      rotates_(
+          rotation[0].squaredNorm() + rotation[1].squaredNorm()
+              + rotation[2].squaredNorm() + rotation[3].squaredNorm()
+          > kEpsilon)
+  {
+    // Hodograph (derivative) control points: a cubic Bezier's derivative is a
+    // quadratic Bezier with control points 3*(P_{i+1} - P_i).
+    for (int i = 0; i < 3; ++i) {
+      translationVel_[i] = 3.0 * (translation_[i + 1] - translation_[i]);
+      rotationVel_[i] = 3.0 * (rotation_[i + 1] - rotation_[i]);
+    }
+    // T''(s) is linear in s: T''(s) = accelBase_ + s * accelSlope_.
+    accelBase_ = 2.0 * (translationVel_[1] - translationVel_[0]);
+    accelSlope_ = 2.0
+                  * (translationVel_[0] - 2.0 * translationVel_[1]
+                     + translationVel_[2]);
+  }
+
+  [[nodiscard]] Eigen::Isometry3d at(double t) const
+  {
+    const double u = 1.0 - t;
+    const double b0 = u * u * u;
+    const double b1 = 3.0 * t * u * u;
+    const double b2 = 3.0 * t * t * u;
+    const double b3 = t * t * t;
+
+    Eigen::Isometry3d result = Eigen::Isometry3d::Identity();
+    result.translation() = b0 * translation_[0] + b1 * translation_[1]
+                           + b2 * translation_[2] + b3 * translation_[3];
+    if (rotates_) {
+      const Eigen::Vector3d w = b0 * rotation_[0] + b1 * rotation_[1]
+                                + b2 * rotation_[2] + b3 * rotation_[3];
+      const double angle = w.norm();
+      if (angle > kEpsilon) {
+        result.linear()
+            = Eigen::AngleAxisd(angle, w / angle).toRotationMatrix();
+      }
+    }
+    return result;
+  }
+
+  [[nodiscard]] bool rotates() const
+  {
+    return rotates_;
+  }
+
+  // Translation alone at parameter t (skips the orientation work in at()).
+  [[nodiscard]] Eigen::Vector3d translationAt(double t) const
+  {
+    const double u = 1.0 - t;
+    return u * u * u * translation_[0] + 3.0 * t * u * u * translation_[1]
+           + 3.0 * t * t * u * translation_[2] + t * t * t * translation_[3];
+  }
+
+  // Instantaneous translational speed |T'(t)| (hodograph evaluated at t).
+  [[nodiscard]] double linearSpeedAt(double t) const
+  {
+    const double u = 1.0 - t;
+    const Eigen::Vector3d v = u * u * translationVel_[0]
+                              + 2.0 * u * t * translationVel_[1]
+                              + t * t * translationVel_[2];
+    return v.norm();
+  }
+
+  // Upper bound on |T''(s)| for s in [t, 1]. T'' is linear in s, and a linear
+  // vector function's norm is convex, so its maximum over an interval is at an
+  // endpoint.
+  [[nodiscard]] double maxLinearAccel(double t) const
+  {
+    const double accelAtT = (accelBase_ + t * accelSlope_).norm();
+    const double accelAtEnd = (accelBase_ + accelSlope_).norm();
+    return std::max(accelAtT, accelAtEnd);
+  }
+
+  // Upper bound on angular speed |omega(s)| for s in [t, 1]. The body-frame
+  // angular velocity is omega = J_r(W) W', and the SO(3) right Jacobian J_r is
+  // a contraction (its singular values are at most 1), so |omega| <= |W'|.
+  // Hence the hodograph bound on |W'| also bounds |omega|.
+  [[nodiscard]] double maxAngularSpeed(double t) const
+  {
+    return rotates_ ? maxQuadraticBezierNorm(rotationVel_, t) : 0.0;
+  }
+
+  // Maximum forward translational displacement along direction n over [t, 1],
+  // i.e. max_{s in [t,1]} (T(s) - T(t)) . n, evaluated in closed form at the
+  // interval ends and the interior extrema of the projected curve. This is the
+  // largest distance the body can travel toward the obstacle over the rest of
+  // the motion. Stepping distance/displacement is the (non-conservative) fast
+  // advancement: it can stride past a curved first contact and converge on a
+  // later one, so it is only used when CcdAdvancement::Fast is requested.
+  [[nodiscard]] double maxForwardDisplacement(
+      double t, const Eigen::Vector3d& n) const
+  {
+    const double v0 = translationVel_[0].dot(n);
+    const double v1 = translationVel_[1].dot(n);
+    const double v2 = translationVel_[2].dot(n);
+
+    const Eigen::Vector3d base = translationAt(t);
+    double best = 0.0;
+    const auto consider = [&](double s) {
+      if (s > t && s < 1.0) {
+        best = std::max(best, (translationAt(s) - base).dot(n));
+      }
+    };
+    best = std::max(best, (translationAt(1.0) - base).dot(n));
+
+    // Interior extrema solve T'(s).n = 0, a quadratic in monomial form.
+    const double a = v0 - 2.0 * v1 + v2;
+    const double b = 2.0 * (v1 - v0);
+    const double c = v0;
+    if (std::abs(a) < kEpsilon) {
+      if (std::abs(b) > kEpsilon) {
+        consider(-c / b);
+      }
+    } else {
+      const double disc = b * b - 4.0 * a * c;
+      if (disc >= 0.0) {
+        const double sd = std::sqrt(disc);
+        consider((-b + sd) / (2.0 * a));
+        consider((-b - sd) / (2.0 * a));
+      }
+    }
+    return best;
+  }
+
+private:
+  // Upper bound on the Euclidean norm of a quadratic Bezier (control points v)
+  // over [t, 1]. de Casteljau subdivision at t yields the right sub-curve's
+  // control points; the curve lies in their convex hull, so the largest control
+  // point norm bounds the curve norm on the remaining interval.
+  static double maxQuadraticBezierNorm(
+      const std::array<Eigen::Vector3d, 3>& v, double t)
+  {
+    const Eigen::Vector3d a = v[0] + t * (v[1] - v[0]);
+    const Eigen::Vector3d b = v[1] + t * (v[2] - v[1]);
+    const Eigen::Vector3d r0 = a + t * (b - a); // curve value at t
+    return std::max({r0.norm(), b.norm(), v[2].norm()});
+  }
+
+  std::array<Eigen::Vector3d, 4> translation_;
+  std::array<Eigen::Vector3d, 4> rotation_;
+  std::array<Eigen::Vector3d, 3> translationVel_;
+  std::array<Eigen::Vector3d, 3> rotationVel_;
+  Eigen::Vector3d accelBase_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d accelSlope_ = Eigen::Vector3d::Zero();
+  bool rotates_;
+};
+
+} // namespace
+
+bool conservativeAdvancement(
+    const ConvexShape& shapeA,
+    const Eigen::Isometry3d& transformAStart,
+    const Eigen::Isometry3d& transformAEnd,
+    const ConvexShape& shapeB,
+    const Eigen::Isometry3d& transformB,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  // Directed conservative-advancement bound (recomputed each step from the
+  // closest direction): the linear term stays undirected; only the rotational
+  // term is projected via |n x axis|.
+  const double linearBound
+      = (transformAEnd.translation() - transformAStart.translation()).norm();
+  const RotationBoundData rotationA
+      = makeRotationBoundData(shapeA, transformAStart, transformAEnd);
+
+  double t = 0.0;
+
+  Eigen::Vector3d initialDir
+      = transformB.translation() - transformAStart.translation();
+  if (initialDir.squaredNorm() < kEpsilon) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  const MotionSample motionA(transformAStart, transformAEnd);
+
+  GjkSimplex warmSimplex;
+  bool haveWarm = false;
+
+  // Clamp to >= 1 so a zero/negative budget still tests the t = 0 overlap.
+  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
+    Eigen::Isometry3d currentTransformA = motionA.at(t);
+
+    auto supportA = [&](const Eigen::Vector3d& dir) {
+      return currentTransformA
+             * shapeA.support(currentTransformA.rotation().transpose() * dir);
+    };
+    auto supportB = [&](const Eigen::Vector3d& dir) {
+      return transformB
+             * shapeB.support(transformB.rotation().transpose() * dir);
+    };
+
+    // Warm-start GJK from the previous step's simplex (see convexCast).
+    GjkResult gjkResult
+        = haveWarm ? detail::queryT(supportA, supportB, warmSimplex, initialDir)
+                   : detail::queryT(supportA, supportB, initialDir);
+    warmSimplex = gjkResult.simplex;
+    haveWarm = true;
+
+    if (gjkResult.intersecting) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      Eigen::Vector3d pointA = supportA(Eigen::Vector3d::UnitX());
+      Eigen::Vector3d pointB = supportB(-Eigen::Vector3d::UnitX());
+      result.point = pointB;
+      // Check the magnitude before normalizing: coincident support points
+      // (degenerate/overlapping configs) would otherwise yield a NaN normal
+      // that slips past a post-normalization guard (NaN < kEpsilon is false).
+      const Eigen::Vector3d normal = pointA - pointB;
+      if (normal.squaredNorm() < kEpsilon) {
+        result.normal = Eigen::Vector3d::UnitZ();
+      } else {
+        result.normal = normal.normalized();
+      }
+      return true;
+    }
+
+    Eigen::Vector3d pointA = gjkResult.closestPointA;
+    Eigen::Vector3d pointB = gjkResult.closestPointB;
+    double distance = gjkResult.distance;
+
+    Eigen::Vector3d sepAxis = gjkResult.separationAxis;
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = pointB - pointA;
+    }
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = Eigen::Vector3d::UnitX();
+    }
+    sepAxis.normalize();
+
+    if (distance < option.tolerance) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = pointB;
+      result.normal = sepAxis;
+      return true;
+    }
+
+    double motionBound = linearBound + rotationA.angularBound(sepAxis);
+    if (motionBound < option.tolerance) {
+      motionBound = option.tolerance;
+    }
+    double dt = distance / motionBound;
+    t += dt;
+
+    if (t > 1.0) {
+      return false;
+    }
+
+    initialDir = sepAxis;
+  }
+
+  return false;
+}
+
+bool convexCast(
+    const ConvexShape& shapeA,
+    const Eigen::Isometry3d& transformAStart,
+    const Eigen::Isometry3d& transformAEnd,
+    const ConvexShape& shapeB,
+    const Eigen::Isometry3d& transformBStart,
+    const Eigen::Isometry3d& transformBEnd,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  // Directed conservative-advancement bound, recomputed each step from the
+  // closest direction. Linear term uses the relative translation (undirected);
+  // each body's rotational term is projected via |n x axis|.
+  const Eigen::Vector3d relativeLinearVel
+      = (transformAEnd.translation() - transformAStart.translation())
+        - (transformBEnd.translation() - transformBStart.translation());
+  const double linearBound = relativeLinearVel.norm();
+  const RotationBoundData rotationA
+      = makeRotationBoundData(shapeA, transformAStart, transformAEnd);
+  const RotationBoundData rotationB
+      = makeRotationBoundData(shapeB, transformBStart, transformBEnd);
+
+  double t = 0.0;
+
+  Eigen::Vector3d initialDir
+      = transformBStart.translation() - transformAStart.translation();
+  if (initialDir.squaredNorm() < kEpsilon) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  const MotionSample motionA(transformAStart, transformAEnd);
+  const MotionSample motionB(transformBStart, transformBEnd);
+
+  GjkSimplex warmSimplex;
+  bool haveWarm = false;
+
+  // Clamp to >= 1 so a zero/negative budget still tests the t = 0 overlap.
+  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
+    const Eigen::Isometry3d currentTransformA = motionA.at(t);
+    const Eigen::Isometry3d currentTransformB = motionB.at(t);
+
+    auto supportA = [&](const Eigen::Vector3d& dir) {
+      return currentTransformA
+             * shapeA.support(currentTransformA.rotation().transpose() * dir);
+    };
+    auto supportB = [&](const Eigen::Vector3d& dir) {
+      return currentTransformB
+             * shapeB.support(currentTransformB.rotation().transpose() * dir);
+    };
+
+    // Warm-start GJK from the previous step's simplex: consecutive
+    // conservative- advancement configurations are nearly identical, so the
+    // prior search directions seed the closest-point query close to its answer.
+    // The warm-start recomputes supports at the current configuration, so the
+    // result is identical -- only the iteration count drops.
+    GjkResult gjkResult
+        = haveWarm ? detail::queryT(supportA, supportB, warmSimplex, initialDir)
+                   : detail::queryT(supportA, supportB, initialDir);
+    warmSimplex = gjkResult.simplex;
+    haveWarm = true;
+
+    if (gjkResult.intersecting) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      Eigen::Vector3d pointA = supportA(Eigen::Vector3d::UnitX());
+      Eigen::Vector3d pointB = supportB(-Eigen::Vector3d::UnitX());
+      result.point = pointB;
+      // Check the magnitude before normalizing: coincident support points
+      // (degenerate/overlapping configs) would otherwise yield a NaN normal
+      // that slips past a post-normalization guard (NaN < kEpsilon is false).
+      const Eigen::Vector3d normal = pointA - pointB;
+      if (normal.squaredNorm() < kEpsilon) {
+        result.normal = Eigen::Vector3d::UnitZ();
+      } else {
+        result.normal = normal.normalized();
+      }
+      return true;
+    }
+
+    Eigen::Vector3d pointA = gjkResult.closestPointA;
+    Eigen::Vector3d pointB = gjkResult.closestPointB;
+    double distance = gjkResult.distance;
+
+    Eigen::Vector3d sepAxis = gjkResult.separationAxis;
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = pointB - pointA;
+    }
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = Eigen::Vector3d::UnitX();
+    }
+    sepAxis.normalize();
+
+    if (distance < option.tolerance) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = pointB;
+      result.normal = sepAxis;
+      return true;
+    }
+
+    double motionBound = linearBound + rotationA.angularBound(sepAxis)
+                         + rotationB.angularBound(sepAxis);
+    if (motionBound < option.tolerance) {
+      motionBound = option.tolerance;
+    }
+    t += distance / motionBound;
+    if (t > 1.0) {
+      return false;
+    }
+
+    initialDir = sepAxis;
+  }
+
+  return false;
+}
+
+bool splineCast(
+    const ConvexShape& shapeA,
+    const std::array<Eigen::Vector3d, 4>& translationControlPoints,
+    const std::array<Eigen::Vector3d, 4>& rotationControlPoints,
+    const ConvexShape& shapeB,
+    const Eigen::Isometry3d& transformB,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  const SplineSample motionA(translationControlPoints, rotationControlPoints);
+
+  // Rotation pivots about shape A's local origin, so the swept radius that
+  // converts angular speed to point speed is the farthest vertex from it.
+  double maxRadius = 0.0;
+  if (motionA.rotates()) {
+    for (const auto& vertex : shapeA.getVertices()) {
+      maxRadius = std::max(maxRadius, vertex.norm());
+    }
+  }
+
+  double t = 0.0;
+
+  Eigen::Vector3d initialDir
+      = transformB.translation() - translationControlPoints[0];
+  if (initialDir.squaredNorm() < kEpsilon) {
+    initialDir = Eigen::Vector3d::UnitX();
+  }
+
+  // Shape A spins only when its rotation control points are non-trivial; shape
+  // B is static. When a body has no rotation, its support reduces to a vertex
+  // scan plus a translation, skipping two matrix-vector products per support
+  // call -- a large saving since the conservative-advancement loop evaluates
+  // supports many times.
+  const bool aRotates = motionA.rotates();
+  const Eigen::Vector3d bTranslation = transformB.translation();
+  const Eigen::Matrix3d bRotation = transformB.rotation();
+  const bool bRotates = !bRotation.isIdentity(kEpsilon);
+  const Eigen::Matrix3d bRotationT = bRotation.transpose();
+
+  auto supportB = [&](const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+    if (bRotates) {
+      return bTranslation + bRotation * shapeB.support(bRotationT * dir);
+    }
+    return bTranslation + shapeB.support(dir);
+  };
+
+  GjkSimplex warmSimplex;
+  bool haveWarm = false;
+
+  // Clamp to >= 1 so a zero/negative budget still tests the t = 0 overlap.
+  for (int iter = 0; iter < std::max(1, option.maxIterations); ++iter) {
+    const Eigen::Vector3d currentTranslationA = motionA.translationAt(t);
+    Eigen::Matrix3d currentRotationA = Eigen::Matrix3d::Identity();
+    if (aRotates) {
+      currentRotationA = motionA.at(t).rotation();
+    }
+
+    auto supportA = [&](const Eigen::Vector3d& dir) -> Eigen::Vector3d {
+      if (aRotates) {
+        return currentTranslationA
+               + currentRotationA
+                     * shapeA.support(currentRotationA.transpose() * dir);
+      }
+      return currentTranslationA + shapeA.support(dir);
+    };
+
+    GjkResult gjkResult
+        = haveWarm ? detail::queryT(supportA, supportB, warmSimplex, initialDir)
+                   : detail::queryT(supportA, supportB, initialDir);
+    warmSimplex = gjkResult.simplex;
+    haveWarm = true;
+
+    if (gjkResult.intersecting) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      Eigen::Vector3d pointA = supportA(Eigen::Vector3d::UnitX());
+      Eigen::Vector3d pointB = supportB(-Eigen::Vector3d::UnitX());
+      result.point = pointB;
+      // Check the magnitude before normalizing: coincident support points
+      // (degenerate/overlapping configs) would otherwise yield a NaN normal
+      // that slips past a post-normalization guard (NaN < kEpsilon is false).
+      const Eigen::Vector3d normal = pointA - pointB;
+      if (normal.squaredNorm() < kEpsilon) {
+        result.normal = Eigen::Vector3d::UnitZ();
+      } else {
+        result.normal = normal.normalized();
+      }
+      return true;
+    }
+
+    const double distance = gjkResult.distance;
+
+    Eigen::Vector3d sepAxis = gjkResult.separationAxis;
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = gjkResult.closestPointB - gjkResult.closestPointA;
+    }
+    if (sepAxis.squaredNorm() < kEpsilon) {
+      sepAxis = Eigen::Vector3d::UnitX();
+    }
+    sepAxis.normalize();
+
+    if (distance < option.tolerance) {
+      result.hit = true;
+      result.timeOfImpact = t;
+      result.point = gjkResult.closestPointB;
+      result.normal = sepAxis;
+      return true;
+    }
+
+    double dt;
+    if (option.advancement == CcdAdvancement::Fast) {
+      // Fast (non-conservative) step: divide the gap by the maximum forward
+      // displacement over the rest of the motion. This strides much closer to
+      // the obstacle per iteration but can overshoot a curved first contact and
+      // converge on a later one -- the speed-for-tunnelling trade the caller
+      // opts into.
+      Eigen::Vector3d toward
+          = gjkResult.closestPointB - gjkResult.closestPointA;
+      if (toward.squaredNorm() < kEpsilon) {
+        toward = sepAxis;
+      }
+      toward.normalize();
+      const double disp = motionA.maxForwardDisplacement(t, toward)
+                          + motionA.maxAngularSpeed(t) * (1.0 - t) * maxRadius;
+      dt = distance / std::max(disp, option.tolerance);
+    } else {
+      // Acceleration-bounded conservative step. Over [t, t+dt] the point speed
+      // is at most v0 + s*accel (translation, linearized by its
+      // second-derivative bound) plus a constant angular contribution, so the
+      // closing of the gap is at most (v0 + angular)*dt + accel*dt^2/2. Solving
+      // that quadratic for the dt that closes exactly `distance` gives the
+      // largest provably safe step -- tighter than distance/max_speed because
+      // it does not assume the curve is already moving at its peak speed.
+      const double v0 = motionA.linearSpeedAt(t);
+      const double angular = motionA.maxAngularSpeed(t) * maxRadius;
+      const double accel = motionA.maxLinearAccel(t);
+      const double linearTerm = v0 + angular;
+
+      if (accel < option.tolerance) {
+        dt = distance / std::max(linearTerm, option.tolerance);
+      } else {
+        // Larger root of (accel/2) dt^2 + linearTerm dt - distance = 0.
+        dt = (-linearTerm
+              + std::sqrt(linearTerm * linearTerm + 2.0 * accel * distance))
+             / accel;
+      }
+    }
+    if (dt < kEpsilon) {
+      dt = kEpsilon;
+    }
+    t += dt;
+    if (t > 1.0) {
+      return false;
+    }
+
+    initialDir = sepAxis;
+  }
+
+  return false;
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/Ccd.cpp
+++ b/dart/collision/native/narrow_phase/Ccd.cpp
@@ -293,7 +293,7 @@ bool sphereCastConvexTarget(
       result.hit = true;
       result.timeOfImpact = t;
       result.point = pointB;
-      result.normal = sepAxis;
+      result.normal = -sepAxis;
       return true;
     }
 
@@ -912,7 +912,7 @@ bool capsuleCastConvexTarget(
       result.hit = true;
       result.timeOfImpact = t;
       result.point = pointB;
-      result.normal = sepAxis;
+      result.normal = -sepAxis;
       return true;
     }
 
@@ -1474,7 +1474,7 @@ bool conservativeAdvancement(
       result.hit = true;
       result.timeOfImpact = t;
       result.point = pointB;
-      result.normal = sepAxis;
+      result.normal = -sepAxis;
       return true;
     }
 
@@ -1593,7 +1593,7 @@ bool convexCast(
       result.hit = true;
       result.timeOfImpact = t;
       result.point = pointB;
-      result.normal = sepAxis;
+      result.normal = -sepAxis;
       return true;
     }
 
@@ -1720,7 +1720,7 @@ bool splineCast(
       result.hit = true;
       result.timeOfImpact = t;
       result.point = gjkResult.closestPointB;
-      result.normal = sepAxis;
+      result.normal = -sepAxis;
       return true;
     }
 

--- a/dart/collision/native/narrow_phase/Ccd.hpp
+++ b/dart/collision/native/narrow_phase/Ccd.hpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/collision/native/Export.hpp>
+#include <dart/collision/native/Types.hpp>
+#include <dart/collision/native/shapes/Shape.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <array>
+
+namespace dart::collision::native {
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool sphereCastSphere(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const SphereShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool sphereCastBox(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const BoxShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool sphereCastCapsule(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const CapsuleShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool sphereCastPlane(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const PlaneShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool sphereCastCylinder(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const CylinderShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool sphereCastConvex(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const ConvexShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool sphereCastMesh(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const MeshShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool capsuleCastSphere(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const SphereShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool capsuleCastBox(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const BoxShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool capsuleCastCapsule(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const CapsuleShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool capsuleCastPlane(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const PlaneShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool capsuleCastCylinder(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const CylinderShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool capsuleCastConvex(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const ConvexShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool capsuleCastMesh(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const MeshShape& target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result);
+
+[[nodiscard]] DART_COLLISION_NATIVE_API bool conservativeAdvancement(
+    const ConvexShape& shapeA,
+    const Eigen::Isometry3d& transformAStart,
+    const Eigen::Isometry3d& transformAEnd,
+    const ConvexShape& shapeB,
+    const Eigen::Isometry3d& transformB,
+    const CcdOption& option,
+    CcdResult& result);
+
+/// Conservative advancement when BOTH convex shapes move over the step.
+///
+/// Generalizes conservativeAdvancement (which holds shape B fixed) to the case
+/// where shape B also translates/rotates, matching reference-engine continuous
+/// collision where each body carries its own motion. The closest distance can
+/// change no faster than the sum of the two per-shape motion bounds, so
+/// advancing by distance / (boundA + boundB) is conservative.
+[[nodiscard]] DART_COLLISION_NATIVE_API bool convexCast(
+    const ConvexShape& shapeA,
+    const Eigen::Isometry3d& transformAStart,
+    const Eigen::Isometry3d& transformAEnd,
+    const ConvexShape& shapeB,
+    const Eigen::Isometry3d& transformBStart,
+    const Eigen::Isometry3d& transformBEnd,
+    const CcdOption& option,
+    CcdResult& result);
+
+/// Conservative advancement for shape A following a cubic polynomial (spline)
+/// trajectory against a static convex shape B.
+///
+/// The trajectory is a cubic Bezier in both translation and rotation vector,
+/// matching the spline-motion parameterization of the reference engine that
+/// supports it: translation `T(t) = sum_i B_i(t) translationControlPoints[i]`
+/// and orientation `R(t) = exp([sum_i B_i(t) rotationControlPoints[i]])` with
+/// `B_i` the cubic Bernstein basis. A spline path is the one motion model the
+/// linear/screw casts cannot represent: it can curve away from the chord
+/// between its endpoints, so a straight-line or screw cast over the same
+/// endpoints can miss a collision the spline actually makes. Pass four zero
+/// vectors for `rotationControlPoints` to sweep a curved translational path
+/// with no spin.
+///
+/// With `CcdAdvancement::Conservative` (the default) the step is
+/// acceleration-bounded -- the gap closes by at most `(v0 + angular)*dt +
+/// accel*dt^2/2`, whose root gives the largest provably safe step. It never
+/// overshoots a true contact (the SO(3) exponential's right Jacobian is a
+/// contraction, so `|omega| <= |W'|`), which is the no-tunnelling guarantee
+/// barrier/IPC solvers need. With `CcdAdvancement::Fast` the step instead
+/// divides the gap by the maximum forward displacement over the rest of the
+/// motion: far fewer iterations, but it may stride past a sharply curved first
+/// contact and report a later one -- for rigid-body use where speed matters
+/// more than first-contact precision.
+[[nodiscard]] DART_COLLISION_NATIVE_API bool splineCast(
+    const ConvexShape& shapeA,
+    const std::array<Eigen::Vector3d, 4>& translationControlPoints,
+    const std::array<Eigen::Vector3d, 4>& rotationControlPoints,
+    const ConvexShape& shapeB,
+    const Eigen::Isometry3d& transformB,
+    const CcdOption& option,
+    CcdResult& result);
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/NarrowPhase.cpp
+++ b/dart/collision/native/narrow_phase/NarrowPhase.cpp
@@ -34,6 +34,7 @@
 #include <dart/collision/native/narrow_phase/CapsuleBox.hpp>
 #include <dart/collision/native/narrow_phase/CapsuleCapsule.hpp>
 #include <dart/collision/native/narrow_phase/CapsuleSphere.hpp>
+#include <dart/collision/native/narrow_phase/Ccd.hpp>
 #include <dart/collision/native/narrow_phase/ConvexConvex.hpp>
 #include <dart/collision/native/narrow_phase/CylinderCollision.hpp>
 #include <dart/collision/native/narrow_phase/Distance.hpp>
@@ -829,6 +830,184 @@ bool raycastShape(
   }
 }
 
+bool sphereCastShape(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const Shape* shape,
+    const Eigen::Isometry3d& transform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  if (!shape) {
+    return false;
+  }
+
+  switch (shape->getType()) {
+    case ShapeType::Sphere: {
+      const auto* s = static_cast<const SphereShape*>(shape);
+      return sphereCastSphere(
+          sphereStart, sphereEnd, sphereRadius, *s, transform, option, result);
+    }
+    case ShapeType::Box: {
+      const auto* b = static_cast<const BoxShape*>(shape);
+      return sphereCastBox(
+          sphereStart, sphereEnd, sphereRadius, *b, transform, option, result);
+    }
+    case ShapeType::Capsule: {
+      const auto* c = static_cast<const CapsuleShape*>(shape);
+      return sphereCastCapsule(
+          sphereStart, sphereEnd, sphereRadius, *c, transform, option, result);
+    }
+    case ShapeType::Cylinder: {
+      const auto* c = static_cast<const CylinderShape*>(shape);
+      return sphereCastCylinder(
+          sphereStart, sphereEnd, sphereRadius, *c, transform, option, result);
+    }
+    case ShapeType::Plane: {
+      const auto* p = static_cast<const PlaneShape*>(shape);
+      return sphereCastPlane(
+          sphereStart, sphereEnd, sphereRadius, *p, transform, option, result);
+    }
+    case ShapeType::Convex: {
+      const auto* c = static_cast<const ConvexShape*>(shape);
+      return sphereCastConvex(
+          sphereStart, sphereEnd, sphereRadius, *c, transform, option, result);
+    }
+    case ShapeType::Mesh: {
+      const auto* m = static_cast<const MeshShape*>(shape);
+      return sphereCastMesh(
+          sphereStart, sphereEnd, sphereRadius, *m, transform, option, result);
+    }
+    case ShapeType::Compound: {
+      const auto* compound = static_cast<const CompoundShape*>(shape);
+      bool hit = false;
+      double bestTime = 2.0;
+      CcdResult bestResult;
+
+      for (const auto& child : compound->children()) {
+        if (!child.shape) {
+          continue;
+        }
+
+        CcdResult childResult;
+        if (sphereCastShape(
+                sphereStart,
+                sphereEnd,
+                sphereRadius,
+                child.shape.get(),
+                transform * child.localTransform,
+                option,
+                childResult)) {
+          if (childResult.timeOfImpact < bestTime) {
+            bestTime = childResult.timeOfImpact;
+            bestResult = childResult;
+          }
+          hit = true;
+        }
+      }
+
+      if (hit) {
+        result = bestResult;
+      }
+      return hit;
+    }
+    default:
+      return false;
+  }
+}
+
+bool capsuleCastShape(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const Shape* shape,
+    const Eigen::Isometry3d& transform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  result.clear();
+
+  if (!shape) {
+    return false;
+  }
+
+  switch (shape->getType()) {
+    case ShapeType::Sphere: {
+      const auto* s = static_cast<const SphereShape*>(shape);
+      return capsuleCastSphere(
+          capsuleStart, capsuleEnd, capsule, *s, transform, option, result);
+    }
+    case ShapeType::Box: {
+      const auto* b = static_cast<const BoxShape*>(shape);
+      return capsuleCastBox(
+          capsuleStart, capsuleEnd, capsule, *b, transform, option, result);
+    }
+    case ShapeType::Capsule: {
+      const auto* c = static_cast<const CapsuleShape*>(shape);
+      return capsuleCastCapsule(
+          capsuleStart, capsuleEnd, capsule, *c, transform, option, result);
+    }
+    case ShapeType::Plane: {
+      const auto* p = static_cast<const PlaneShape*>(shape);
+      return capsuleCastPlane(
+          capsuleStart, capsuleEnd, capsule, *p, transform, option, result);
+    }
+    case ShapeType::Cylinder: {
+      const auto* c = static_cast<const CylinderShape*>(shape);
+      return capsuleCastCylinder(
+          capsuleStart, capsuleEnd, capsule, *c, transform, option, result);
+    }
+    case ShapeType::Convex: {
+      const auto* c = static_cast<const ConvexShape*>(shape);
+      return capsuleCastConvex(
+          capsuleStart, capsuleEnd, capsule, *c, transform, option, result);
+    }
+    case ShapeType::Mesh: {
+      const auto* m = static_cast<const MeshShape*>(shape);
+      return capsuleCastMesh(
+          capsuleStart, capsuleEnd, capsule, *m, transform, option, result);
+    }
+    case ShapeType::Compound: {
+      const auto* compound = static_cast<const CompoundShape*>(shape);
+      bool hit = false;
+      double bestTime = 2.0;
+      CcdResult bestResult;
+
+      for (const auto& child : compound->children()) {
+        if (!child.shape) {
+          continue;
+        }
+
+        CcdResult childResult;
+        if (capsuleCastShape(
+                capsuleStart,
+                capsuleEnd,
+                capsule,
+                child.shape.get(),
+                transform * child.localTransform,
+                option,
+                childResult)) {
+          if (childResult.timeOfImpact < bestTime) {
+            bestTime = childResult.timeOfImpact;
+            bestResult = childResult;
+          }
+          hit = true;
+        }
+      }
+
+      if (hit) {
+        result = bestResult;
+      }
+      return hit;
+    }
+    default:
+      return false;
+  }
+}
+
 bool collideBatchShapes(
     span<const NarrowPhasePair> pairs,
     span<CollisionResult> results,
@@ -913,6 +1092,44 @@ bool NarrowPhase::raycast(
     RaycastResult& result)
 {
   return raycastShape(ray, shape, transform, option, result);
+}
+
+bool NarrowPhase::sphereCast(
+    const Eigen::Vector3d& sphereStart,
+    const Eigen::Vector3d& sphereEnd,
+    double sphereRadius,
+    const Shape* target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  return sphereCastShape(
+      sphereStart,
+      sphereEnd,
+      sphereRadius,
+      target,
+      targetTransform,
+      option,
+      result);
+}
+
+bool NarrowPhase::capsuleCast(
+    const Eigen::Isometry3d& capsuleStart,
+    const Eigen::Isometry3d& capsuleEnd,
+    const CapsuleShape& capsule,
+    const Shape* target,
+    const Eigen::Isometry3d& targetTransform,
+    const CcdOption& option,
+    CcdResult& result)
+{
+  return capsuleCastShape(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
 }
 
 bool NarrowPhase::isSupported(ShapeType type1, ShapeType type2)
@@ -1057,6 +1274,40 @@ bool NarrowPhase::isRaycastSupported(ShapeType type)
     case ShapeType::Plane:
     case ShapeType::Mesh:
     case ShapeType::Convex:
+    case ShapeType::Compound:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool NarrowPhase::isSphereCastSupported(ShapeType type)
+{
+  switch (type) {
+    case ShapeType::Sphere:
+    case ShapeType::Box:
+    case ShapeType::Capsule:
+    case ShapeType::Cylinder:
+    case ShapeType::Plane:
+    case ShapeType::Convex:
+    case ShapeType::Mesh:
+    case ShapeType::Compound:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool NarrowPhase::isCapsuleCastSupported(ShapeType type)
+{
+  switch (type) {
+    case ShapeType::Sphere:
+    case ShapeType::Box:
+    case ShapeType::Capsule:
+    case ShapeType::Plane:
+    case ShapeType::Cylinder:
+    case ShapeType::Convex:
+    case ShapeType::Mesh:
     case ShapeType::Compound:
       return true;
     default:

--- a/dart/collision/native/narrow_phase/NarrowPhase.hpp
+++ b/dart/collision/native/narrow_phase/NarrowPhase.hpp
@@ -41,6 +41,7 @@
 
 namespace dart::collision::native {
 
+class CapsuleShape;
 enum class ShapeType;
 
 struct DART_COLLISION_NATIVE_API NarrowPhasePair

--- a/dart/collision/native/narrow_phase/NarrowPhase.hpp
+++ b/dart/collision/native/narrow_phase/NarrowPhase.hpp
@@ -88,11 +88,33 @@ public:
       const RaycastOption& option,
       RaycastResult& result);
 
+  static bool sphereCast(
+      const Eigen::Vector3d& sphereStart,
+      const Eigen::Vector3d& sphereEnd,
+      double sphereRadius,
+      const Shape* target,
+      const Eigen::Isometry3d& targetTransform,
+      const CcdOption& option,
+      CcdResult& result);
+
+  static bool capsuleCast(
+      const Eigen::Isometry3d& capsuleStart,
+      const Eigen::Isometry3d& capsuleEnd,
+      const CapsuleShape& capsule,
+      const Shape* target,
+      const Eigen::Isometry3d& targetTransform,
+      const CcdOption& option,
+      CcdResult& result);
+
   static bool isSupported(ShapeType type1, ShapeType type2);
 
   static bool isDistanceSupported(ShapeType type1, ShapeType type2);
 
   static bool isRaycastSupported(ShapeType type);
+
+  static bool isSphereCastSupported(ShapeType type);
+
+  static bool isCapsuleCastSupported(ShapeType type);
 };
 
 } // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/PrimitiveCcd.cpp
+++ b/dart/collision/native/narrow_phase/PrimitiveCcd.cpp
@@ -401,6 +401,72 @@ bool pointInsideTriangle(
   return u >= -slack && v >= -slack && w >= -slack;
 }
 
+std::array<Eigen::Vector3d, 3> crossQuadraticCoefficients(
+    const Eigen::Vector3d& x0,
+    const Eigen::Vector3d& dx,
+    const Eigen::Vector3d& y0,
+    const Eigen::Vector3d& dy)
+{
+  return {x0.cross(y0), x0.cross(dy) + dx.cross(y0), dx.cross(dy)};
+}
+
+void addVectorQuadraticZeroRoots(
+    const std::array<Eigen::Vector3d, 3>& coef, std::vector<double>& candidates)
+{
+  for (int i = 0; i < 3; ++i) {
+    quadraticRootsInUnit(coef[2][i], coef[1][i], coef[0][i], candidates);
+  }
+}
+
+void addMovingPointOnSegmentRoots(
+    const Eigen::Vector3d& pointStart,
+    const Eigen::Vector3d& pointVelocity,
+    const Eigen::Vector3d& segmentStart,
+    const Eigen::Vector3d& segmentVelocity,
+    const Eigen::Vector3d& segmentEndStart,
+    const Eigen::Vector3d& segmentEndVelocity,
+    std::vector<double>& candidates)
+{
+  addVectorQuadraticZeroRoots(
+      crossQuadraticCoefficients(
+          segmentEndStart - segmentStart,
+          segmentEndVelocity - segmentVelocity,
+          pointStart - segmentStart,
+          pointVelocity - segmentVelocity),
+      candidates);
+}
+
+void addMovingPointPairRoots(
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aVelocity,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bVelocity,
+    std::vector<double>& candidates)
+{
+  const Eigen::Vector3d offset = aStart - bStart;
+  const Eigen::Vector3d velocity = aVelocity - bVelocity;
+  for (int i = 0; i < 3; ++i) {
+    if (std::abs(velocity[i]) <= kEpsilon) {
+      continue;
+    }
+    const double t = -offset[i] / velocity[i];
+    if (t > 0.0 && t < 1.0) {
+      candidates.push_back(t);
+    }
+  }
+}
+
+void sortUniqueCandidates(std::vector<double>& candidates)
+{
+  std::sort(candidates.begin(), candidates.end());
+  candidates.erase(
+      std::unique(
+          candidates.begin(),
+          candidates.end(),
+          [](double x, double y) { return std::abs(x - y) <= 1e-9; }),
+      candidates.end());
+}
+
 } // namespace
 
 //==============================================================================
@@ -529,26 +595,17 @@ bool pointTriangleCcdExact(
        std::abs(coef[2]),
        std::abs(coef[3])});
   if (coefMag <= 1e-10 * triangleScale * triangleScale * triangleScale) {
-    constexpr int kSamples = 256;
-    bool prevContact = contactAt(0.0);
-    for (int i = 1; i <= kSamples; ++i) {
-      double hi = static_cast<double>(i) / static_cast<double>(kSamples);
-      bool curContact = contactAt(hi);
-      if (!prevContact && curContact) {
-        double lo = static_cast<double>(i - 1) / static_cast<double>(kSamples);
-        for (int b = 0; b < 40; ++b) {
-          const double mid = 0.5 * (lo + hi);
-          if (contactAt(mid)) {
-            hi = mid;
-          } else {
-            lo = mid;
-          }
-        }
-        candidates.push_back(hi);
-      }
-      prevContact = curContact;
-    }
-    std::sort(candidates.begin(), candidates.end());
+    addMovingPointOnSegmentRoots(
+        pStart, dp, aStart, da, bStart, db, candidates);
+    addMovingPointOnSegmentRoots(
+        pStart, dp, bStart, db, cStart, dc, candidates);
+    addMovingPointOnSegmentRoots(
+        pStart, dp, cStart, dc, aStart, da, candidates);
+
+    addMovingPointPairRoots(pStart, dp, aStart, da, candidates);
+    addMovingPointPairRoots(pStart, dp, bStart, db, candidates);
+    addMovingPointPairRoots(pStart, dp, cStart, dc, candidates);
+    sortUniqueCandidates(candidates);
   }
 
   for (const double t : candidates) {
@@ -621,39 +678,20 @@ bool edgeEdgeCcdExact(
        std::abs(coef[2]),
        std::abs(coef[3])});
   if (coefMag <= 1e-10 * edgeScale * edgeScale * edgeScale) {
-    const auto segGap = [&](double t) {
-      double s = 0.0;
-      double u = 0.0;
-      return distanceSegmentSegment(
-                 aStart + t * da,
-                 bStart + t * db,
-                 cStart + t * dc,
-                 dStart + t * dd,
-                 s,
-                 u)
-             - distTol;
-    };
-    constexpr int kSamples = 256;
-    double prevGap = segGap(0.0);
-    for (int i = 1; i <= kSamples; ++i) {
-      double hi = static_cast<double>(i) / static_cast<double>(kSamples);
-      const double curGap = segGap(hi);
-      if (prevGap > 0.0 && curGap <= 0.0) {
-        // Entering contact between (i-1)/N and i/N; bisect for the entry time.
-        double lo = static_cast<double>(i - 1) / static_cast<double>(kSamples);
-        for (int b = 0; b < 40; ++b) {
-          const double mid = 0.5 * (lo + hi);
-          if (segGap(mid) > 0.0) {
-            lo = mid;
-          } else {
-            hi = mid;
-          }
-        }
-        candidates.push_back(hi);
-      }
-      prevGap = curGap;
-    }
-    std::sort(candidates.begin(), candidates.end());
+    addMovingPointOnSegmentRoots(
+        aStart, da, cStart, dc, dStart, dd, candidates);
+    addMovingPointOnSegmentRoots(
+        bStart, db, cStart, dc, dStart, dd, candidates);
+    addMovingPointOnSegmentRoots(
+        cStart, dc, aStart, da, bStart, db, candidates);
+    addMovingPointOnSegmentRoots(
+        dStart, dd, aStart, da, bStart, db, candidates);
+
+    addMovingPointPairRoots(aStart, da, cStart, dc, candidates);
+    addMovingPointPairRoots(aStart, da, dStart, dd, candidates);
+    addMovingPointPairRoots(bStart, db, cStart, dc, candidates);
+    addMovingPointPairRoots(bStart, db, dStart, dd, candidates);
+    sortUniqueCandidates(candidates);
   }
 
   for (const double t : candidates) {

--- a/dart/collision/native/narrow_phase/PrimitiveCcd.cpp
+++ b/dart/collision/native/narrow_phase/PrimitiveCcd.cpp
@@ -1,0 +1,633 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/narrow_phase/PrimitiveCcd.hpp>
+
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <array>
+#include <vector>
+
+#include <cmath>
+
+namespace dart::collision::native {
+
+namespace {
+
+constexpr double kEpsilon = 1e-12;
+
+// Conservative advancement scaling s in (0, 1). Each step covers (1 - s) of the
+// maximal provably-safe advance, which (a) keeps the iterate strictly short of
+// contact and (b) gives geometric convergence so the loop terminates in O(1/s)
+// iterations. s = 0.1 matches the additive-CCD inner loop (factor 0.9).
+constexpr double kConservativeScale = 0.1;
+
+//==============================================================================
+// Closest-distance primitives (Ericson, Real-Time Collision Detection)
+//==============================================================================
+
+Eigen::Vector3d closestPointOnTriangle(
+    const Eigen::Vector3d& p,
+    const Eigen::Vector3d& a,
+    const Eigen::Vector3d& b,
+    const Eigen::Vector3d& c)
+{
+  const Eigen::Vector3d ab = b - a;
+  const Eigen::Vector3d ac = c - a;
+  const Eigen::Vector3d ap = p - a;
+
+  const double d1 = ab.dot(ap);
+  const double d2 = ac.dot(ap);
+  if (d1 <= 0.0 && d2 <= 0.0) {
+    return a;
+  }
+
+  const Eigen::Vector3d bp = p - b;
+  const double d3 = ab.dot(bp);
+  const double d4 = ac.dot(bp);
+  if (d3 >= 0.0 && d4 <= d3) {
+    return b;
+  }
+
+  const double vc = d1 * d4 - d3 * d2;
+  if (vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0) {
+    const double v = d1 / (d1 - d3);
+    return a + v * ab;
+  }
+
+  const Eigen::Vector3d cp = p - c;
+  const double d5 = ab.dot(cp);
+  const double d6 = ac.dot(cp);
+  if (d6 >= 0.0 && d5 <= d6) {
+    return c;
+  }
+
+  const double vb = d5 * d2 - d1 * d6;
+  if (vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0) {
+    const double w = d2 / (d2 - d6);
+    return a + w * ac;
+  }
+
+  const double va = d3 * d6 - d5 * d4;
+  if (va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0) {
+    const double w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+    return b + w * (c - b);
+  }
+
+  const double denom = 1.0 / (va + vb + vc);
+  const double v = vb * denom;
+  const double w = vc * denom;
+  return a + ab * v + ac * w;
+}
+
+double distancePointTriangle(
+    const Eigen::Vector3d& p,
+    const Eigen::Vector3d& a,
+    const Eigen::Vector3d& b,
+    const Eigen::Vector3d& c)
+{
+  return (p - closestPointOnTriangle(p, a, b, c)).norm();
+}
+
+double distanceSegmentSegment(
+    const Eigen::Vector3d& p1,
+    const Eigen::Vector3d& q1,
+    const Eigen::Vector3d& p2,
+    const Eigen::Vector3d& q2,
+    double& sOut,
+    double& tOut)
+{
+  const Eigen::Vector3d d1 = q1 - p1;
+  const Eigen::Vector3d d2 = q2 - p2;
+  const Eigen::Vector3d r = p1 - p2;
+  const double a = d1.dot(d1);
+  const double e = d2.dot(d2);
+  const double f = d2.dot(r);
+
+  double s = 0.0;
+  double t = 0.0;
+
+  if (a <= kEpsilon && e <= kEpsilon) {
+    s = 0.0;
+    t = 0.0;
+  } else if (a <= kEpsilon) {
+    s = 0.0;
+    t = std::clamp(f / e, 0.0, 1.0);
+  } else {
+    const double c = d1.dot(r);
+    if (e <= kEpsilon) {
+      t = 0.0;
+      s = std::clamp(-c / a, 0.0, 1.0);
+    } else {
+      const double b = d1.dot(d2);
+      const double denom = a * e - b * b;
+      if (denom > kEpsilon) {
+        s = std::clamp((b * f - c * e) / denom, 0.0, 1.0);
+      } else {
+        s = 0.0;
+      }
+      t = (b * s + f) / e;
+      if (t < 0.0) {
+        t = 0.0;
+        s = std::clamp(-c / a, 0.0, 1.0);
+      } else if (t > 1.0) {
+        t = 1.0;
+        s = std::clamp((b - c) / a, 0.0, 1.0);
+      }
+    }
+  }
+
+  sOut = s;
+  tOut = t;
+  const Eigen::Vector3d c1 = p1 + d1 * s;
+  const Eigen::Vector3d c2 = p2 + d2 * t;
+  return (c1 - c2).norm();
+}
+
+double distanceSegmentSegment(
+    const Eigen::Vector3d& p1,
+    const Eigen::Vector3d& q1,
+    const Eigen::Vector3d& p2,
+    const Eigen::Vector3d& q2)
+{
+  double s = 0.0;
+  double t = 0.0;
+  return distanceSegmentSegment(p1, q1, p2, q2, s, t);
+}
+
+//==============================================================================
+// Additive conservative advancement (ACCD)
+//==============================================================================
+
+// Generic ACCD loop. lp is the additive relative-velocity bound on the
+// (already mean-centered) trajectories; distAt(t) returns the unsigned distance
+// between the two primitives at time t along those trajectories.
+template <typename DistFn>
+bool accdAdvance(
+    double lp,
+    const CcdOption& option,
+    DistFn&& distAt,
+    CcdPrimitiveResult& result)
+{
+  result.clear();
+
+  const double minSeparation = std::max(0.0, option.minSeparation);
+  double d = distAt(0.0);
+
+  const double gap0 = d - minSeparation;
+  if (gap0 <= 0.0) {
+    result.hit = true;
+    result.status = CcdPrimitiveStatus::Hit;
+    result.timeOfImpact = 0.0;
+    return true;
+  }
+
+  if (lp <= kEpsilon) {
+    // No relative motion: the clearance is constant, so no new contact forms.
+    result.status = CcdPrimitiveStatus::Miss;
+    return false;
+  }
+
+  const double stepFactor = 1.0 - kConservativeScale;
+  // Absolute contact band. A hit means the primitives close to within
+  // minSeparation, so the threshold must be an absolute distance -- scaling it
+  // by the initial gap would report a hit for a non-colliding near-miss that
+  // merely ends close relative to a large starting separation.
+  const double convergeAbs = std::max(option.tolerance, kEpsilon);
+  const int maxIter = std::max(1, option.maxIterations);
+
+  double t = 0.0;
+  for (int iter = 0; iter < maxIter; ++iter) {
+    const double clearance = d - minSeparation;
+    if (clearance <= convergeAbs) {
+      result.hit = true;
+      result.status = CcdPrimitiveStatus::Hit;
+      result.timeOfImpact = t;
+      return true;
+    }
+
+    // The distance shrinks no faster than the additive velocity bound lp, so
+    // the earliest the gap can reach contact is t + clearance / lp. If that is
+    // at or beyond the end of the step, the only contact possible in the
+    // inclusive interval [0, 1] is exactly at the final endpoint, so check
+    // t = 1 directly before giving up (an end-of-step contact is still a hit).
+    // (This also bounds the loop: each iteration adds at least
+    // stepFactor * convergeAbs / lp to t, so t reaches this guard or the
+    // convergence threshold in finite steps for any well-posed input.)
+    if (t + clearance / lp >= 1.0) {
+      if (distAt(1.0) - minSeparation <= convergeAbs) {
+        result.hit = true;
+        result.status = CcdPrimitiveStatus::Hit;
+        result.timeOfImpact = 1.0;
+        return true;
+      }
+      result.status = CcdPrimitiveStatus::Miss;
+      return false;
+    }
+
+    t += stepFactor * clearance / lp;
+    d = distAt(t);
+  }
+
+  // Exhausted the iteration budget without converging to contact or proving
+  // none can occur -- a slow, near-tangential approach that has not been shown
+  // to close to minSeparation in [0, 1].
+  result.status = CcdPrimitiveStatus::Indeterminate;
+  return false;
+}
+
+//==============================================================================
+// Exact coplanarity cubic (validation only)
+//==============================================================================
+
+// Coplanarity cubic f(t) = (z0 + t dz) . ((x0 + t dx) x (y0 + t dy)) for the
+// four moving points, returned as coefficients [c0, c1, c2, c3] (ascending).
+std::array<double, 4> coplanarityCubic(
+    const Eigen::Vector3d& x0,
+    const Eigen::Vector3d& dx,
+    const Eigen::Vector3d& y0,
+    const Eigen::Vector3d& dy,
+    const Eigen::Vector3d& z0,
+    const Eigen::Vector3d& dz)
+{
+  const Eigen::Vector3d c0 = x0.cross(y0);
+  const Eigen::Vector3d c1 = x0.cross(dy) + dx.cross(y0);
+  const Eigen::Vector3d c2 = dx.cross(dy);
+
+  return {
+      z0.dot(c0), z0.dot(c1) + dz.dot(c0), z0.dot(c2) + dz.dot(c1), dz.dot(c2)};
+}
+
+double evalPoly(const std::array<double, 4>& coef, double t)
+{
+  return ((coef[3] * t + coef[2]) * t + coef[1]) * t + coef[0];
+}
+
+// Real roots of a*t^2 + b*t + c in (0, 1), appended to out.
+void quadraticRootsInUnit(
+    double a, double b, double c, std::vector<double>& out)
+{
+  if (std::abs(a) <= kEpsilon) {
+    if (std::abs(b) > kEpsilon) {
+      const double r = -c / b;
+      if (r > 0.0 && r < 1.0) {
+        out.push_back(r);
+      }
+    }
+    return;
+  }
+  const double disc = b * b - 4.0 * a * c;
+  if (disc < 0.0) {
+    return;
+  }
+  const double sq = std::sqrt(disc);
+  for (const double r : {(-b - sq) / (2.0 * a), (-b + sq) / (2.0 * a)}) {
+    if (r > 0.0 && r < 1.0) {
+      out.push_back(r);
+    }
+  }
+}
+
+double refineRootBisection(
+    const std::array<double, 4>& coef, double lo, double hi)
+{
+  double flo = evalPoly(coef, lo);
+  for (int i = 0; i < 80; ++i) {
+    const double mid = 0.5 * (lo + hi);
+    const double fmid = evalPoly(coef, mid);
+    if ((flo < 0.0) == (fmid < 0.0)) {
+      lo = mid;
+      flo = fmid;
+    } else {
+      hi = mid;
+    }
+  }
+  return 0.5 * (lo + hi);
+}
+
+// All real roots of the cubic in [0, 1], sorted ascending.
+std::vector<double> cubicRootsInUnit(const std::array<double, 4>& coef)
+{
+  std::vector<double> breaks;
+  breaks.push_back(0.0);
+  // Critical points partition [0,1] into monotonic intervals.
+  quadraticRootsInUnit(3.0 * coef[3], 2.0 * coef[2], coef[1], breaks);
+  breaks.push_back(1.0);
+  std::sort(breaks.begin(), breaks.end());
+
+  std::vector<double> roots;
+  for (std::size_t i = 0; i + 1 < breaks.size(); ++i) {
+    const double lo = breaks[i];
+    const double hi = breaks[i + 1];
+    if (hi - lo <= kEpsilon) {
+      continue;
+    }
+    const double flo = evalPoly(coef, lo);
+    const double fhi = evalPoly(coef, hi);
+    if (std::abs(flo) <= kEpsilon) {
+      roots.push_back(lo);
+    }
+    if ((flo < 0.0) != (fhi < 0.0)) {
+      roots.push_back(refineRootBisection(coef, lo, hi));
+    }
+  }
+  const double fEnd = evalPoly(coef, 1.0);
+  if (std::abs(fEnd) <= kEpsilon) {
+    roots.push_back(1.0);
+  }
+
+  std::sort(roots.begin(), roots.end());
+  roots.erase(
+      std::unique(
+          roots.begin(),
+          roots.end(),
+          [](double x, double y) { return std::abs(x - y) <= 1e-9; }),
+      roots.end());
+  return roots;
+}
+
+bool pointInsideTriangle(
+    const Eigen::Vector3d& p,
+    const Eigen::Vector3d& a,
+    const Eigen::Vector3d& b,
+    const Eigen::Vector3d& c,
+    double slack)
+{
+  const Eigen::Vector3d v0 = b - a;
+  const Eigen::Vector3d v1 = c - a;
+  const Eigen::Vector3d v2 = p - a;
+  const double d00 = v0.dot(v0);
+  const double d01 = v0.dot(v1);
+  const double d11 = v1.dot(v1);
+  const double d20 = v2.dot(v0);
+  const double d21 = v2.dot(v1);
+  const double denom = d00 * d11 - d01 * d01;
+  if (std::abs(denom) <= kEpsilon) {
+    return false;
+  }
+  const double v = (d11 * d20 - d01 * d21) / denom;
+  const double w = (d00 * d21 - d01 * d20) / denom;
+  const double u = 1.0 - v - w;
+  return u >= -slack && v >= -slack && w >= -slack;
+}
+
+} // namespace
+
+//==============================================================================
+// Public ACCD queries
+//==============================================================================
+
+bool pointTriangleCcd(
+    const Eigen::Vector3d& pStart,
+    const Eigen::Vector3d& pEnd,
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result)
+{
+  Eigen::Vector3d dp = pEnd - pStart;
+  Eigen::Vector3d da = aEnd - aStart;
+  Eigen::Vector3d db = bEnd - bStart;
+  Eigen::Vector3d dc = cEnd - cStart;
+
+  // Mean-center the displacements: collision depends only on relative motion,
+  // so this is exact and shrinks the velocity bound (additive CCD).
+  const Eigen::Vector3d mean = 0.25 * (dp + da + db + dc);
+  dp -= mean;
+  da -= mean;
+  db -= mean;
+  dc -= mean;
+
+  const double lp = dp.norm() + std::max({da.norm(), db.norm(), dc.norm()});
+
+  const auto distAt = [&](double t) {
+    return distancePointTriangle(
+        pStart + t * dp, aStart + t * da, bStart + t * db, cStart + t * dc);
+  };
+
+  return accdAdvance(lp, option, distAt, result);
+}
+
+bool edgeEdgeCcd(
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const Eigen::Vector3d& dStart,
+    const Eigen::Vector3d& dEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result)
+{
+  Eigen::Vector3d da = aEnd - aStart;
+  Eigen::Vector3d db = bEnd - bStart;
+  Eigen::Vector3d dc = cEnd - cStart;
+  Eigen::Vector3d dd = dEnd - dStart;
+
+  const Eigen::Vector3d mean = 0.25 * (da + db + dc + dd);
+  da -= mean;
+  db -= mean;
+  dc -= mean;
+  dd -= mean;
+
+  const double lp
+      = std::max(da.norm(), db.norm()) + std::max(dc.norm(), dd.norm());
+
+  const auto distAt = [&](double t) {
+    return distanceSegmentSegment(
+        aStart + t * da, bStart + t * db, cStart + t * dc, dStart + t * dd);
+  };
+
+  return accdAdvance(lp, option, distAt, result);
+}
+
+//==============================================================================
+// Public exact coplanarity-cubic queries (validation only)
+//==============================================================================
+
+bool pointTriangleCcdExact(
+    const Eigen::Vector3d& pStart,
+    const Eigen::Vector3d& pEnd,
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result)
+{
+  result.clear();
+
+  const Eigen::Vector3d dp = pEnd - pStart;
+  const Eigen::Vector3d da = aEnd - aStart;
+  const Eigen::Vector3d db = bEnd - bStart;
+  const Eigen::Vector3d dc = cEnd - cStart;
+
+  const Eigen::Vector3d x0 = bStart - aStart;
+  const Eigen::Vector3d dx = db - da;
+  const Eigen::Vector3d y0 = cStart - aStart;
+  const Eigen::Vector3d dy = dc - da;
+  const Eigen::Vector3d z0 = pStart - aStart;
+  const Eigen::Vector3d dz = dp - da;
+
+  const auto coef = coplanarityCubic(x0, dx, y0, dy, z0, dz);
+  const double slack = std::max(option.tolerance, 1e-9);
+
+  for (const double t : cubicRootsInUnit(coef)) {
+    const Eigen::Vector3d p = pStart + t * dp;
+    const Eigen::Vector3d a = aStart + t * da;
+    const Eigen::Vector3d b = bStart + t * db;
+    const Eigen::Vector3d c = cStart + t * dc;
+    if (pointInsideTriangle(p, a, b, c, slack)) {
+      result.hit = true;
+      result.status = CcdPrimitiveStatus::Hit;
+      result.timeOfImpact = std::clamp(t, 0.0, 1.0);
+      return true;
+    }
+  }
+  result.status = CcdPrimitiveStatus::Miss;
+  return false;
+}
+
+bool edgeEdgeCcdExact(
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const Eigen::Vector3d& dStart,
+    const Eigen::Vector3d& dEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result)
+{
+  result.clear();
+
+  const Eigen::Vector3d da = aEnd - aStart;
+  const Eigen::Vector3d db = bEnd - bStart;
+  const Eigen::Vector3d dc = cEnd - cStart;
+  const Eigen::Vector3d dd = dEnd - dStart;
+
+  const Eigen::Vector3d x0 = bStart - aStart;
+  const Eigen::Vector3d dx = db - da;
+  const Eigen::Vector3d y0 = dStart - cStart;
+  const Eigen::Vector3d dy = dd - dc;
+  const Eigen::Vector3d z0 = cStart - aStart;
+  const Eigen::Vector3d dz = dc - da;
+
+  const auto coef = coplanarityCubic(x0, dx, y0, dy, z0, dz);
+  const double slack = std::max(option.tolerance, 1e-9);
+
+  // Validation distance scale: a fraction of the edge lengths at the start.
+  const double edgeScale = std::max({x0.norm(), y0.norm(), 1.0});
+  const double distTol = slack * edgeScale + 1e-9;
+
+  const auto contactAt = [&](double t) {
+    const Eigen::Vector3d a = aStart + t * da;
+    const Eigen::Vector3d b = bStart + t * db;
+    const Eigen::Vector3d c = cStart + t * dc;
+    const Eigen::Vector3d d = dStart + t * dd;
+    double s = 0.0;
+    double u = 0.0;
+    const double dist = distanceSegmentSegment(a, b, c, d, s, u);
+    return dist <= distTol && s >= -slack && s <= 1.0 + slack && u >= -slack
+           && u <= 1.0 + slack;
+  };
+
+  std::vector<double> candidates = cubicRootsInUnit(coef);
+
+  // Degenerate case: when the coplanarity cubic is identically zero the four
+  // points stay coplanar for the whole step, so it yields no interior roots
+  // even though the segments can still cross mid-step. Bracket the
+  // segment-segment distance over [0, 1] and add interior crossing times so
+  // they get checked.
+  const double coefMag = std::max(
+      {std::abs(coef[0]),
+       std::abs(coef[1]),
+       std::abs(coef[2]),
+       std::abs(coef[3])});
+  if (coefMag <= 1e-10 * edgeScale * edgeScale * edgeScale) {
+    const auto segGap = [&](double t) {
+      double s = 0.0;
+      double u = 0.0;
+      return distanceSegmentSegment(
+                 aStart + t * da,
+                 bStart + t * db,
+                 cStart + t * dc,
+                 dStart + t * dd,
+                 s,
+                 u)
+             - distTol;
+    };
+    constexpr int kSamples = 256;
+    double prevGap = segGap(0.0);
+    for (int i = 1; i <= kSamples; ++i) {
+      double hi = static_cast<double>(i) / static_cast<double>(kSamples);
+      const double curGap = segGap(hi);
+      if (prevGap > 0.0 && curGap <= 0.0) {
+        // Entering contact between (i-1)/N and i/N; bisect for the entry time.
+        double lo = static_cast<double>(i - 1) / static_cast<double>(kSamples);
+        for (int b = 0; b < 40; ++b) {
+          const double mid = 0.5 * (lo + hi);
+          if (segGap(mid) > 0.0) {
+            lo = mid;
+          } else {
+            hi = mid;
+          }
+        }
+        candidates.push_back(hi);
+      }
+      prevGap = curGap;
+    }
+    std::sort(candidates.begin(), candidates.end());
+  }
+
+  for (const double t : candidates) {
+    if (contactAt(t)) {
+      result.hit = true;
+      result.status = CcdPrimitiveStatus::Hit;
+      result.timeOfImpact = std::clamp(t, 0.0, 1.0);
+      return true;
+    }
+  }
+  result.status = CcdPrimitiveStatus::Miss;
+  return false;
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/narrow_phase/PrimitiveCcd.cpp
+++ b/dart/collision/native/narrow_phase/PrimitiveCcd.cpp
@@ -509,12 +509,50 @@ bool pointTriangleCcdExact(
   const auto coef = coplanarityCubic(x0, dx, y0, dy, z0, dz);
   const double slack = std::max(option.tolerance, 1e-9);
 
-  for (const double t : cubicRootsInUnit(coef)) {
+  const double triangleScale = std::max({x0.norm(), y0.norm(), 1.0});
+  const double distTol = slack * triangleScale + 1e-9;
+
+  const auto contactAt = [&](double t) {
     const Eigen::Vector3d p = pStart + t * dp;
     const Eigen::Vector3d a = aStart + t * da;
     const Eigen::Vector3d b = bStart + t * db;
     const Eigen::Vector3d c = cStart + t * dc;
-    if (pointInsideTriangle(p, a, b, c, slack)) {
+    return distancePointTriangle(p, a, b, c) <= distTol
+           && pointInsideTriangle(p, a, b, c, slack);
+  };
+
+  std::vector<double> candidates = cubicRootsInUnit(coef);
+
+  const double coefMag = std::max(
+      {std::abs(coef[0]),
+       std::abs(coef[1]),
+       std::abs(coef[2]),
+       std::abs(coef[3])});
+  if (coefMag <= 1e-10 * triangleScale * triangleScale * triangleScale) {
+    constexpr int kSamples = 256;
+    bool prevContact = contactAt(0.0);
+    for (int i = 1; i <= kSamples; ++i) {
+      double hi = static_cast<double>(i) / static_cast<double>(kSamples);
+      bool curContact = contactAt(hi);
+      if (!prevContact && curContact) {
+        double lo = static_cast<double>(i - 1) / static_cast<double>(kSamples);
+        for (int b = 0; b < 40; ++b) {
+          const double mid = 0.5 * (lo + hi);
+          if (contactAt(mid)) {
+            hi = mid;
+          } else {
+            lo = mid;
+          }
+        }
+        candidates.push_back(hi);
+      }
+      prevContact = curContact;
+    }
+    std::sort(candidates.begin(), candidates.end());
+  }
+
+  for (const double t : candidates) {
+    if (contactAt(t)) {
       result.hit = true;
       result.status = CcdPrimitiveStatus::Hit;
       result.timeOfImpact = std::clamp(t, 0.0, 1.0);

--- a/dart/collision/native/narrow_phase/PrimitiveCcd.hpp
+++ b/dart/collision/native/narrow_phase/PrimitiveCcd.hpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// Primitive-level continuous collision detection for independently moving
+// vertices (point-triangle and edge-edge). These are the queries IPC-class and
+// deformable-body solvers consume: each vertex follows a linear trajectory
+// x(t) = x0 + t (x1 - x0) over the step t in [0, 1], and the query returns a
+// conservative time of impact. Rigid meshes are the special case where all
+// vertices of a body share one rigid motion sampled at the endpoints.
+//
+// The default solver is additive conservative advancement (ACCD): it returns a
+// time of impact that never overshoots the true first contact, which is the
+// safety contract a barrier method requires. An exact coplanarity-cubic solver
+// is also provided for validation/diagnostics; it is exact in real arithmetic
+// but not conservative under floating point, so it must not be used as a
+// runtime default. See docs/dev_tasks/continuous_collision_detection/.
+
+#include <dart/collision/native/Export.hpp>
+#include <dart/collision/native/Types.hpp>
+
+#include <Eigen/Core>
+
+namespace dart::collision::native {
+
+//==============================================================================
+// Additive conservative advancement (ACCD) - conservative, gap-aware default
+//==============================================================================
+
+/// Continuous collision between a moving point and a moving triangle.
+///
+/// The point moves pStart -> pEnd; the triangle vertices move aStart -> aEnd,
+/// bStart -> bEnd, cStart -> cEnd. Reports a hit if the point closes to within
+/// option.minSeparation of the triangle for some t in [0, 1];
+/// result.timeOfImpact is a conservative lower bound on that time.
+[[nodiscard]] DART_COLLISION_NATIVE_API bool pointTriangleCcd(
+    const Eigen::Vector3d& pStart,
+    const Eigen::Vector3d& pEnd,
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result);
+
+/// Continuous collision between two moving line segments (edges).
+///
+/// Edge A spans (aStart..aEnd) -> ... moving as aStart->aEnd' is encoded per
+/// endpoint: edge A endpoints are a (aStart at t0, aEnd at t1) and b; edge B
+/// endpoints are c and d. Reports a hit if the edges close to within
+/// option.minSeparation for some t in [0, 1]; result.timeOfImpact is a
+/// conservative lower bound on that time.
+[[nodiscard]] DART_COLLISION_NATIVE_API bool edgeEdgeCcd(
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const Eigen::Vector3d& dStart,
+    const Eigen::Vector3d& dEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result);
+
+//==============================================================================
+// Exact coplanarity-cubic solver - VALIDATION ONLY (not conservative under FP)
+//==============================================================================
+
+/// Exact point-triangle time of impact via the coplanarity cubic
+/// (Provot/Bridson). Exact in real arithmetic but not conservative under
+/// floating point; provided for cross-validation and diagnostics, never as a
+/// runtime default. Returns the earliest validated coplanarity time in [0, 1].
+[[nodiscard]] DART_COLLISION_NATIVE_API bool pointTriangleCcdExact(
+    const Eigen::Vector3d& pStart,
+    const Eigen::Vector3d& pEnd,
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result);
+
+/// Exact edge-edge time of impact via the coplanarity cubic (Provot/Bridson).
+/// Validation only; see pointTriangleCcdExact.
+[[nodiscard]] DART_COLLISION_NATIVE_API bool edgeEdgeCcdExact(
+    const Eigen::Vector3d& aStart,
+    const Eigen::Vector3d& aEnd,
+    const Eigen::Vector3d& bStart,
+    const Eigen::Vector3d& bEnd,
+    const Eigen::Vector3d& cStart,
+    const Eigen::Vector3d& cEnd,
+    const Eigen::Vector3d& dStart,
+    const Eigen::Vector3d& dEnd,
+    const CcdOption& option,
+    CcdPrimitiveResult& result);
+
+} // namespace dart::collision::native

--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -12,7 +12,7 @@
 >   names (a project convention; see the naming note in
 >   `02-default-environment-split.md`).
 >
-> _Last updated: 2026-07-08._
+> _Last updated: 2026-07-09._
 
 ## Lanes & owners
 
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1/D2 (#3352, #3355) merged; phase 3 D3 active on `feature/native-voxelgrid-compound` |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1-D3 (#3352, #3355, #3358) merged; phase 3 D4 active on `feature/native-ccd` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -98,6 +98,11 @@
   normalization (merged 2026-07-08).
 - **#3355** phase-3 D2 native detector raycast adapter and native-vs-Bullet
   raycast benchmarks (merged 2026-07-08).
+- **#3357** DART 6 autonomous AI workflow rename to `dart-ultrawork` (merged
+  2026-07-09).
+- **#3358** phase-3 D3 native `VoxelGridShape`/octree replacement via compound
+  voxel boxes and compound collision/distance/raycast routing (merged
+  2026-07-09).
 - **#3283** main-branch dual for the native sphere-sphere binary-check fix
   (merged 2026-07-07).
 
@@ -112,16 +117,16 @@
   **#3239** release-branch AI enforcement stack · **#3245** MSVC SIMD fix ·
   **#3233** release CI concurrency fix.
 
-### 🔄 Open — monitoring (checked 2026-07-08)
+### 🔄 Open — monitoring (checked 2026-07-09)
 
-- **Phase 3 D3** `feature/native-voxelgrid-compound` — active local slice for
-  native `VoxelGridShape`/octree replacement via compound voxel boxes. Keep it
-  one PR to reduce CI overhead.
+- **Phase 3 D4** `feature/native-ccd` — active local slice for native CCD
+  engine support (rigid sphere/capsule casts, primitive point-triangle/edge-edge
+  CCD, and shape+transform dispatcher entry points). Keep it one PR to reduce
+  CI overhead.
 - **#3353** is open on `release-6.20` for the separate performance-generalization
   plan parking lane.
-- **#3357** is a draft docs/workflow PR on `release-6.20`.
 - The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
-  #3324, and #3325 are merged. The perf lane's WP-PG.01 baseline packet
+  #3324, #3325, #3357, and #3358 are merged. The perf lane's WP-PG.01 baseline packet
   **#3263** also merged.
 
 Related remote heads still visible: `feature/native-occupancy-grid`,
@@ -152,11 +157,10 @@ before treating it as an open/active PR.)_
 - **Phase 2 status:** P1-P10 are merged: broadphase, dispatcher, adapter bridge,
   `"native"` registration, sphere/box/capsule/convex/cylinder/mesh/plane
   coverage, distance helpers, mixed-scene parity, and associated parity/
-  performance tests. **Phase 3 D1/D2 are merged (#3352/#3355):** native detector
-  distance and raycast adapter wiring against the FCL/Bullet incumbents, bundled
-  with DART 6-style native source/header basenames to avoid another cleanup PR.
-  **Current slice is phase 3 D3:** native VoxelGrid/octree replacement via
-  compound voxel boxes and compound collision routing.
+  performance tests. **Phase 3 D1-D3 are merged (#3352/#3355/#3358):** native
+  detector distance, raycast, and VoxelGrid/compound wiring against the FCL/
+  Bullet incumbents and prior DART 6 support gaps. **Current slice is phase 3
+  D4:** native CCD engine support.
 - **Default flip:** still late-phase only. Do not flip defaults until `03`'s full
   A/B packet and gz gate pass.
 - _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
@@ -168,8 +172,8 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `e3f7f67211e65d88d16834f331bc40b1f0edaead`; `origin/main` =
-     `c6b5152e777ec1b4607b61a97a82f0d588dfb60f`.
+     `e2e03ffe8ee99cedda2fcda051f6eb30dc102363`; `origin/main` =
+     `a70fc2ed5cb7c3a4c44759ec222ce0338b8507f54`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
    - All remote mutations are owned by the maintainer.
@@ -183,11 +187,12 @@ before treating it as an open/active PR.)_
    Windows `Install`-step and coverage `Build with coverage` failures
    reproduced on base pushes, and FreeBSD ssh exit-8 / runner `Setup pixi`
    failures are infra flakes that clear on re-run.
-4. **Native-collision lane: plan before port.** The #3056 performance stack is
-   useful evidence, but the DART 7 native port/default-flip is still unstarted
-   on DART 6.20. Do not treat `feature/native-occupancy-grid` or
-   `task/native-collision-performance-exec` as release-branch PRs unless a live
-   PR exists and is based on `release-6.20`.
+4. **Native-collision lane: stay inside the active phase.** The #3056
+   performance stack is useful evidence, but the DART 7 native default flip is
+   still a later phase. Phase 3 capability parity is active; do not treat
+   `feature/native-occupancy-grid` or `task/native-collision-performance-exec`
+   as release-branch PRs unless a live PR exists and is based on
+   `release-6.20`.
 
 ## Effort-level status
 
@@ -206,11 +211,12 @@ before treating it as an open/active PR.)_
 - **Just landed (2026-06-22):** legacy `dart/integration` dead-code removal (#3122);
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
-- **Open queue (2026-07-08):** no open native-collision release PRs remain after
-  #3355. Phase 3 D3 is active locally on `feature/native-voxelgrid-compound`; the
-  former #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319, plus
-  #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355 lane milestones, main-branch
-  dual #3283, and MSVC policy #3348 are merged.
+- **Open queue (2026-07-09):** no open native-collision release PRs remain after
+  #3358. Phase 3 D4 is active locally on `feature/native-ccd`; the former
+  #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319, plus
+  #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355/#3358 lane milestones,
+  main-branch dual #3283, workflow rename #3357, and MSVC policy #3348 are
+  merged.
 - **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE
   optional and eventually drops `fcl` from core. The DART 7 native engine is
   only partially ported to DART 6.20; default-flip is still a late-phase

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -1,6 +1,6 @@
 # HANDOFF — DART 6.20 dependency minimization (native collision port)
 
-> Session handoff, refreshed 2026-07-08. Read [README.md](README.md) (overall SSOT),
+> Session handoff, refreshed 2026-07-09. Read [README.md](README.md) (overall SSOT),
 > then [03-native-collision-port-scoping.md](03-native-collision-port-scoping.md)
 > (plan of record for the remaining work), then
 > [07-phase2-adapter-scoping.md](07-phase2-adapter-scoping.md) (phase-2 execution
@@ -61,11 +61,13 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
   native basename normalization, and native-vs-FCL distance benchmarks.
 - **#3355** phase-3 **D2**: native detector raycast adapter and native-vs-Bullet
   raycast benchmarks.
+- **#3358** phase-3 **D3**: native `VoxelGridShape`/octree replacement via
+  compound voxel boxes, plus compound collision/distance/raycast routing.
 
-`origin/release-6.20` tip at this refresh: `e3f7f67211e` (moves as the
+`origin/release-6.20` tip at this refresh: `e2e03ffe8ee` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
-## 4. Phase 2 complete; Phase 3 VoxelGrid/compound active
+## 4. Phase 2 complete; Phase 3 CCD active
 
 Bridge design (see `07` §0–§1): **bypass DART 7's EnTT `CollisionWorld`**; the
 adapter (`NativeCollisionDetector/Group/Object` + `NativeShapeConversion`)
@@ -87,19 +89,24 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **P10** | mixed-scene fcl/dart/native parity integration test | ✅ **merged (#3350)** |
 | **D1** | DART 6 `NativeCollisionDetector::distance()` adapter + native basename normalization | ✅ **merged (#3352)** |
 | **D2** | DART 6 `NativeCollisionDetector::raycast()` adapter + native-vs-Bullet raycast benchmarks | ✅ **merged (#3355)** |
-| **D3** | `VoxelGridShape`/octree replacement via native compound boxes + compound collision recursion | 🔄 **active local branch** `feature/native-voxelgrid-compound` |
+| **D3** | `VoxelGridShape`/octree replacement via native compound boxes + compound collision/distance/raycast recursion | ✅ **merged (#3358)** |
+| **D4** | Native CCD engine: rigid sphere/capsule casts, primitive point-triangle/edge-edge CCD, and shape+transform dispatcher support | 🔄 **active local branch** `feature/native-ccd` |
+| **D5** | Persistent manifold cache and manifold reuse/reduction follow-up | ⬜ not started |
 
-### Exact next step: finish Phase 3 VoxelGrid/compound
+### Exact next step: finish Phase 3 D4 native CCD
 
-1. Continue with the **Phase 3 D3** branch `feature/native-voxelgrid-compound`,
+1. Continue with the **Phase 3 D4** branch `feature/native-ccd`,
    based on the current `origin/release-6.20`.
-2. Keep it as one PR: convert occupied `dynamics::VoxelGridShape` octree leaves
-   into a native `CompoundShape` of voxel `BoxShape` children, route compound
-   collision through the existing narrowphase child pairs, and cover collision,
-   distance/raycast, and shape-version refresh behavior.
-3. Leave CCD, persistent manifolds, Bullet/ODE/FCL facades, and the default
-   flip for later phase-3/phase-5/phase-6 slices.
-4. Gates for **every** native-collision capability PR:
+2. Keep it as one PR: port `Ccd` and `PrimitiveCcd` from DART 7 with DART 6
+   PascalCase file names and C++17-compatible includes; expose only
+   shape+transform `NarrowPhase::sphereCast` and `capsuleCast` entry points,
+   not the DART 7 EnTT `CollisionObject` overloads.
+3. Cover rigid sphere/capsule casts, primitive point-triangle/edge-edge CCD,
+   compound-target earliest-hit selection, and the support matrix. Keep the
+   native detector opt-in only.
+4. Leave persistent manifolds, Bullet/ODE/FCL facades, and the default flip for
+   later phase-3/phase-5/phase-6 slices.
+5. Gates for **every** native-collision capability PR:
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
    UNIT_collision_native --output-on-failure` (`pixi run test-all` only *builds*);
@@ -111,13 +118,12 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 
 ## 5. Open PRs / loose ends
 
-- **Phase 3 D3 VoxelGrid/compound native support** — active on
-  `feature/native-voxelgrid-compound` as one PR-sized slice to minimize CI
-  overhead.
+- **Phase 3 D4 native CCD support** — active on `feature/native-ccd` as one
+  PR-sized slice to minimize CI overhead.
 - **#3353** is open on `release-6.20` for the separate performance-generalization
   plan parking lane.
-- **#3357** is a draft docs/workflow PR on `release-6.20`; unrelated to this
-  native-collision code slice.
+- **#3357** is merged; it renamed the DART 6 autonomous AI workflow to
+  `dart-ultrawork` and is unrelated to this native-collision code slice.
 - **#3283 (main sphere-sphere `enableContact` fix)** and **#3348** (MSVC
   toolchain policy) are MERGED.
 

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -19,13 +19,15 @@ This task is for the DART 6.20 support lane.
 Evidence was first collected on 2026-06-19 after fetching `origin/main`,
 `origin/release-6.20`, and `origin/release-6.19`. The native-collision port
 evidence in `03-native-collision-port-scoping.md` and the dashboard state in
-`04-orchestration-dashboard.md` were refreshed on 2026-07-08 after fetching
-`origin/main` and `origin/release-6.20`, and after phase-2 P10 merged.
+`04-orchestration-dashboard.md` were refreshed on 2026-07-09 after fetching
+`origin/main` and `origin/release-6.20`, and after phase-3 D3 merged.
 
 ## Current Branch State
 
 - `origin/release-6.20` currently points at
-  `e3f7f67211e65d88d16834f331bc40b1f0edaead`.
+  `e2e03ffe8ee99cedda2fcda051f6eb30dc102363`.
+- `origin/main` currently points at
+  `a70fc2ed5cb7c3a4c44759ec222ce0338b8507f54`.
 - `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x
   package version (`6.19.3` in the current CMake configure output).
 - DART 6.20 intentionally uses the release lane while package version metadata

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -70,17 +70,20 @@ scope-diff-guarded.
   **#3352** — **merged**.
 - **D2** (native detector raycast adapter + native-vs-Bullet raycast
   benchmarks): **#3355** — **merged**.
+- **D3** (native VoxelGrid/compound support): **#3358** — **merged**.
 
-**Next: Phase 3 D3 — native VoxelGrid/compound support** on
-`feature/native-voxelgrid-compound`. Keep this as one PR: convert occupied
-`VoxelGridShape` octree leaves into native compound-box children, route compound
-collision through the existing narrowphase child pairs, and cover collision,
-distance/raycast, and shape-version refresh behavior. Keep the native detector
-opt-in only. **Do not** add a `CollisionDetectorType::Native` enum or touch
-`World`/`ConstraintSolver`/`WorldConfig`; FCL remains the default until phase 6.
+**Next: Phase 3 D4 — native CCD support** on `feature/native-ccd`. Keep this
+as one PR: port DART 7's rigid sphere/capsule casts and primitive
+point-triangle/edge-edge CCD into `dart/collision/native/narrow_phase/` using
+DART 6 PascalCase file names, expose shape+transform
+`NarrowPhase::sphereCast` and `capsuleCast` entry points, and cover the
+support matrix plus compound-target earliest-hit behavior. Keep the native
+detector opt-in only. **Do not** add a `CollisionDetectorType::Native` enum or
+touch `World`/`ConstraintSolver`/`WorldConfig`; FCL remains the default until
+phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
-PRs, worktrees, gotchas, and exact Phase 3 D3 next steps).
+PRs, worktrees, gotchas, and exact Phase 3 D4 next steps).
 
 ## Standing constraints
 

--- a/tests/unit/collision/native/CMakeLists.txt
+++ b/tests/unit/collision/native/CMakeLists.txt
@@ -35,6 +35,11 @@ dart_add_test(
 )
 dart_add_test(
   "unit"
+  UNIT_collision_native_ccd
+  test_ccd.cpp
+)
+dart_add_test(
+  "unit"
   UNIT_collision_native_convex_convex
   test_convex_convex.cpp
 )
@@ -57,6 +62,11 @@ dart_add_test(
   "unit"
   UNIT_collision_native_plane_sphere
   test_plane_sphere.cpp
+)
+dart_add_test(
+  "unit"
+  UNIT_collision_native_primitive_ccd
+  test_primitive_ccd.cpp
 )
 dart_add_test(
   "unit"

--- a/tests/unit/collision/native/test_ccd.cpp
+++ b/tests/unit/collision/native/test_ccd.cpp
@@ -268,6 +268,37 @@ TEST(SphereCastBox, SlabMissAndInitialOverlapNormal)
   }
 }
 
+TEST(SphereCastBox, InflatedCornerStationaryMiss)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d center(1.4, 1.4, 0.0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  EXPECT_FALSE(
+      sphereCastBox(center, center, radius, target, transform, option, result));
+}
+
+TEST(SphereCastBox, InflatedCornerSweepMiss)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(1.4, 1.4, -3.0);
+  Eigen::Vector3d end(1.4, 1.4, 3.0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  EXPECT_FALSE(
+      sphereCastBox(start, end, radius, target, transform, option, result));
+}
+
 TEST(SphereCastBox, HitFrontFace)
 {
   BoxShape target(Eigen::Vector3d(1, 1, 1));

--- a/tests/unit/collision/native/test_ccd.cpp
+++ b/tests/unit/collision/native/test_ccd.cpp
@@ -213,6 +213,26 @@ TEST(SphereCastSphere, StationarySweep)
   EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-6);
 }
 
+TEST(SphereCastSphere, StationaryTouching)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(1.5, 0, 0);
+  Eigen::Vector3d end(1.5, 0, 0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastSphere(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-6);
+  EXPECT_NEAR(result.normal.x(), 1.0, 1e-6);
+}
+
 //==============================================================================
 // Sphere-cast Box tests
 //==============================================================================

--- a/tests/unit/collision/native/test_ccd.cpp
+++ b/tests/unit/collision/native/test_ccd.cpp
@@ -1,0 +1,2244 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/Types.hpp>
+#include <dart/collision/native/narrow_phase/Ccd.hpp>
+#include <dart/collision/native/narrow_phase/NarrowPhase.hpp>
+#include <dart/collision/native/shapes/Shape.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <memory>
+#include <vector>
+
+using namespace dart::collision::native;
+
+//==============================================================================
+// Sphere-cast Sphere tests
+//==============================================================================
+
+TEST(SphereCastSphere, Miss)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 0);
+
+  Eigen::Vector3d start(10, 0, 0);
+  Eigen::Vector3d end(10, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastSphere(start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+  EXPECT_FALSE(result.isHit());
+}
+
+TEST(SphereCastSphere, DegenerateQuadraticBranches)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  constexpr double radius = 0.5;
+
+  CcdOption option;
+
+  {
+    CcdResult result;
+    EXPECT_FALSE(sphereCastSphere(
+        Eigen::Vector3d(5.0, 0.0, 0.0),
+        Eigen::Vector3d(5.0, 0.0, 0.0),
+        radius,
+        target,
+        transform,
+        option,
+        result));
+  }
+
+  {
+    CcdResult result;
+    EXPECT_FALSE(sphereCastSphere(
+        Eigen::Vector3d(5.0, 0.0, 0.0),
+        Eigen::Vector3d(5.0 - 1e-6, 0.0, 0.0),
+        radius,
+        target,
+        transform,
+        option,
+        result));
+  }
+
+  {
+    CcdResult result;
+    EXPECT_FALSE(sphereCastSphere(
+        Eigen::Vector3d(5.0, 0.0, 0.0),
+        Eigen::Vector3d(6.0, 0.0, 0.0),
+        radius,
+        target,
+        transform,
+        option,
+        result));
+  }
+}
+
+TEST(SphereCastSphere, DirectHit)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastSphere(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.isHit());
+  EXPECT_NEAR(result.timeOfImpact, 0.35, 1e-6);
+  EXPECT_NEAR(result.point.z(), 4.0, 1e-6);
+  EXPECT_NEAR(result.normal.z(), -1.0, 1e-6);
+}
+
+TEST(SphereCastSphere, StartingInside)
+{
+  SphereShape target(2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastSphere(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-6);
+}
+
+TEST(SphereCastSphere, GrazingHit)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(1.4, 0, 5);
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastSphere(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+TEST(SphereCastSphere, JustMissing)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(1.6, 0, 5);
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastSphere(start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastSphere, StationarySweep)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0.5, 0, 0);
+  Eigen::Vector3d end(0.5, 0, 0);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastSphere(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-6);
+}
+
+//==============================================================================
+// Sphere-cast Box tests
+//==============================================================================
+
+TEST(SphereCastBox, Miss)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(10, 0, 0);
+  Eigen::Vector3d end(10, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastBox(start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastBox, SlabMissAndInitialOverlapNormal)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  CcdOption option;
+
+  {
+    CcdResult result;
+    EXPECT_FALSE(sphereCastBox(
+        Eigen::Vector3d(-5.0, 2.0, 0.0),
+        Eigen::Vector3d(5.0, 1.5, 0.0),
+        0.1,
+        target,
+        transform,
+        option,
+        result));
+  }
+
+  {
+    CcdResult result;
+    ASSERT_TRUE(sphereCastBox(
+        Eigen::Vector3d(1.2, 0.0, 0.0),
+        Eigen::Vector3d(1.2, 0.0, 0.0),
+        0.5,
+        target,
+        transform,
+        option,
+        result));
+    EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+    EXPECT_NEAR(result.normal.x(), 1.0, 1e-12);
+  }
+}
+
+TEST(SphereCastBox, HitFrontFace)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, -5);
+  Eigen::Vector3d end(0, 0, 5);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastBox(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.z(), -1.0, 1e-6);
+}
+
+TEST(SphereCastBox, HitSideFace)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(-5, 0, 0);
+  Eigen::Vector3d end(5, 0, 0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastBox(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.normal.x(), -1.0, 1e-6);
+}
+
+TEST(SphereCastBox, StartingInside)
+{
+  BoxShape target(Eigen::Vector3d(2, 2, 2));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastBox(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-6);
+}
+
+TEST(SphereCastBox, RotatedBox)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 4, Eigen::Vector3d::UnitY()));
+
+  Eigen::Vector3d start(0, 0, -5);
+  Eigen::Vector3d end(0, 0, 5);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastBox(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+TEST(SphereCastBox, TranslatedBox)
+{
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 7);
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastBox(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.55, 1e-6);
+}
+
+//==============================================================================
+// Sphere-cast Capsule tests
+//==============================================================================
+
+TEST(SphereCastCapsule, Miss)
+{
+  CapsuleShape target(0.5, 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(10, 0, 0);
+  Eigen::Vector3d end(10, 0, 10);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCapsule(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastCapsule, HitCylindricalPart)
+{
+  CapsuleShape target(1.0, 4.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(-5, 0, 0);
+  Eigen::Vector3d end(5, 0, 0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCapsule(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.x(), -1.0, 1e-6);
+}
+
+TEST(SphereCastCapsule, HitSphericalCap)
+{
+  CapsuleShape target(1.0, 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, -5);
+  Eigen::Vector3d end(0, 0, 5);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCapsule(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.z(), -1.0, 1e-6);
+}
+
+TEST(SphereCastCapsule, TranslatedCapsule)
+{
+  CapsuleShape target(1.0, 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCapsule(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+TEST(SphereCastCapsule, RotatedCapsule)
+{
+  CapsuleShape target(0.5, 4.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 2, Eigen::Vector3d::UnitX()));
+
+  Eigen::Vector3d start(0, -5, 0);
+  Eigen::Vector3d end(0, 5, 0);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCapsule(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+//==============================================================================
+// Sphere-cast Plane tests
+//==============================================================================
+
+TEST(SphereCastPlane, Miss_ParallelMotion)
+{
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, 5);
+  Eigen::Vector3d end(10, 0, 5);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastPlane(start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastPlane, Miss_MovingAway)
+{
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, 5);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastPlane(start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastPlane, HitFromAbove)
+{
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, 5);
+  Eigen::Vector3d end(0, 0, -5);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastPlane(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.45, 1e-6);
+  EXPECT_NEAR(result.point.z(), 0.0, 1e-6);
+  EXPECT_NEAR(result.normal.z(), 1.0, 1e-6);
+}
+
+TEST(SphereCastPlane, StartingBelow)
+{
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, -1);
+  Eigen::Vector3d end(0, 0, 5);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastPlane(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-6);
+}
+
+TEST(SphereCastPlane, PlaneWithOffset)
+{
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, 10);
+  Eigen::Vector3d end(0, 0, 0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastPlane(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.75, 1e-6);
+  EXPECT_NEAR(result.point.z(), 2.0, 1e-6);
+}
+
+TEST(SphereCastPlane, TransformedPlane)
+{
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 3);
+
+  Eigen::Vector3d start(0, 0, 10);
+  Eigen::Vector3d end(0, 0, 0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastPlane(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.65, 1e-6);
+  EXPECT_NEAR(result.point.z(), 3.0, 1e-6);
+}
+
+TEST(SphereCastPlane, RotatedPlane)
+{
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 2, Eigen::Vector3d::UnitX()));
+
+  Eigen::Vector3d start(0, -5, 0);
+  Eigen::Vector3d end(0, 5, 0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastPlane(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+//==============================================================================
+// Sphere-cast Cylinder tests
+//==============================================================================
+
+TEST(SphereCastCylinder, Miss)
+{
+  CylinderShape target(1.0, 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(10, 0, 0);
+  Eigen::Vector3d end(10, 0, 10);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCylinder(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastCylinder, HitCurvedSurface)
+{
+  CylinderShape target(1.0, 4.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(-5, 0, 0);
+  Eigen::Vector3d end(5, 0, 0);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCylinder(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.x(), -1.0, 1e-6);
+}
+
+TEST(SphereCastCylinder, HitTopCap)
+{
+  CylinderShape target(1.0, 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, 5);
+  Eigen::Vector3d end(0, 0, -5);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCylinder(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.z(), 1.0, 1e-6);
+}
+
+TEST(SphereCastCylinder, HitBottomCap)
+{
+  CylinderShape target(1.0, 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(0, 0, -5);
+  Eigen::Vector3d end(0, 0, 5);
+  double radius = 0.5;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = sphereCastCylinder(
+      start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.z(), -1.0, 1e-6);
+}
+
+//==============================================================================
+// Sphere-cast Convex tests
+//==============================================================================
+
+TEST(SphereCastConvex, Miss)
+{
+  std::vector<Eigen::Vector3d> vertices
+      = {{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}};
+  ConvexShape target(vertices);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(10, 0, 0);
+  Eigen::Vector3d end(10, 0, 10);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastConvex(start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastConvex, DirectHit)
+{
+  std::vector<Eigen::Vector3d> vertices
+      = {{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}};
+  ConvexShape target(vertices);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(-5, 0, 0);
+  Eigen::Vector3d end(5, 0, 0);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastConvex(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.3);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+TEST(SphereCastConvex, TranslatedTarget)
+{
+  std::vector<Eigen::Vector3d> vertices
+      = {{1, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, -1, 0}, {0, 0, 1}, {0, 0, -1}};
+  ConvexShape target(vertices);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  Eigen::Vector3d start(0, 0, 0);
+  Eigen::Vector3d end(0, 0, 10);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastConvex(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.3);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+TEST(SphereCastConvex, StationaryOverlapUsesFallbackDirections)
+{
+  ConvexShape target(
+      {{-1, -1, -1},
+       {1, -1, -1},
+       {1, 1, -1},
+       {-1, 1, -1},
+       {-1, -1, 1},
+       {1, -1, 1},
+       {1, 1, 1},
+       {-1, 1, 1}});
+  const Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+  ASSERT_TRUE(sphereCastConvex(
+      Eigen::Vector3d::Zero(),
+      Eigen::Vector3d::Zero(),
+      0.25,
+      target,
+      transform,
+      option,
+      result));
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  EXPECT_TRUE(result.point.allFinite());
+  EXPECT_TRUE(result.normal.allFinite());
+}
+
+//==============================================================================
+// Sphere-cast Mesh tests
+//==============================================================================
+
+TEST(SphereCastMesh, Miss)
+{
+  std::vector<Eigen::Vector3d> vertices
+      = {{0, 0, 0}, {2, 0, 0}, {1, 2, 0}, {1, 1, 2}};
+  std::vector<MeshShape::Triangle> triangles
+      = {{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}};
+  MeshShape target(vertices, triangles);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(10, 0, 0);
+  Eigen::Vector3d end(10, 0, 10);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastMesh(start, end, radius, target, transform, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(SphereCastMesh, DirectHit)
+{
+  std::vector<Eigen::Vector3d> vertices
+      = {{-1, -1, -1}, {1, -1, -1}, {0, 1, -1}, {0, 0, 1}};
+  std::vector<MeshShape::Triangle> triangles
+      = {{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}};
+  MeshShape target(vertices, triangles);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  Eigen::Vector3d start(-5, 0, 0);
+  Eigen::Vector3d end(5, 0, 0);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastMesh(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+TEST(SphereCastMesh, TranslatedTarget)
+{
+  std::vector<Eigen::Vector3d> vertices
+      = {{0, 0, 0}, {2, 0, 0}, {1, 2, 0}, {1, 1, 2}};
+  std::vector<MeshShape::Triangle> triangles
+      = {{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}};
+  MeshShape target(vertices, triangles);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  Eigen::Vector3d start(1, 1, 0);
+  Eigen::Vector3d end(1, 1, 10);
+  double radius = 0.25;
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit
+      = sphereCastMesh(start, end, radius, target, transform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.3);
+  EXPECT_LT(result.timeOfImpact, 0.6);
+}
+
+//==============================================================================
+// Capsule-cast Sphere tests
+//==============================================================================
+
+TEST(CapsuleCastSphere, Miss)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  SphereShape target(1.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(10, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(10, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastSphere(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(CapsuleCastSphere, DirectHit)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  SphereShape target(1.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+  targetTransform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(0, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(0, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastSphere(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+TEST(CapsuleCastSphere, RotatingCapsule)
+{
+  CapsuleShape capsule(0.5, 4.0);
+  SphereShape target(1.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+  targetTransform.translation() = Eigen::Vector3d(3, 0, 0);
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 2, Eigen::Vector3d::UnitY()));
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastSphere(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+TEST(CapsuleCastSphere, SideOfCapsuleBodyHit)
+{
+  // A long thin capsule (axis along Z) slides sideways in -X past a sphere
+  // aligned with its mid-height. The sphere strikes the cylindrical body far
+  // from both spherical caps -- a contact a caps-only endpoint sweep misses.
+  CapsuleShape capsule(0.2, 4.0); // radius 0.2, half-height 2.0
+  SphereShape target(0.3);
+  const Eigen::Isometry3d targetTransform
+      = Eigen::Isometry3d::Identity(); // sphere at origin
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(3, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(-3, 0, 0);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = capsuleCastSphere(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  // Contact when |x| reaches capsuleRadius + sphereRadius = 0.5; with
+  // x(t) = 3 - 6t that is t ~ 0.417.
+  EXPECT_NEAR(result.timeOfImpact, 0.417, 0.05);
+}
+
+//==============================================================================
+// Capsule-cast Box tests
+//==============================================================================
+
+TEST(CapsuleCastBox, Miss)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(10, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(10, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastBox(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(CapsuleCastBox, DirectHit)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  BoxShape target(Eigen::Vector3d(1, 1, 1));
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(0, 0, -5);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(0, 0, 5);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastBox(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+//==============================================================================
+// Capsule-cast Capsule tests
+//==============================================================================
+
+TEST(CapsuleCastCapsule, Miss)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  CapsuleShape target(1.0, 2.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(10, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(10, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastCapsule(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(CapsuleCastCapsule, DirectHit)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  CapsuleShape target(1.0, 2.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(-5, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(5, 0, 0);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastCapsule(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+//==============================================================================
+// Capsule-cast Plane tests
+//==============================================================================
+
+TEST(CapsuleCastPlane, Miss)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(0, 0, 5);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(0, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastPlane(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(CapsuleCastPlane, DirectHit)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(0, 0, 5);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(0, 0, -5);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastPlane(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+TEST(CapsuleCastPlane, TiltedCapsule)
+{
+  CapsuleShape capsule(0.5, 4.0);
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(0, 0, 5);
+  capsuleStart.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 4, Eigen::Vector3d::UnitX()));
+
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(0, 0, -5);
+  capsuleEnd.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 4, Eigen::Vector3d::UnitX()));
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastPlane(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+//==============================================================================
+// Capsule-cast Cylinder tests
+//==============================================================================
+
+TEST(CapsuleCastCylinder, Miss)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  CylinderShape target(1.0, 2.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(10, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(10, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastCylinder(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(CapsuleCastCylinder, DirectHit)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  CylinderShape target(1.0, 2.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(-5, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(5, 0, 0);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastCylinder(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+//==============================================================================
+// Capsule-cast Convex tests
+//==============================================================================
+
+TEST(CapsuleCastConvex, Miss)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  std::vector<Eigen::Vector3d> vertices
+      = {{-1, -1, -1},
+         {1, -1, -1},
+         {1, 1, -1},
+         {-1, 1, -1},
+         {-1, -1, 1},
+         {1, -1, 1},
+         {1, 1, 1},
+         {-1, 1, 1}};
+  ConvexShape target(vertices);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(10, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(10, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastConvex(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(CapsuleCastConvex, DirectHit)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  std::vector<Eigen::Vector3d> vertices
+      = {{-1, -1, -1},
+         {1, -1, -1},
+         {1, 1, -1},
+         {-1, 1, -1},
+         {-1, -1, 1},
+         {1, -1, 1},
+         {1, 1, 1},
+         {-1, 1, 1}};
+  ConvexShape target(vertices);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(-5, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(5, 0, 0);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastConvex(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+TEST(CapsuleCastConvex, StationaryOverlapUsesFallbackDirections)
+{
+  CapsuleShape capsule(0.25, 0.5);
+  ConvexShape target(
+      {{-1, -1, -1},
+       {1, -1, -1},
+       {1, 1, -1},
+       {-1, 1, -1},
+       {-1, -1, 1},
+       {1, -1, 1},
+       {1, 1, 1},
+       {-1, 1, 1}});
+  const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+  ASSERT_TRUE(capsuleCastConvex(
+      identity, identity, capsule, target, identity, option, result));
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  EXPECT_TRUE(result.point.allFinite());
+  EXPECT_TRUE(result.normal.allFinite());
+}
+
+//==============================================================================
+// Capsule-cast Mesh tests
+//==============================================================================
+
+TEST(CapsuleCastMesh, Miss)
+{
+  CapsuleShape capsule(0.5, 2.0);
+  std::vector<Eigen::Vector3d> vertices
+      = {{0, 0, 0}, {2, 0, 0}, {1, 2, 0}, {1, 1, 2}};
+  std::vector<MeshShape::Triangle> triangles
+      = {{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}};
+  MeshShape target(vertices, triangles);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(10, 0, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(10, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastMesh(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(CapsuleCastMesh, DirectHit)
+{
+  CapsuleShape capsule(0.25, 1.0);
+  std::vector<Eigen::Vector3d> vertices
+      = {{0, 0, 0}, {2, 0, 0}, {1, 2, 0}, {1, 1, 2}};
+  std::vector<MeshShape::Triangle> triangles
+      = {{0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}};
+  MeshShape target(vertices, triangles);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+  targetTransform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(1, 1, 0);
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(1, 1, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastMesh(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+//==============================================================================
+// Conservative Advancement tests
+//==============================================================================
+
+std::vector<Eigen::Vector3d> makeCubeVertices(double halfExtent)
+{
+  double h = halfExtent;
+  return {
+      {-h, -h, -h},
+      {h, -h, -h},
+      {h, h, -h},
+      {-h, h, -h},
+      {-h, -h, h},
+      {h, -h, h},
+      {h, h, h},
+      {-h, h, h}};
+}
+
+std::vector<Eigen::Vector3d> makeBoxVertices(const Eigen::Vector3d& half)
+{
+  return {
+      {-half.x(), -half.y(), -half.z()},
+      {half.x(), -half.y(), -half.z()},
+      {half.x(), half.y(), -half.z()},
+      {-half.x(), half.y(), -half.z()},
+      {-half.x(), -half.y(), half.z()},
+      {half.x(), -half.y(), half.z()},
+      {half.x(), half.y(), half.z()},
+      {-half.x(), half.y(), half.z()}};
+}
+
+TEST(ConservativeAdvancement, Miss)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d transformAStart = Eigen::Isometry3d::Identity();
+  transformAStart.translation() = Eigen::Vector3d(10, 0, 0);
+  Eigen::Isometry3d transformAEnd = Eigen::Isometry3d::Identity();
+  transformAEnd.translation() = Eigen::Vector3d(10, 10, 0);
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = conservativeAdvancement(
+      shapeA,
+      transformAStart,
+      transformAEnd,
+      shapeB,
+      transformB,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(ConservativeAdvancement, DirectHit)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d transformAStart = Eigen::Isometry3d::Identity();
+  transformAStart.translation() = Eigen::Vector3d(-5, 0, 0);
+  Eigen::Isometry3d transformAEnd = Eigen::Isometry3d::Identity();
+  transformAEnd.translation() = Eigen::Vector3d(5, 0, 0);
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = conservativeAdvancement(
+      shapeA,
+      transformAStart,
+      transformAEnd,
+      shapeB,
+      transformB,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.3);
+  EXPECT_LT(result.timeOfImpact, 0.6);
+}
+
+TEST(ConservativeAdvancement, StartingInContact)
+{
+  ConvexShape shapeA(makeCubeVertices(1.0));
+  ConvexShape shapeB(makeCubeVertices(1.0));
+
+  Eigen::Isometry3d transformAStart = Eigen::Isometry3d::Identity();
+  transformAStart.translation() = Eigen::Vector3d(1.5, 0, 0);
+  Eigen::Isometry3d transformAEnd = Eigen::Isometry3d::Identity();
+  transformAEnd.translation() = Eigen::Vector3d(5, 0, 0);
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = conservativeAdvancement(
+      shapeA,
+      transformAStart,
+      transformAEnd,
+      shapeB,
+      transformB,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 0.1);
+}
+
+TEST(ConservativeAdvancement, StationaryOverlapUsesFallbackDirections)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+  const Eigen::Isometry3d identity = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+  const bool hit = conservativeAdvancement(
+      shapeA, identity, identity, shapeB, identity, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  EXPECT_TRUE(result.point.allFinite());
+  EXPECT_TRUE(result.normal.allFinite());
+}
+
+TEST(ConservativeAdvancement, RotatingShape)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d transformAStart = Eigen::Isometry3d::Identity();
+  transformAStart.translation() = Eigen::Vector3d(3, 0, 0);
+
+  Eigen::Isometry3d transformAEnd = Eigen::Isometry3d::Identity();
+  transformAEnd.translation() = Eigen::Vector3d(0.5, 0, 0);
+  transformAEnd.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 4, Eigen::Vector3d::UnitZ()));
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = conservativeAdvancement(
+      shapeA,
+      transformAStart,
+      transformAEnd,
+      shapeB,
+      transformB,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.5);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+//==============================================================================
+// Convex cast (both shapes moving)
+//==============================================================================
+
+TEST(ConvexCast, BothMovingTowardEachOther)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d aStart = Eigen::Isometry3d::Identity();
+  aStart.translation() = Eigen::Vector3d(-5, 0, 0);
+  Eigen::Isometry3d aEnd = Eigen::Isometry3d::Identity();
+  aEnd.translation() = Eigen::Vector3d(0, 0, 0);
+
+  Eigen::Isometry3d bStart = Eigen::Isometry3d::Identity();
+  bStart.translation() = Eigen::Vector3d(5, 0, 0);
+  Eigen::Isometry3d bEnd = Eigen::Isometry3d::Identity();
+  bEnd.translation() = Eigen::Vector3d(0, 0, 0);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit
+      = convexCast(shapeA, aStart, aEnd, shapeB, bStart, bEnd, option, result);
+
+  EXPECT_TRUE(hit);
+  // Centers close from 10 to surface contact at distance 1 -> t = 0.9.
+  EXPECT_NEAR(result.timeOfImpact, 0.9, 5e-2);
+}
+
+TEST(ConvexCast, BothMovingSameDirectionMiss)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d aStart = Eigen::Isometry3d::Identity();
+  aStart.translation() = Eigen::Vector3d(-5, 0, 0);
+  Eigen::Isometry3d aEnd = Eigen::Isometry3d::Identity();
+  aEnd.translation() = Eigen::Vector3d(0, 0, 0);
+
+  Eigen::Isometry3d bStart = Eigen::Isometry3d::Identity();
+  bStart.translation() = Eigen::Vector3d(-3, 0, 0);
+  Eigen::Isometry3d bEnd = Eigen::Isometry3d::Identity();
+  bEnd.translation() = Eigen::Vector3d(2, 0, 0);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit
+      = convexCast(shapeA, aStart, aEnd, shapeB, bStart, bEnd, option, result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(ConvexCast, MatchesConservativeAdvancementWhenBStatic)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d aStart = Eigen::Isometry3d::Identity();
+  aStart.translation() = Eigen::Vector3d(-5, 0, 0);
+  Eigen::Isometry3d aEnd = Eigen::Isometry3d::Identity();
+  aEnd.translation() = Eigen::Vector3d(5, 0, 0);
+
+  const Eigen::Isometry3d bStatic = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult castResult;
+  CcdResult advResult;
+
+  const bool castHit = convexCast(
+      shapeA, aStart, aEnd, shapeB, bStatic, bStatic, option, castResult);
+  const bool advHit = conservativeAdvancement(
+      shapeA, aStart, aEnd, shapeB, bStatic, option, advResult);
+
+  EXPECT_EQ(castHit, advHit);
+  ASSERT_TRUE(castHit);
+  EXPECT_NEAR(castResult.timeOfImpact, advResult.timeOfImpact, 1e-9);
+}
+
+// A zero (or negative) iteration budget must still detect shapes already
+// overlapping at t = 0; the cast loops clamp to at least one iteration so the
+// initial configuration is always tested.
+TEST(ConvexCast, ZeroIterationBudgetDetectsInitialOverlap)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+  const Eigen::Isometry3d atOrigin = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  option.maxIterations = 0;
+  CcdResult result;
+  const bool hit = convexCast(
+      shapeA, atOrigin, atOrigin, shapeB, atOrigin, atOrigin, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-9);
+}
+
+TEST(ConvexCast, CoincidentSupportPointsGiveFiniteNormal)
+{
+  // Degenerate convexes whose support points coincide (overlapping point-like
+  // shapes) must not produce a NaN contact normal: the magnitude is checked
+  // before normalizing, so the fallback normal is used instead.
+  ConvexShape shapeA(std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero()});
+  ConvexShape shapeB(std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero()});
+  const Eigen::Isometry3d atOrigin = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+  const bool hit = convexCast(
+      shapeA, atOrigin, atOrigin, shapeB, atOrigin, atOrigin, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.normal.allFinite());
+  EXPECT_NEAR(result.normal.norm(), 1.0, 1e-9);
+}
+
+TEST(SplineCast, ZeroIterationBudgetDetectsInitialOverlap)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+  const Eigen::Isometry3d atOrigin = Eigen::Isometry3d::Identity();
+  const std::array<Eigen::Vector3d, 4> origin
+      = {Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero()};
+
+  CcdOption option;
+  option.maxIterations = 0;
+  CcdResult result;
+  const bool hit
+      = splineCast(shapeA, origin, origin, shapeB, atOrigin, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-9);
+}
+
+//==============================================================================
+// Spline (cubic-Bezier) cast tests
+//==============================================================================
+
+namespace {
+
+// First time on a fine grid at which shape A (following the spline) is within
+// contact tolerance of static shape B -- a discrete reference that upper-bounds
+// the true time of impact, so a conservative cast must not exceed it.
+double splineSubstepHitTime(
+    const ConvexShape& shapeA,
+    const std::array<Eigen::Vector3d, 4>& translation,
+    const std::array<Eigen::Vector3d, 4>& rotation,
+    const ConvexShape& shapeB,
+    const Eigen::Isometry3d& transformB,
+    const CcdOption& option)
+{
+  constexpr int kSamples = 4000;
+  const bool rotates = rotation[0].squaredNorm() + rotation[1].squaredNorm()
+                           + rotation[2].squaredNorm()
+                           + rotation[3].squaredNorm()
+                       > 1e-12;
+  for (int i = 0; i <= kSamples; ++i) {
+    const double t = static_cast<double>(i) / static_cast<double>(kSamples);
+    const double u = 1.0 - t;
+    const double b0 = u * u * u;
+    const double b1 = 3.0 * t * u * u;
+    const double b2 = 3.0 * t * t * u;
+    const double b3 = t * t * t;
+    Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+    pose.translation() = b0 * translation[0] + b1 * translation[1]
+                         + b2 * translation[2] + b3 * translation[3];
+    if (rotates) {
+      const Eigen::Vector3d w = b0 * rotation[0] + b1 * rotation[1]
+                                + b2 * rotation[2] + b3 * rotation[3];
+      const double angle = w.norm();
+      if (angle > 1e-12) {
+        pose.linear() = Eigen::AngleAxisd(angle, w / angle).toRotationMatrix();
+      }
+    }
+    CcdResult probe;
+    if (conservativeAdvancement(
+            shapeA, pose, pose, shapeB, transformB, option, probe)) {
+      return t;
+    }
+  }
+  return -1.0;
+}
+
+} // namespace
+
+// A spline can curve away from the chord between its endpoints, so it collides
+// where a straight-line cast over the same endpoints misses entirely. This is
+// the capability the linear and screw motion models cannot represent.
+TEST(SplineCast, CurvedPathHitsWhereChordMisses)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+  transformB.translation() = Eigen::Vector3d(0, -1, 0);
+
+  // Downward-bulging cubic Bezier; the chord stays at y = 2 (far from B), but
+  // the curve dips to the obstacle at its midpoint.
+  const std::array<Eigen::Vector3d, 4> translation
+      = {Eigen::Vector3d(-2, 2, 0),
+         Eigen::Vector3d(-2, -2, 0),
+         Eigen::Vector3d(2, -2, 0),
+         Eigen::Vector3d(2, 2, 0)};
+  const std::array<Eigen::Vector3d, 4> rotation
+      = {Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero()};
+
+  CcdOption option;
+  CcdResult result;
+  const bool hit = splineCast(
+      shapeA, translation, rotation, shapeB, transformB, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+
+  // A straight cast over the same endpoints (the chord) never approaches B.
+  Eigen::Isometry3d chordStart = Eigen::Isometry3d::Identity();
+  chordStart.translation() = translation[0];
+  Eigen::Isometry3d chordEnd = Eigen::Isometry3d::Identity();
+  chordEnd.translation() = translation[3];
+  CcdResult chordResult;
+  const bool chordHit = conservativeAdvancement(
+      shapeA, chordStart, chordEnd, shapeB, transformB, option, chordResult);
+  EXPECT_FALSE(chordHit);
+}
+
+// A conservative cast must never overshoot the true contact, so its time of
+// impact stays at or below the first overlap a fine discrete sampling finds.
+TEST(SplineCast, ConservativeVersusSubstep)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+  transformB.translation() = Eigen::Vector3d(0, -1, 0);
+
+  const std::array<Eigen::Vector3d, 4> translation
+      = {Eigen::Vector3d(-2, 2, 0),
+         Eigen::Vector3d(-2, -2, 0),
+         Eigen::Vector3d(2, -2, 0),
+         Eigen::Vector3d(2, 2, 0)};
+  const std::array<Eigen::Vector3d, 4> rotation
+      = {Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero()};
+
+  CcdOption option;
+  CcdResult result;
+  ASSERT_TRUE(splineCast(
+      shapeA, translation, rotation, shapeB, transformB, option, result));
+
+  const double substepHit = splineSubstepHitTime(
+      shapeA, translation, rotation, shapeB, transformB, option);
+  ASSERT_GT(substepHit, 0.0);
+  EXPECT_LE(result.timeOfImpact, substepHit + 1e-3);
+}
+
+// Evenly spaced collinear control points make the cubic Bezier a constant-speed
+// straight line, so the spline cast must reproduce the linear impact time.
+TEST(SplineCast, DegeneratesToLinearMotion)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  const Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+
+  const Eigen::Vector3d p0(-5, 0, 0);
+  const Eigen::Vector3d p3(5, 0, 0);
+  const Eigen::Vector3d d = p3 - p0;
+  const std::array<Eigen::Vector3d, 4> translation
+      = {p0, p0 + d / 3.0, p0 + 2.0 * d / 3.0, p3};
+  const std::array<Eigen::Vector3d, 4> rotation
+      = {Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero()};
+
+  CcdOption option;
+  CcdResult splineResult;
+  ASSERT_TRUE(splineCast(
+      shapeA, translation, rotation, shapeB, transformB, option, splineResult));
+
+  Eigen::Isometry3d linearStart = Eigen::Isometry3d::Identity();
+  linearStart.translation() = p0;
+  Eigen::Isometry3d linearEnd = Eigen::Isometry3d::Identity();
+  linearEnd.translation() = p3;
+  CcdResult linearResult;
+  ASSERT_TRUE(conservativeAdvancement(
+      shapeA,
+      linearStart,
+      linearEnd,
+      shapeB,
+      transformB,
+      option,
+      linearResult));
+
+  EXPECT_NEAR(splineResult.timeOfImpact, linearResult.timeOfImpact, 1e-3);
+}
+
+// A spline carrying rotation exercises the angular term of the motion bound: a
+// rod that is clear of the obstacle while horizontal sweeps into it as it
+// spins.
+TEST(SplineCast, RotatingSplineHitsConservatively)
+{
+  ConvexShape shapeA(makeBoxVertices(Eigen::Vector3d(1.2, 0.1, 0.1)));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+
+  // Stationary center just above B; rotation about Z sweeps the rod down into
+  // B.
+  const std::array<Eigen::Vector3d, 4> translation
+      = {Eigen::Vector3d(0, 1, 0),
+         Eigen::Vector3d(0, 1, 0),
+         Eigen::Vector3d(0, 1, 0),
+         Eigen::Vector3d(0, 1, 0)};
+  const double pi = 3.141592653589793238462643383279502884;
+  const std::array<Eigen::Vector3d, 4> rotation
+      = {Eigen::Vector3d(0, 0, 0),
+         Eigen::Vector3d(0, 0, pi / 3.0),
+         Eigen::Vector3d(0, 0, 2.0 * pi / 3.0),
+         Eigen::Vector3d(0, 0, pi)};
+
+  CcdOption option;
+  CcdResult result;
+  const bool hit = splineCast(
+      shapeA, translation, rotation, shapeB, transformB, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+
+  const double substepHit = splineSubstepHitTime(
+      shapeA, translation, rotation, shapeB, transformB, option);
+  ASSERT_GT(substepHit, 0.0);
+  EXPECT_LE(result.timeOfImpact, substepHit + 1e-3);
+}
+
+// The fast advancement mode takes larger displacement-based steps, trading the
+// no-tunnelling guarantee for speed. On a sharply curved sweep it strides past
+// the true first contact and reports a later one, whereas the conservative mode
+// (default) reports the first contact. Both still detect the collision.
+TEST(SplineCast, FastModeOvershootsConservativeFirstContact)
+{
+  ConvexShape shapeA(makeCubeVertices(0.5));
+  ConvexShape shapeB(makeCubeVertices(0.5));
+
+  Eigen::Isometry3d transformB = Eigen::Isometry3d::Identity();
+  transformB.translation() = Eigen::Vector3d(0, -1, 0);
+
+  const std::array<Eigen::Vector3d, 4> translation
+      = {Eigen::Vector3d(-2, 2, 0),
+         Eigen::Vector3d(-2, -2, 0),
+         Eigen::Vector3d(2, -2, 0),
+         Eigen::Vector3d(2, 2, 0)};
+  const std::array<Eigen::Vector3d, 4> rotation
+      = {Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero(),
+         Eigen::Vector3d::Zero()};
+
+  CcdOption conservative;
+  CcdResult conservativeResult;
+  ASSERT_TRUE(splineCast(
+      shapeA,
+      translation,
+      rotation,
+      shapeB,
+      transformB,
+      conservative,
+      conservativeResult));
+
+  CcdOption fast;
+  fast.advancement = CcdAdvancement::Fast;
+  CcdResult fastResult;
+  ASSERT_TRUE(splineCast(
+      shapeA, translation, rotation, shapeB, transformB, fast, fastResult));
+
+  // The conservative mode finds the genuine first contact; the fast mode
+  // strides past it to a later overlap.
+  EXPECT_LT(conservativeResult.timeOfImpact, 0.5);
+  EXPECT_GT(fastResult.timeOfImpact, conservativeResult.timeOfImpact);
+}
+
+//==============================================================================
+// Determinism tests
+//==============================================================================
+
+TEST(SphereCast, Determinism)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(1.23456, 2.34567, 5.0);
+
+  Eigen::Vector3d start(0.1, 0.2, 0.0);
+  Eigen::Vector3d end(0.1, 0.2, 10.0);
+  double radius = 0.3;
+
+  CcdOption option;
+
+  std::vector<CcdResult> results;
+  for (int i = 0; i < 100; ++i) {
+    CcdResult result;
+    [[maybe_unused]] bool hit = sphereCastSphere(
+        start, end, radius, target, transform, option, result);
+    results.push_back(result);
+  }
+
+  for (std::size_t i = 1; i < results.size(); ++i) {
+    EXPECT_EQ(results[i].hit, results[0].hit);
+    EXPECT_EQ(results[i].timeOfImpact, results[0].timeOfImpact);
+    EXPECT_EQ(results[i].point.x(), results[0].point.x());
+    EXPECT_EQ(results[i].point.y(), results[0].point.y());
+    EXPECT_EQ(results[i].point.z(), results[0].point.z());
+    EXPECT_EQ(results[i].normal.x(), results[0].normal.x());
+    EXPECT_EQ(results[i].normal.y(), results[0].normal.y());
+    EXPECT_EQ(results[i].normal.z(), results[0].normal.z());
+  }
+}
+
+//==============================================================================
+// NarrowPhase dispatcher tests
+//==============================================================================
+
+TEST(NarrowPhaseSphereCast, SphereTarget)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::sphereCast(
+      Eigen::Vector3d(0, 0, 0),
+      Eigen::Vector3d(0, 0, 10),
+      0.5,
+      &target,
+      transform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.isHit());
+  EXPECT_NEAR(result.timeOfImpact, 0.35, 1e-6);
+}
+
+TEST(NarrowPhaseSphereCast, BoxTarget)
+{
+  BoxShape target(Eigen::Vector3d::Ones());
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  transform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::sphereCast(
+      Eigen::Vector3d(0, 0, 0),
+      Eigen::Vector3d(0, 0, 10),
+      0.5,
+      &target,
+      transform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.isHit());
+}
+
+TEST(NarrowPhaseSphereCast, CompoundUsesEarliestChildHit)
+{
+  CompoundShape target;
+
+  Eigen::Isometry3d farther = Eigen::Isometry3d::Identity();
+  farther.translation() = Eigen::Vector3d(0, 0, 8);
+  target.addChild(std::make_unique<SphereShape>(1.0), farther);
+
+  Eigen::Isometry3d nearer = Eigen::Isometry3d::Identity();
+  nearer.translation() = Eigen::Vector3d(0, 0, 5);
+  target.addChild(std::make_unique<SphereShape>(1.0), nearer);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::sphereCast(
+      Eigen::Vector3d(0, 0, 0),
+      Eigen::Vector3d(0, 0, 10),
+      0.5,
+      &target,
+      Eigen::Isometry3d::Identity(),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.35, 1e-6);
+}
+
+TEST(NarrowPhaseSphereCast, CompoundKeepsEndpointChildHit)
+{
+  CompoundShape target;
+
+  Eigen::Isometry3d endpoint = Eigen::Isometry3d::Identity();
+  endpoint.translation() = Eigen::Vector3d(0, 0, 11.5);
+  target.addChild(std::make_unique<SphereShape>(1.0), endpoint);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::sphereCast(
+      Eigen::Vector3d(0, 0, 0),
+      Eigen::Vector3d(0, 0, 10),
+      0.5,
+      &target,
+      Eigen::Isometry3d::Identity(),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.isHit());
+  EXPECT_NEAR(result.timeOfImpact, 1.0, 1e-12);
+}
+
+TEST(NarrowPhaseSphereCast, IsSphereCastSupported)
+{
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Sphere));
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Box));
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Capsule));
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Cylinder));
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Plane));
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Convex));
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Mesh));
+  EXPECT_TRUE(NarrowPhase::isSphereCastSupported(ShapeType::Compound));
+  EXPECT_FALSE(NarrowPhase::isSphereCastSupported(ShapeType::Sdf));
+}
+
+TEST(NarrowPhaseCapsuleCast, SphereTarget)
+{
+  SphereShape target(1.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+  targetTransform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  CapsuleShape capsule(0.5, 2.0);
+  Eigen::Isometry3d start = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d end = Eigen::Isometry3d::Identity();
+  end.translation() = Eigen::Vector3d(0, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::capsuleCast(
+      start, end, capsule, &target, targetTransform, option, result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.isHit());
+}
+
+TEST(NarrowPhaseCapsuleCast, BoxTarget)
+{
+  BoxShape target(Eigen::Vector3d::Ones());
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+  targetTransform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  CapsuleShape capsule(0.5, 2.0);
+  Eigen::Isometry3d start = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d end = Eigen::Isometry3d::Identity();
+  end.translation() = Eigen::Vector3d(0, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::capsuleCast(
+      start, end, capsule, &target, targetTransform, option, result);
+
+  EXPECT_TRUE(hit);
+}
+
+TEST(NarrowPhaseCapsuleCast, CylinderTarget)
+{
+  CylinderShape target(1.0, 2.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+  targetTransform.translation() = Eigen::Vector3d(0, 0, 5);
+
+  CapsuleShape capsule(0.5, 2.0);
+  Eigen::Isometry3d start = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d end = Eigen::Isometry3d::Identity();
+  end.translation() = Eigen::Vector3d(0, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::capsuleCast(
+      start, end, capsule, &target, targetTransform, option, result);
+
+  EXPECT_TRUE(hit);
+}
+
+TEST(NarrowPhaseCapsuleCast, CompoundUsesEarliestChildHit)
+{
+  CompoundShape target;
+
+  Eigen::Isometry3d farther = Eigen::Isometry3d::Identity();
+  farther.translation() = Eigen::Vector3d(0, 0, 8);
+  target.addChild(std::make_unique<SphereShape>(1.0), farther);
+
+  Eigen::Isometry3d nearer = Eigen::Isometry3d::Identity();
+  nearer.translation() = Eigen::Vector3d(0, 0, 5);
+  target.addChild(std::make_unique<SphereShape>(1.0), nearer);
+
+  CapsuleShape capsule(0.5, 2.0);
+  Eigen::Isometry3d start = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d end = Eigen::Isometry3d::Identity();
+  end.translation() = Eigen::Vector3d(0, 0, 10);
+
+  CcdOption option;
+  CcdResult result;
+
+  const bool hit = NarrowPhase::capsuleCast(
+      start,
+      end,
+      capsule,
+      &target,
+      Eigen::Isometry3d::Identity(),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+}
+
+TEST(NarrowPhaseCapsuleCast, IsCapsuleCastSupported)
+{
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Sphere));
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Box));
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Capsule));
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Plane));
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Cylinder));
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Convex));
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Mesh));
+  EXPECT_TRUE(NarrowPhase::isCapsuleCastSupported(ShapeType::Compound));
+  EXPECT_FALSE(NarrowPhase::isCapsuleCastSupported(ShapeType::Sdf));
+}

--- a/tests/unit/collision/native/test_ccd.cpp
+++ b/tests/unit/collision/native/test_ccd.cpp
@@ -412,6 +412,52 @@ TEST(SphereCastCapsule, HitCylindricalPart)
   EXPECT_NEAR(result.normal.x(), -1.0, 1e-6);
 }
 
+TEST(SphereCastCapsule, StartingInsideCylindricalPart)
+{
+  CapsuleShape target(1.0, 4.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  CcdOption option;
+
+  {
+    CcdResult result;
+    ASSERT_TRUE(sphereCastCapsule(
+        Eigen::Vector3d(0.5, 0.0, 0.0),
+        Eigen::Vector3d(0.5, 0.0, 0.0),
+        0.5,
+        target,
+        transform,
+        option,
+        result));
+    EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  }
+
+  {
+    CcdResult result;
+    ASSERT_TRUE(sphereCastCapsule(
+        Eigen::Vector3d(0.5, 0.0, -1.0),
+        Eigen::Vector3d(0.5, 0.0, 1.0),
+        0.5,
+        target,
+        transform,
+        option,
+        result));
+    EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  }
+
+  {
+    CcdResult result;
+    ASSERT_TRUE(sphereCastCapsule(
+        Eigen::Vector3d(0.5, 0.0, 0.0),
+        Eigen::Vector3d(3.0, 0.0, 0.0),
+        0.5,
+        target,
+        transform,
+        option,
+        result));
+    EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  }
+}
+
 TEST(SphereCastCapsule, HitSphericalCap)
 {
   CapsuleShape target(1.0, 2.0);
@@ -702,6 +748,60 @@ TEST(SphereCastCylinder, HitBottomCap)
   EXPECT_GT(result.timeOfImpact, 0.0);
   EXPECT_LT(result.timeOfImpact, 0.5);
   EXPECT_NEAR(result.normal.z(), -1.0, 1e-6);
+}
+
+TEST(SphereCastCylinder, StartingInside)
+{
+  CylinderShape target(1.0, 4.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+  CcdOption option;
+
+  {
+    CcdResult result;
+    ASSERT_TRUE(sphereCastCylinder(
+        Eigen::Vector3d(0.5, 0.0, 0.0),
+        Eigen::Vector3d(0.5, 0.0, 0.0),
+        0.5,
+        target,
+        transform,
+        option,
+        result));
+    EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  }
+
+  {
+    CcdResult result;
+    ASSERT_TRUE(sphereCastCylinder(
+        Eigen::Vector3d(0.5, 0.0, -1.0),
+        Eigen::Vector3d(0.5, 0.0, 1.0),
+        0.5,
+        target,
+        transform,
+        option,
+        result));
+    EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+  }
+}
+
+TEST(SphereCastCylinder, HitCapRim)
+{
+  CylinderShape target(1.0, 2.0);
+  Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
+
+  CcdOption option;
+  CcdResult result;
+  ASSERT_TRUE(sphereCastCylinder(
+      Eigen::Vector3d(1.3, 0.0, 5.0),
+      Eigen::Vector3d(1.3, 0.0, -5.0),
+      0.5,
+      target,
+      transform,
+      option,
+      result));
+
+  EXPECT_NEAR(result.timeOfImpact, 0.36, 0.05);
+  EXPECT_TRUE(result.point.allFinite());
+  EXPECT_TRUE(result.normal.allFinite());
 }
 
 //==============================================================================
@@ -1202,6 +1302,40 @@ TEST(CapsuleCastPlane, TiltedCapsule)
   EXPECT_TRUE(hit);
   EXPECT_GT(result.timeOfImpact, 0.0);
   EXPECT_LT(result.timeOfImpact, 1.0);
+}
+
+TEST(CapsuleCastPlane, RotatingEndpointArcHits)
+{
+  CapsuleShape capsule(0.2, 4.0);
+  PlaneShape target(Eigen::Vector3d::UnitZ(), 0.0);
+  Eigen::Isometry3d targetTransform = Eigen::Isometry3d::Identity();
+
+  Eigen::Isometry3d capsuleStart = Eigen::Isometry3d::Identity();
+  capsuleStart.translation() = Eigen::Vector3d(0, 0, 1.5);
+  capsuleStart.rotate(Eigen::AngleAxisd(
+      -3.141592653589793238462643383279502884 / 3, Eigen::Vector3d::UnitY()));
+
+  Eigen::Isometry3d capsuleEnd = Eigen::Isometry3d::Identity();
+  capsuleEnd.translation() = Eigen::Vector3d(0, 0, 1.5);
+  capsuleEnd.rotate(Eigen::AngleAxisd(
+      3.141592653589793238462643383279502884 / 3, Eigen::Vector3d::UnitY()));
+
+  CcdOption option;
+  CcdResult result;
+
+  bool hit = capsuleCastPlane(
+      capsuleStart,
+      capsuleEnd,
+      capsule,
+      target,
+      targetTransform,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.z(), 1.0, 1e-6);
 }
 
 //==============================================================================

--- a/tests/unit/collision/native/test_ccd.cpp
+++ b/tests/unit/collision/native/test_ccd.cpp
@@ -879,6 +879,7 @@ TEST(SphereCastConvex, DirectHit)
   EXPECT_TRUE(hit);
   EXPECT_GT(result.timeOfImpact, 0.3);
   EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.x(), -1.0, 1e-6);
 }
 
 TEST(SphereCastConvex, TranslatedTarget)
@@ -1242,6 +1243,7 @@ TEST(CapsuleCastCapsule, DirectHit)
   EXPECT_TRUE(hit);
   EXPECT_GT(result.timeOfImpact, 0.0);
   EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.x(), -1.0, 1e-6);
 }
 
 //==============================================================================
@@ -1501,6 +1503,7 @@ TEST(CapsuleCastConvex, DirectHit)
   EXPECT_TRUE(hit);
   EXPECT_GT(result.timeOfImpact, 0.0);
   EXPECT_LT(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.normal.x(), -1.0, 1e-6);
 }
 
 TEST(CapsuleCastConvex, StationaryOverlapUsesFallbackDirections)

--- a/tests/unit/collision/native/test_primitive_ccd.cpp
+++ b/tests/unit/collision/native/test_primitive_ccd.cpp
@@ -1,0 +1,600 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/Types.hpp>
+#include <dart/collision/native/narrow_phase/PrimitiveCcd.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace dart::collision::native;
+
+namespace {
+
+// A triangle in the z = 0 plane whose interior contains the origin's
+// projection.
+const Eigen::Vector3d kA(-1.0, -1.0, 0.0);
+const Eigen::Vector3d kB(1.0, -1.0, 0.0);
+const Eigen::Vector3d kC(0.0, 1.0, 0.0);
+
+} // namespace
+
+//==============================================================================
+// Point-triangle ACCD
+//==============================================================================
+
+TEST(PointTriangleCcd, DirectDropHit)
+{
+  // Point falls straight through the static triangle; crosses z=0 at t=0.5.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 1),
+      Eigen::Vector3d(0, 0, -1),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.isHit());
+  EXPECT_EQ(result.status, CcdPrimitiveStatus::Hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LE(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.timeOfImpact, 0.5, 1e-2);
+}
+
+TEST(PointTriangleCcd, MissBesideTriangle)
+{
+  // Point crosses the triangle's plane far outside the triangle.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(5, 0, 1),
+      Eigen::Vector3d(5, 0, -1),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+  EXPECT_FALSE(result.isHit());
+  EXPECT_EQ(result.status, CcdPrimitiveStatus::Miss);
+}
+
+TEST(PointTriangleCcd, IterationExhaustionIsIndeterminate)
+{
+  CcdOption option;
+  option.maxIterations = 1;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 1),
+      Eigen::Vector3d(0, 0, -1),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+  EXPECT_FALSE(result.isHit());
+  EXPECT_EQ(result.status, CcdPrimitiveStatus::Indeterminate);
+}
+
+TEST(PointTriangleCcd, BothMoving)
+{
+  // Point descends z:1->0 while the triangle rises z:0->0.5; meet at t=2/3.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const Eigen::Vector3d up(0, 0, 0.5);
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 1),
+      Eigen::Vector3d(0, 0, 0),
+      kA,
+      kA + up,
+      kB,
+      kB + up,
+      kC,
+      kC + up,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_LE(result.timeOfImpact, 2.0 / 3.0 + 1e-9);
+  EXPECT_NEAR(result.timeOfImpact, 2.0 / 3.0, 1e-2);
+}
+
+TEST(PointTriangleCcd, AlreadyWithinSeparation)
+{
+  // Point starts inside the minimum-separation band -> immediate contact.
+  CcdOption option;
+  option.minSeparation = 0.1;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 0.05),
+      Eigen::Vector3d(0, 0, 0.05),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.0, 1e-12);
+}
+
+TEST(PointTriangleCcd, MinimumSeparationAdvancesImpact)
+{
+  // With a 0.2 gap, contact is when |1 - 2t| = 0.2 -> t = 0.4.
+  CcdOption option;
+  option.minSeparation = 0.2;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 1),
+      Eigen::Vector3d(0, 0, -1),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_LE(result.timeOfImpact, 0.4 + 1e-9);
+  EXPECT_NEAR(result.timeOfImpact, 0.4, 1e-2);
+}
+
+TEST(PointTriangleCcd, NoRelativeMotion)
+{
+  // Point and triangle translate together; clearance never changes -> no hit.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const Eigen::Vector3d shift(0, 0, 1);
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 1),
+      Eigen::Vector3d(0, 0, 1) + shift,
+      kA,
+      kA + shift,
+      kB,
+      kB + shift,
+      kC,
+      kC + shift,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(PointTriangleCcd, IterationCapDoesNotFalsePositive)
+{
+  // A point gliding at height 0.3 over the triangle in +x never touches z = 0,
+  // but the slow approach can exhaust a small iteration budget before that is
+  // proven. ACCD must report no contact, not a false-positive hit, when the
+  // budget runs out without converging.
+  const Eigen::Vector3d p0(0, 0, 0.3);
+  const Eigen::Vector3d p1(4, 0, 0.3);
+  CcdPrimitiveResult result;
+
+  // Default budget: the no-contact early-out proves no impact occurs in [0, 1].
+  CcdOption option;
+  EXPECT_FALSE(
+      pointTriangleCcd(p0, p1, kA, kA, kB, kB, kC, kC, option, result));
+  EXPECT_FALSE(result.isHit());
+
+  // Tiny budget: the loop caps before proving anything; it must still report no
+  // contact rather than overshoot into a hit.
+  CcdOption capped;
+  capped.maxIterations = 3;
+  EXPECT_FALSE(
+      pointTriangleCcd(p0, p1, kA, kA, kB, kB, kC, kC, capped, result));
+  EXPECT_FALSE(result.isHit());
+}
+
+TEST(PointTriangleCcd, ContactExactlyAtEndOfStep)
+{
+  // The point reaches the triangle plane exactly at t = 1; the inclusive
+  // interval [0, 1] means this is a hit, not a miss.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 1),
+      Eigen::Vector3d(0, 0, 0),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_TRUE(result.isHit());
+  EXPECT_NEAR(result.timeOfImpact, 1.0, 1e-6);
+}
+
+TEST(PointTriangleCcd, LargeGapNearMissNotReportedAsHit)
+{
+  // Start far above the triangle (large initial gap) and stop just short of it
+  // with a small positive gap. The contact band is absolute, so this near-miss
+  // must not be reported as a hit -- a gap-relative band would inflate with the
+  // large starting separation and falsely flag the positive final clearance.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcd(
+      Eigen::Vector3d(0, 0, 10.0),
+      Eigen::Vector3d(0, 0, 5e-4), // ends 5e-4 above the triangle: no contact
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+  EXPECT_FALSE(result.isHit());
+}
+
+//==============================================================================
+// Edge-edge ACCD
+//==============================================================================
+
+TEST(EdgeEdgeCcd, CrossingHit)
+{
+  // Edge A (along x at z) descends z:0.5->-0.5 across static edge B (along y).
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = edgeEdgeCcd(
+      Eigen::Vector3d(-1, 0, 0.5),
+      Eigen::Vector3d(-1, 0, -0.5),
+      Eigen::Vector3d(1, 0, 0.5),
+      Eigen::Vector3d(1, 0, -0.5),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_LE(result.timeOfImpact, 0.5);
+  EXPECT_NEAR(result.timeOfImpact, 0.5, 1e-2);
+}
+
+TEST(EdgeEdgeCcd, MissApproachingButNotTouching)
+{
+  // Edge A descends from z=1 to z=0.6 above static edge B at z=0: never meets.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = edgeEdgeCcd(
+      Eigen::Vector3d(-1, 0, 1.0),
+      Eigen::Vector3d(-1, 0, 0.6),
+      Eigen::Vector3d(1, 0, 1.0),
+      Eigen::Vector3d(1, 0, 0.6),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(EdgeEdgeCcd, MinimumSeparationAdvancesImpact)
+{
+  // Same crossing as CrossingHit but with a 0.2 gap: contact at |0.5-t|=0.2.
+  CcdOption option;
+  option.minSeparation = 0.2;
+  CcdPrimitiveResult result;
+
+  const bool hit = edgeEdgeCcd(
+      Eigen::Vector3d(-1, 0, 0.5),
+      Eigen::Vector3d(-1, 0, -0.5),
+      Eigen::Vector3d(1, 0, 0.5),
+      Eigen::Vector3d(1, 0, -0.5),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_LE(result.timeOfImpact, 0.3 + 1e-9);
+  EXPECT_NEAR(result.timeOfImpact, 0.3, 1e-2);
+}
+
+TEST(EdgeEdgeCcd, ParallelStationaryNoHit)
+{
+  // Parallel, separated, no motion -> no relative motion, no contact.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = edgeEdgeCcd(
+      Eigen::Vector3d(-1, 0, 1),
+      Eigen::Vector3d(-1, 0, 1),
+      Eigen::Vector3d(1, 0, 1),
+      Eigen::Vector3d(1, 0, 1),
+      Eigen::Vector3d(-1, 0, 0),
+      Eigen::Vector3d(-1, 0, 0),
+      Eigen::Vector3d(1, 0, 0),
+      Eigen::Vector3d(1, 0, 0),
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+//==============================================================================
+// Exact coplanarity-cubic solver (validation path)
+//==============================================================================
+
+TEST(PointTriangleCcdExact, DirectDropRootAtHalf)
+{
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcdExact(
+      Eigen::Vector3d(0, 0, 1),
+      Eigen::Vector3d(0, 0, -1),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.5, 1e-6);
+}
+
+TEST(PointTriangleCcdExact, MissBesideTriangle)
+{
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcdExact(
+      Eigen::Vector3d(5, 0, 1),
+      Eigen::Vector3d(5, 0, -1),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_FALSE(hit);
+}
+
+TEST(EdgeEdgeCcdExact, CrossingRootAtHalf)
+{
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = edgeEdgeCcdExact(
+      Eigen::Vector3d(-1, 0, 0.5),
+      Eigen::Vector3d(-1, 0, -0.5),
+      Eigen::Vector3d(1, 0, 0.5),
+      Eigen::Vector3d(1, 0, -0.5),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.5, 1e-6);
+}
+
+TEST(EdgeEdgeCcdExact, CoplanarInteriorCrossing)
+{
+  // Both edges stay in the z = 0 plane, so the coplanarity cubic is identically
+  // zero and yields no interior roots. A static horizontal edge (x in [-1, 1])
+  // is swept across by a vertical edge whose x glides -2 -> 2; the two overlap
+  // once the vertical edge enters the horizontal edge's span at t = 0.25 -- an
+  // interior first contact the exact path must still detect (not just t = 0/1).
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = edgeEdgeCcdExact(
+      Eigen::Vector3d(-1, 0, 0), // edge 1 (a): static
+      Eigen::Vector3d(-1, 0, 0),
+      Eigen::Vector3d(1, 0, 0), // edge 1 (b): static
+      Eigen::Vector3d(1, 0, 0),
+      Eigen::Vector3d(-2, -1, 0), // edge 2 (c): sweeps -2 -> 2 in x
+      Eigen::Vector3d(2, -1, 0),
+      Eigen::Vector3d(-2, 1, 0), // edge 2 (d): sweeps -2 -> 2 in x
+      Eigen::Vector3d(2, 1, 0),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+  EXPECT_NEAR(result.timeOfImpact, 0.25, 0.05);
+}
+
+//==============================================================================
+// Conservativeness: ACCD must never overshoot the exact time of impact
+//==============================================================================
+
+TEST(PrimitiveCcdConservativeness, PointTriangleNeverOvershoots)
+{
+  CcdOption option;
+
+  struct Case
+  {
+    Eigen::Vector3d p0, p1, aOff, bOff, cOff;
+  };
+  const std::vector<Case> cases = {
+      {{0, 0, 1}, {0, 0, -1}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+      {{0.3, -0.2, 1.5}, {0.1, 0.2, -0.5}, {0, 0, 0.2}, {0, 0, 0.1}, {0, 0, 0}},
+      {{-0.4, 0.3, 2.0},
+       {0.2, -0.1, -1.0},
+       {0.1, 0, 0},
+       {0, 0.1, 0},
+       {0, 0, 0.1}},
+  };
+
+  for (const auto& tc : cases) {
+    CcdPrimitiveResult accd;
+    CcdPrimitiveResult exact;
+    const bool accdHit = pointTriangleCcd(
+        tc.p0,
+        tc.p1,
+        kA,
+        kA + tc.aOff,
+        kB,
+        kB + tc.bOff,
+        kC,
+        kC + tc.cOff,
+        option,
+        accd);
+    const bool exactHit = pointTriangleCcdExact(
+        tc.p0,
+        tc.p1,
+        kA,
+        kA + tc.aOff,
+        kB,
+        kB + tc.bOff,
+        kC,
+        kC + tc.cOff,
+        option,
+        exact);
+
+    if (exactHit) {
+      EXPECT_TRUE(accdHit);
+      EXPECT_LE(accd.timeOfImpact, exact.timeOfImpact + 1e-6);
+    }
+  }
+}
+
+TEST(PrimitiveCcdConservativeness, EdgeEdgeNeverOvershoots)
+{
+  CcdOption option;
+
+  CcdPrimitiveResult accd;
+  CcdPrimitiveResult exact;
+  const bool accdHit = edgeEdgeCcd(
+      Eigen::Vector3d(-1, 0, 0.5),
+      Eigen::Vector3d(-1, 0, -0.5),
+      Eigen::Vector3d(1, 0, 0.5),
+      Eigen::Vector3d(1, 0, -0.5),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      option,
+      accd);
+  const bool exactHit = edgeEdgeCcdExact(
+      Eigen::Vector3d(-1, 0, 0.5),
+      Eigen::Vector3d(-1, 0, -0.5),
+      Eigen::Vector3d(1, 0, 0.5),
+      Eigen::Vector3d(1, 0, -0.5),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, -1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      Eigen::Vector3d(0, 1, 0),
+      option,
+      exact);
+
+  ASSERT_TRUE(exactHit);
+  ASSERT_TRUE(accdHit);
+  EXPECT_LE(accd.timeOfImpact, exact.timeOfImpact + 1e-6);
+}
+
+//==============================================================================
+// Determinism
+//==============================================================================
+
+TEST(PrimitiveCcd, Determinism)
+{
+  CcdOption option;
+
+  double first = -1.0;
+  for (int i = 0; i < 100; ++i) {
+    CcdPrimitiveResult result;
+    const bool hit = pointTriangleCcd(
+        Eigen::Vector3d(0.12, -0.07, 1.0),
+        Eigen::Vector3d(-0.05, 0.09, -1.0),
+        kA,
+        kA,
+        kB,
+        kB,
+        kC,
+        kC,
+        option,
+        result);
+    ASSERT_TRUE(hit);
+    if (i == 0) {
+      first = result.timeOfImpact;
+    } else {
+      EXPECT_EQ(result.timeOfImpact, first);
+    }
+  }
+}

--- a/tests/unit/collision/native/test_primitive_ccd.cpp
+++ b/tests/unit/collision/native/test_primitive_ccd.cpp
@@ -502,6 +502,29 @@ TEST(EdgeEdgeCcdExact, CoplanarInteriorCrossing)
   EXPECT_NEAR(result.timeOfImpact, 0.25, 0.05);
 }
 
+TEST(EdgeEdgeCcdExact, CoplanarNarrowInteriorCrossing)
+{
+  // The contact interval is much narrower than the old fixed 1/256 grid: the
+  // static edge is 0.001 wide in x, and a vertical edge sweeps across it.
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = edgeEdgeCcdExact(
+      Eigen::Vector3d(-0.0005, 0, 0),
+      Eigen::Vector3d(-0.0005, 0, 0),
+      Eigen::Vector3d(0.0005, 0, 0),
+      Eigen::Vector3d(0.0005, 0, 0),
+      Eigen::Vector3d(-2, -1, 0),
+      Eigen::Vector3d(2, -1, 0),
+      Eigen::Vector3d(-2, 1, 0),
+      Eigen::Vector3d(2, 1, 0),
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_NEAR(result.timeOfImpact, 0.499875, 1e-6);
+}
+
 //==============================================================================
 // Conservativeness: ACCD must never overshoot the exact time of impact
 //==============================================================================

--- a/tests/unit/collision/native/test_primitive_ccd.cpp
+++ b/tests/unit/collision/native/test_primitive_ccd.cpp
@@ -430,6 +430,29 @@ TEST(PointTriangleCcdExact, MissBesideTriangle)
   EXPECT_FALSE(hit);
 }
 
+TEST(PointTriangleCcdExact, CoplanarInteriorCrossing)
+{
+  CcdOption option;
+  CcdPrimitiveResult result;
+
+  const bool hit = pointTriangleCcdExact(
+      Eigen::Vector3d(-2, 0, 0),
+      Eigen::Vector3d(2, 0, 0),
+      kA,
+      kA,
+      kB,
+      kB,
+      kC,
+      kC,
+      option,
+      result);
+
+  EXPECT_TRUE(hit);
+  EXPECT_GT(result.timeOfImpact, 0.0);
+  EXPECT_LT(result.timeOfImpact, 1.0);
+  EXPECT_NEAR(result.timeOfImpact, 0.375, 0.05);
+}
+
 TEST(EdgeEdgeCcdExact, CrossingRootAtHalf)
 {
   CcdOption option;


### PR DESCRIPTION
## Summary
- Port the native CCD engine into the DART 6 `dart/collision/native` tree using PascalCase `Ccd` / `PrimitiveCcd` files and C++17-compatible includes.
- Add shape+transform `NarrowPhase::sphereCast` and `NarrowPhase::capsuleCast` dispatch for sphere, box, capsule, cylinder, plane, convex, mesh, and compound targets, including earliest-child compound hit selection.
- Add focused CCD and primitive CCD unit coverage, plus a regression for compound endpoint hits, and refresh the dependency-minimization handoff/dashboard after #3358.

## Scope notes
- This is phase 3 D4 engine support only: the native detector stays opt-in, FCL remains the default, and this does not touch `World`, `ConstraintSolver`, `WorldConfig`, or `CollisionDetectorType`.
- No EnTT, no new dependency, no `std::span`, and no DART 7 `CollisionWorld` / `CollisionObject` overloads are imported.

## Testing
- `pixi run cmake --build build/default/cpp/Release --target UNIT_collision_native_ccd UNIT_collision_native_primitive_ccd --parallel 8`
- `ctest --test-dir build/default/cpp/Release -R 'UNIT_collision_native_(ccd|primitive_ccd)$' --output-on-failure`
- `ctest --test-dir build/default/cpp/Release -R UNIT_collision_native --output-on-failure`
- `pixi run cmake --build build/default/cpp/Debug --target UNIT_collision_native_ccd UNIT_collision_native_primitive_ccd --parallel 8`
- `ctest --test-dir build/default/cpp/Debug -R 'UNIT_collision_native_(ccd|primitive_ccd)$' --output-on-failure`
- `pixi run lint`
- pre-commit Tier-0 gate: `pixi run check-lint-quick`
- `pixi run -e gazebo test-gz` (gz-physics 199/199 + 4/4 performance tests; gz-sim `INTEGRATION_entity_system` passed)
- `git diff --check`
- portability scan on touched code for EnTT, `std::span`, C++20 `<numbers>`, DART 7 snake_case include paths, and stale lowercase CCD include names

## Performance / benchmark evidence
- This slice adds opt-in CCD engine APIs and does not change the default detector path or simulation collision dispatch, so the #3307-style contact RTF comparison is not a meaningful pass/fail metric for this PR.
- Downstream performance-sensitive guards still passed through `pixi run -e gazebo test-gz`, including gz-physics' 4 performance tests against the source-built DART plugin.
- I attempted a small local contact-benchmark guard anyway: `pixi run ./build/default/cpp/Release/bin/contact_benchmark --generate-objects 30 --steps 20 --warmup 0 --checkpoint 0 --quiet --collision default --world-threads 1 --max-contacts 20000 --max-contacts-per-pair 4`. It exited 139 before producing output on the incumbent default path, matching the local allocator/MemoryManager blocker observed while preparing this slice, so I am not presenting contact-benchmark numbers as evidence here.
