### PR TITLE
Add native persistent manifold cache

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -35,9 +35,9 @@ jobs:
     runs-on: windows-2025-vs2026
     env:
       CMAKE_GENERATOR: Visual Studio 18 2026
-    # Fail fast on hung Windows jobs instead of consuming the protected-branch
-    # runner indefinitely.
-    timeout-minutes: 120
+    # Keep the job bounded, but allow large native-collision PRs enough time
+    # for MSVC Release test linking on hosted runners.
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,11 @@
     comparing native and FCL VoxelGrid collision queries:
     [#3358](https://github.com/dartsim/dart/pull/3358)
 
+  * Add opt-in DART-native persistent contact manifolds and PGS-compatible
+    cached contact impulse seeding for native-detector contacts, preserving the
+    FCL default detector while reducing repeated native contact reconstruction:
+    [#3056](https://github.com/dartsim/dart/issues/3056)
+
   * Fix FCL primitive contact normal orientation and switch default FCL primitive
     handling to `PRIMITIVE` for `FCLCollisionDetector`, the default constraint
     solver, and SKEL parser fallback paths. Users needing legacy mesh

--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -10,6 +10,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/ContactPoint.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Types.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ContactManifold.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/PersistentManifoldCache.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionDetector.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionGroup.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionObject.hpp
@@ -75,6 +76,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/Aabb.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/Types.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ContactManifold.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/PersistentManifoldCache.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionDetector.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionGroup.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/NativeCollisionObject.cpp

--- a/dart/collision/native/NativeCollisionDetector.cpp
+++ b/dart/collision/native/NativeCollisionDetector.cpp
@@ -38,12 +38,20 @@
 #include "dart/collision/DistanceFilter.hpp"
 #include "dart/collision/native/NativeCollisionGroup.hpp"
 #include "dart/collision/native/NativeCollisionObject.hpp"
+#include "dart/collision/native/PersistentManifoldCache.hpp"
 #include "dart/collision/native/narrow_phase/NarrowPhase.hpp"
 #include "dart/common/Console.hpp"
 
 #include <algorithm>
+#include <array>
 #include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
 #include <vector>
+
+#include <cstdint>
 
 namespace dart {
 namespace collision {
@@ -146,6 +154,65 @@ struct NativeRayHitCandidate
   RayHit hit;
   double distance = std::numeric_limits<double>::max();
 };
+
+//==============================================================================
+std::size_t getManifoldCacheId(const CollisionObject* object)
+{
+  return static_cast<std::size_t>(reinterpret_cast<std::uintptr_t>(object));
+}
+
+//==============================================================================
+using ManifoldCacheMap = std::unordered_map<
+    const NativeCollisionDetector*,
+    std::unique_ptr<native::PersistentManifoldCache>>;
+
+//==============================================================================
+struct ManifoldCacheRegistry
+{
+  ManifoldCacheMap caches;
+  std::mutex mutex;
+};
+
+//==============================================================================
+ManifoldCacheRegistry& getManifoldCacheRegistry()
+{
+  static ManifoldCacheRegistry registry;
+  return registry;
+}
+
+//==============================================================================
+native::PersistentManifoldCache* findManifoldCache(
+    const NativeCollisionDetector* detector)
+{
+  auto& registry = getManifoldCacheRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  const auto it = registry.caches.find(detector);
+  if (it == registry.caches.end())
+    return nullptr;
+
+  return it->second.get();
+}
+
+//==============================================================================
+native::PersistentManifoldCache& getOrCreateManifoldCache(
+    const NativeCollisionDetector* detector)
+{
+  auto& registry = getManifoldCacheRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  auto& cache = registry.caches[detector];
+  if (!cache)
+    cache = std::make_unique<native::PersistentManifoldCache>();
+
+  return *cache;
+}
+
+//==============================================================================
+void removeManifoldCache(const NativeCollisionDetector* detector)
+{
+  auto& registry = getManifoldCacheRegistry();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  registry.caches.erase(detector);
+}
 
 //==============================================================================
 RayHit convertRayHit(
@@ -301,6 +368,224 @@ void addPairOnlyContact(
 }
 
 //==============================================================================
+void attachCachedContactImpulses(
+    CollisionResult* result, native::PersistentManifoldCache* manifoldCache)
+{
+  if (!result || !manifoldCache)
+    return;
+
+  if (result->getNumContacts() == 1u) {
+    auto& contact = result->getContact(0);
+    auto* object1 = contact.collisionObject1;
+    auto* object2 = contact.collisionObject2;
+    if (!object1 || !object2)
+      return;
+
+    const auto id1 = getManifoldCacheId(object1);
+    const auto id2 = getManifoldCacheId(object2);
+    if (id1 == 0u || id2 == 0u)
+      return;
+
+    const auto tf1 = object1->getTransform();
+    const auto tf2 = object2->getTransform();
+    const auto tf1Inv = tf1.inverse();
+    const auto tf2Inv = tf2.inverse();
+    const bool swapped = id2 < id1;
+
+    native::CachedContact cached;
+    cached.localPointA
+        = swapped ? tf2Inv * contact.point : tf1Inv * contact.point;
+    cached.localPointB
+        = swapped ? tf1Inv * contact.point : tf2Inv * contact.point;
+    cached.normal = contact.normal;
+    cached.penetrationDepth = contact.penetrationDepth;
+
+    auto& manifold = manifoldCache->getOrCreate(id1, id2);
+    manifold.addOrReplace(cached);
+    if (manifold.numContacts == 1) {
+      auto& manifoldContact = manifold.contacts[0];
+      contact.userData = &manifoldContact;
+      return;
+    }
+
+    manifold.refresh(swapped ? tf2 : tf1, swapped ? tf1 : tf2);
+    if (manifold.numContacts == 0) {
+      manifoldCache->remove(id1, id2);
+      return;
+    }
+
+    const auto match = manifold.findMatch(cached.localPointA);
+    if (match < 0)
+      return;
+
+    const auto matchIndex = static_cast<std::size_t>(match);
+    auto& manifoldContact = manifold.contacts[matchIndex];
+    contact.userData = &manifoldContact;
+    return;
+  }
+
+  CollisionObject* cachedObject1 = nullptr;
+  CollisionObject* cachedObject2 = nullptr;
+  Eigen::Isometry3d tf1;
+  Eigen::Isometry3d tf2;
+  Eigen::Isometry3d tf1Inv;
+  Eigen::Isometry3d tf2Inv;
+  std::size_t id1 = 0u;
+  std::size_t id2 = 0u;
+  bool swapped = false;
+  native::PersistentManifold* manifold = nullptr;
+  std::vector<std::size_t> pendingContactIndices;
+  std::vector<Eigen::Vector3d> pendingLocalPoints;
+  pendingContactIndices.reserve(result->getNumContacts());
+  pendingLocalPoints.reserve(result->getNumContacts());
+
+  auto flushPair = [&]() {
+    if (!manifold || pendingContactIndices.empty())
+      return;
+
+    manifold->refresh(swapped ? tf2 : tf1, swapped ? tf1 : tf2);
+    if (manifold->numContacts == 0) {
+      manifoldCache->remove(id1, id2);
+      manifold = nullptr;
+      pendingContactIndices.clear();
+      pendingLocalPoints.clear();
+      return;
+    }
+
+    std::array<bool, native::PersistentManifold::kMaxContacts> assignedSlots{};
+    for (std::size_t pendingIndex = 0u;
+         pendingIndex < pendingContactIndices.size();
+         ++pendingIndex) {
+      const auto match = manifold->findMatch(pendingLocalPoints[pendingIndex]);
+      if (match < 0)
+        continue;
+
+      const auto matchIndex = static_cast<std::size_t>(match);
+      if (assignedSlots[matchIndex])
+        continue;
+      assignedSlots[matchIndex] = true;
+
+      auto& contact = result->getContact(pendingContactIndices[pendingIndex]);
+      auto& manifoldContact = manifold->contacts[matchIndex];
+      contact.userData = &manifoldContact;
+    }
+
+    manifold = nullptr;
+    pendingContactIndices.clear();
+    pendingLocalPoints.clear();
+  };
+
+  for (std::size_t i = 0u; i < result->getNumContacts(); ++i) {
+    auto& contact = result->getContact(i);
+    auto* object1 = contact.collisionObject1;
+    auto* object2 = contact.collisionObject2;
+    if (!object1 || !object2)
+      continue;
+
+    if (object1 != cachedObject1 || object2 != cachedObject2) {
+      flushPair();
+      cachedObject1 = object1;
+      cachedObject2 = object2;
+      tf1 = object1->getTransform();
+      tf2 = object2->getTransform();
+      tf1Inv = tf1.inverse();
+      tf2Inv = tf2.inverse();
+      id1 = getManifoldCacheId(object1);
+      id2 = getManifoldCacheId(object2);
+      swapped = id2 < id1;
+    }
+
+    if (id1 == 0u || id2 == 0u) {
+      flushPair();
+      cachedObject1 = nullptr;
+      cachedObject2 = nullptr;
+      continue;
+    }
+
+    if (!manifold)
+      manifold = &manifoldCache->getOrCreate(id1, id2);
+
+    native::CachedContact cached;
+    cached.localPointA
+        = swapped ? tf2Inv * contact.point : tf1Inv * contact.point;
+    cached.localPointB
+        = swapped ? tf1Inv * contact.point : tf2Inv * contact.point;
+    cached.normal = contact.normal;
+    cached.penetrationDepth = contact.penetrationDepth;
+
+    manifold->addOrReplace(cached);
+    pendingContactIndices.push_back(i);
+    pendingLocalPoints.push_back(cached.localPointA);
+  }
+
+  flushPair();
+}
+
+//==============================================================================
+void refreshManifoldCache(
+    const std::vector<CollisionObject*>& objects,
+    native::PersistentManifoldCache* manifoldCache)
+{
+  if (!manifoldCache)
+    return;
+
+  std::unordered_map<std::size_t, CollisionObject*> objectsById;
+  objectsById.reserve(objects.size());
+  for (auto* object : objects) {
+    const auto id = getManifoldCacheId(object);
+    if (id != 0u)
+      objectsById[id] = object;
+  }
+
+  manifoldCache->refreshAll(
+      [&](std::size_t idA, std::size_t idB)
+          -> std::optional<std::pair<Eigen::Isometry3d, Eigen::Isometry3d>> {
+        const auto itA = objectsById.find(idA);
+        const auto itB = objectsById.find(idB);
+        if (itA == objectsById.end() || itB == objectsById.end())
+          return std::nullopt;
+
+        return std::make_pair(
+            itA->second->getTransform(), itB->second->getTransform());
+      });
+}
+
+//==============================================================================
+void refreshManifoldCache(
+    const std::vector<CollisionObject*>& objects1,
+    const std::vector<CollisionObject*>& objects2,
+    native::PersistentManifoldCache* manifoldCache)
+{
+  if (!manifoldCache)
+    return;
+
+  std::unordered_map<std::size_t, CollisionObject*> objectsById;
+  objectsById.reserve(objects1.size() + objects2.size());
+  for (auto* object : objects1) {
+    const auto id = getManifoldCacheId(object);
+    if (id != 0u)
+      objectsById[id] = object;
+  }
+  for (auto* object : objects2) {
+    const auto id = getManifoldCacheId(object);
+    if (id != 0u)
+      objectsById[id] = object;
+  }
+
+  manifoldCache->refreshAll(
+      [&](std::size_t idA, std::size_t idB)
+          -> std::optional<std::pair<Eigen::Isometry3d, Eigen::Isometry3d>> {
+        const auto itA = objectsById.find(idA);
+        const auto itB = objectsById.find(idB);
+        if (itA == objectsById.end() || itB == objectsById.end())
+          return std::nullopt;
+
+        return std::make_pair(
+            itA->second->getTransform(), itB->second->getTransform());
+      });
+}
+
+//==============================================================================
 bool emitContacts(
     const native::CollisionResult& nativeResult,
     NativeCollisionObject* object1,
@@ -402,7 +687,52 @@ std::shared_ptr<NativeCollisionDetector> NativeCollisionDetector::create()
 }
 
 //==============================================================================
-NativeCollisionDetector::~NativeCollisionDetector() = default;
+NativeCollisionDetector::~NativeCollisionDetector()
+{
+  removeManifoldCache(this);
+}
+
+//==============================================================================
+native::CachedContact* NativeCollisionDetector::getCachedContact(
+    const NativeCollisionObject* object1,
+    const NativeCollisionObject* object2,
+    void* userData) const
+{
+  if (!object1 || !object2 || !userData)
+    return nullptr;
+
+  if (object1->getCollisionDetector() != this
+      || object2->getCollisionDetector() != this) {
+    return nullptr;
+  }
+
+  const auto* manifoldCache = findManifoldCache(this);
+  if (!manifoldCache)
+    return nullptr;
+
+  const auto id1 = getManifoldCacheId(object1);
+  const auto id2 = getManifoldCacheId(object2);
+  if (!manifoldCache->ownsContact(id1, id2, userData))
+    return nullptr;
+
+  return static_cast<native::CachedContact*>(userData);
+}
+
+//==============================================================================
+void NativeCollisionDetector::notifyCollisionObjectDestroying(
+    CollisionObject* object)
+{
+  CollisionDetector::notifyCollisionObjectDestroying(object);
+
+  if (!object)
+    return;
+
+  auto* manifoldCache = findManifoldCache(this);
+  if (!manifoldCache)
+    return;
+
+  manifoldCache->removeObject(getManifoldCacheId(object));
+}
 
 //==============================================================================
 std::shared_ptr<CollisionDetector>
@@ -447,6 +777,8 @@ bool NativeCollisionDetector::collide(
 
   auto* nativeGroup = static_cast<NativeCollisionGroup*>(group);
   nativeGroup->updateEngineData();
+  auto& manifoldCache = getOrCreateManifoldCache(this);
+  refreshManifoldCache(nativeGroup->mCollisionObjects, &manifoldCache);
 
   bool collisionFound = false;
   nativeGroup->mBroadPhase->visitPairs([&](std::size_t id1, std::size_t id2) {
@@ -454,6 +786,9 @@ bool NativeCollisionDetector::collide(
     auto* object2 = nativeGroup->mIdToObject.at(id2);
     return !processNativePair(object1, object2, option, result, collisionFound);
   });
+
+  if (option.enableContact)
+    attachCachedContactImpulses(result, &manifoldCache);
 
   return collisionFound;
 }
@@ -484,6 +819,11 @@ bool NativeCollisionDetector::collide(
   auto* nativeGroup2 = static_cast<NativeCollisionGroup*>(group2);
   nativeGroup1->updateEngineData();
   nativeGroup2->updateEngineData();
+  auto& manifoldCache = getOrCreateManifoldCache(this);
+  refreshManifoldCache(
+      nativeGroup1->mCollisionObjects,
+      nativeGroup2->mCollisionObjects,
+      &manifoldCache);
 
   bool collisionFound = false;
   for (auto* object1 : nativeGroup1->mCollisionObjects) {
@@ -494,10 +834,15 @@ bool NativeCollisionDetector::collide(
               option,
               result,
               collisionFound)) {
+        if (option.enableContact)
+          attachCachedContactImpulses(result, &manifoldCache);
         return collisionFound;
       }
     }
   }
+
+  if (option.enableContact)
+    attachCachedContactImpulses(result, &manifoldCache);
 
   return collisionFound;
 }
@@ -618,6 +963,7 @@ bool NativeCollisionDetector::raycast(
 //==============================================================================
 NativeCollisionDetector::NativeCollisionDetector() : CollisionDetector()
 {
+  getOrCreateManifoldCache(this);
   mCollisionObjectManager.reset(new ManagerForSharableCollisionObjects(this));
 }
 

--- a/dart/collision/native/NativeCollisionDetector.hpp
+++ b/dart/collision/native/NativeCollisionDetector.hpp
@@ -34,11 +34,14 @@
 #define DART_COLLISION_NATIVE_NATIVECOLLISIONDETECTOR_HPP_
 
 #include <dart/collision/CollisionDetector.hpp>
+#include <dart/collision/native/Fwd.hpp>
 
 #include <memory>
 
 namespace dart {
 namespace collision {
+
+class NativeCollisionObject;
 
 class NativeCollisionDetector : public CollisionDetector
 {
@@ -96,6 +99,11 @@ public:
       const RaycastOption& option = RaycastOption(),
       RaycastResult* result = nullptr) override;
 
+  [[nodiscard]] native::CachedContact* getCachedContact(
+      const NativeCollisionObject* object1,
+      const NativeCollisionObject* object2,
+      void* userData) const;
+
 protected:
   NativeCollisionDetector();
 
@@ -105,6 +113,9 @@ protected:
 
   // Documentation inherited
   void refreshCollisionObject(CollisionObject* object) override;
+
+  // Documentation inherited
+  void notifyCollisionObjectDestroying(CollisionObject* object) override;
 
 private:
   static Registrar<NativeCollisionDetector> mRegistrar;

--- a/dart/collision/native/PersistentManifoldCache.cpp
+++ b/dart/collision/native/PersistentManifoldCache.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/collision/native/PersistentManifoldCache.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <vector>
+
+#include <cmath>
+
+namespace dart {
+namespace collision {
+namespace native {
+
+namespace {
+
+constexpr double kNormalEpsilon = 1e-9;
+constexpr double kNormalEpsilonSquared = kNormalEpsilon * kNormalEpsilon;
+constexpr double kFrictionBasisNormalDotTolerance = 1e-6;
+constexpr double kFrictionBasisNormalDeltaSquared
+    = kFrictionBasisNormalDotTolerance * kFrictionBasisNormalDotTolerance;
+constexpr double kFrictionBasisMinNormalDot
+    = 1.0 - kFrictionBasisNormalDotTolerance;
+constexpr double kFrictionBasisMinNormalDotSquared
+    = kFrictionBasisMinNormalDot * kFrictionBasisMinNormalDot;
+
+//==============================================================================
+PairKey canonicalPair(std::size_t idA, std::size_t idB)
+{
+  if (idA <= idB)
+    return {idA, idB};
+
+  return {idB, idA};
+}
+
+//==============================================================================
+Eigen::Vector3d normalizedOrDefault(const Eigen::Vector3d& normal)
+{
+  const double norm = normal.norm();
+  if (norm < kNormalEpsilon)
+    return Eigen::Vector3d::UnitZ();
+
+  return normal / norm;
+}
+
+//==============================================================================
+bool hasMatchingFrictionBasis(
+    const CachedContact& existing, const CachedContact& contact)
+{
+  const double normalDot = existing.normal.dot(contact.normal);
+  if (!std::isfinite(normalDot))
+    return false;
+
+  if (normalDot <= 0.0)
+    return false;
+
+  if ((existing.normal - contact.normal).squaredNorm()
+      <= kFrictionBasisNormalDeltaSquared) {
+    return true;
+  }
+
+  const double existingNormalNormSquared = existing.normal.squaredNorm();
+  const double contactNormalNormSquared = contact.normal.squaredNorm();
+  if (existingNormalNormSquared < kNormalEpsilonSquared
+      || contactNormalNormSquared < kNormalEpsilonSquared) {
+    return false;
+  }
+
+  return normalDot * normalDot >= kFrictionBasisMinNormalDotSquared
+                                      * existingNormalNormSquared
+                                      * contactNormalNormSquared;
+}
+
+//==============================================================================
+std::array<int, PersistentManifold::kMaxContacts> selectContactIndices(
+    const std::vector<CachedContact>& candidates)
+{
+  std::array<int, PersistentManifold::kMaxContacts> selected{-1, -1, -1, -1};
+  if (candidates.empty())
+    return selected;
+
+  std::vector<bool> used(candidates.size(), false);
+
+  int deepest = 0;
+  double maxDepth = candidates[0].penetrationDepth;
+  for (std::size_t i = 1; i < candidates.size(); ++i) {
+    if (candidates[i].penetrationDepth > maxDepth) {
+      maxDepth = candidates[i].penetrationDepth;
+      deepest = static_cast<int>(i);
+    }
+  }
+
+  selected[0] = deepest;
+  used[static_cast<std::size_t>(deepest)] = true;
+
+  if (candidates.size() == 1)
+    return selected;
+
+  const Eigen::Vector3d& p0
+      = candidates[static_cast<std::size_t>(selected[0])].localPointA;
+
+  double farthestDist = -1.0;
+  int farthest = -1;
+  for (std::size_t i = 0; i < candidates.size(); ++i) {
+    if (used[i])
+      continue;
+
+    const double d2 = (candidates[i].localPointA - p0).squaredNorm();
+    if (d2 > farthestDist) {
+      farthestDist = d2;
+      farthest = static_cast<int>(i);
+    }
+  }
+
+  if (farthest >= 0) {
+    selected[1] = farthest;
+    used[static_cast<std::size_t>(farthest)] = true;
+  }
+
+  if (candidates.size() <= 2 || selected[1] < 0)
+    return selected;
+
+  const Eigen::Vector3d& p1
+      = candidates[static_cast<std::size_t>(selected[1])].localPointA;
+  const Eigen::Vector3d e01 = p1 - p0;
+
+  double maxArea2 = -1.0;
+  int bestThird = -1;
+  for (std::size_t i = 0; i < candidates.size(); ++i) {
+    if (used[i])
+      continue;
+
+    const Eigen::Vector3d e02 = candidates[i].localPointA - p0;
+    const double area2 = e01.cross(e02).squaredNorm();
+    if (area2 > maxArea2) {
+      maxArea2 = area2;
+      bestThird = static_cast<int>(i);
+    }
+  }
+
+  if (bestThird >= 0) {
+    selected[2] = bestThird;
+    used[static_cast<std::size_t>(bestThird)] = true;
+  }
+
+  if (candidates.size() <= 3 || selected[2] < 0)
+    return selected;
+
+  const Eigen::Vector3d& p2
+      = candidates[static_cast<std::size_t>(selected[2])].localPointA;
+  const Eigen::Vector3d e02 = p2 - p0;
+
+  double maxVolume = -1.0;
+  int bestFourth = -1;
+  for (std::size_t i = 0; i < candidates.size(); ++i) {
+    if (used[i])
+      continue;
+
+    const Eigen::Vector3d e03 = candidates[i].localPointA - p0;
+    const double volume6 = std::abs(e01.dot(e02.cross(e03)));
+    if (volume6 > maxVolume) {
+      maxVolume = volume6;
+      bestFourth = static_cast<int>(i);
+    }
+  }
+
+  if (bestFourth >= 0)
+    selected[3] = bestFourth;
+
+  return selected;
+}
+
+//==============================================================================
+void writeReducedContacts(
+    const std::vector<CachedContact>& candidates, PersistentManifold& manifold)
+{
+  const auto selected = selectContactIndices(candidates);
+  int count = 0;
+  for (int idx : selected) {
+    if (idx < 0 || count >= PersistentManifold::kMaxContacts)
+      continue;
+
+    manifold.contacts[static_cast<std::size_t>(count)]
+        = candidates[static_cast<std::size_t>(idx)];
+    ++count;
+  }
+
+  manifold.numContacts = count;
+}
+
+} // namespace
+
+//==============================================================================
+int PersistentManifold::findMatch(
+    const Eigen::Vector3d& localPointA, double threshold) const
+{
+  if (numContacts <= 0)
+    return -1;
+
+  const double threshold2 = threshold * threshold;
+  int bestMatch = -1;
+  double bestDistance = std::numeric_limits<double>::max();
+
+  for (int i = 0; i < numContacts; ++i) {
+    const double d2
+        = (contacts[static_cast<std::size_t>(i)].localPointA - localPointA)
+              .squaredNorm();
+    if (d2 < bestDistance) {
+      bestDistance = d2;
+      bestMatch = i;
+    }
+  }
+
+  if (bestDistance <= threshold2)
+    return bestMatch;
+
+  return -1;
+}
+
+//==============================================================================
+void PersistentManifold::addOrReplace(const CachedContact& contact)
+{
+  const int match = findMatch(contact.localPointA);
+  if (match >= 0) {
+    CachedContact updated = contact;
+    const CachedContact& existing = contacts[static_cast<std::size_t>(match)];
+    updated.cachedNormalImpulse = existing.cachedNormalImpulse;
+    if (hasMatchingFrictionBasis(existing, contact)) {
+      updated.cachedFrictionImpulse1 = existing.cachedFrictionImpulse1;
+      updated.cachedFrictionImpulse2 = existing.cachedFrictionImpulse2;
+      updated.cachedFrictionBasis1 = existing.cachedFrictionBasis1;
+      updated.cachedFrictionBasis2 = existing.cachedFrictionBasis2;
+      updated.hasCachedFrictionBasis = existing.hasCachedFrictionBasis;
+    } else {
+      updated.cachedFrictionImpulse1 = 0.0;
+      updated.cachedFrictionImpulse2 = 0.0;
+      updated.cachedFrictionBasis1.setZero();
+      updated.cachedFrictionBasis2.setZero();
+      updated.hasCachedFrictionBasis = false;
+    }
+    updated.lifetime = 0;
+    contacts[static_cast<std::size_t>(match)] = updated;
+    return;
+  }
+
+  if (numContacts < kMaxContacts) {
+    CachedContact toInsert = contact;
+    toInsert.lifetime = 0;
+    contacts[static_cast<std::size_t>(numContacts)] = toInsert;
+    ++numContacts;
+    return;
+  }
+
+  reduce();
+
+  std::vector<CachedContact> candidates;
+  candidates.reserve(static_cast<std::size_t>(kMaxContacts + 1));
+  for (int i = 0; i < numContacts; ++i)
+    candidates.push_back(contacts[static_cast<std::size_t>(i)]);
+
+  CachedContact toInsert = contact;
+  toInsert.lifetime = 0;
+  candidates.push_back(toInsert);
+
+  writeReducedContacts(candidates, *this);
+}
+
+//==============================================================================
+void PersistentManifold::reduce()
+{
+  if (numContacts <= kMaxContacts)
+    return;
+
+  std::vector<CachedContact> candidates;
+  candidates.reserve(static_cast<std::size_t>(numContacts));
+  for (int i = 0; i < numContacts; ++i)
+    candidates.push_back(contacts[static_cast<std::size_t>(i)]);
+
+  writeReducedContacts(candidates, *this);
+}
+
+//==============================================================================
+void PersistentManifold::refresh(
+    const Eigen::Isometry3d& tfA,
+    const Eigen::Isometry3d& tfB,
+    double breakingThreshold)
+{
+  int writeIndex = 0;
+  for (int i = 0; i < numContacts; ++i) {
+    CachedContact contact = contacts[static_cast<std::size_t>(i)];
+
+    const Eigen::Vector3d worldA = tfA * contact.localPointA;
+    const Eigen::Vector3d worldB = tfB * contact.localPointB;
+    const Eigen::Vector3d rel = worldB - worldA;
+
+    const Eigen::Vector3d n = normalizedOrDefault(contact.normal);
+    const double normalDistance = std::abs(rel.dot(n));
+    const Eigen::Vector3d tangential = rel - n * rel.dot(n);
+    const double tangentialDrift = tangential.norm();
+
+    if (normalDistance > breakingThreshold
+        || tangentialDrift > breakingThreshold) {
+      continue;
+    }
+
+    ++contact.lifetime;
+    contacts[static_cast<std::size_t>(writeIndex)] = contact;
+    ++writeIndex;
+  }
+
+  numContacts = writeIndex;
+}
+
+//==============================================================================
+bool PairKey::operator==(const PairKey& other) const
+{
+  return idA == other.idA && idB == other.idB;
+}
+
+//==============================================================================
+std::size_t PairKeyHash::operator()(const PairKey& key) const
+{
+  const std::size_t h1 = std::hash<std::size_t>{}(key.idA);
+  const std::size_t h2 = std::hash<std::size_t>{}(key.idB);
+  return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6U) + (h1 >> 2U));
+}
+
+//==============================================================================
+PersistentManifold& PersistentManifoldCache::getOrCreate(
+    std::size_t idA, std::size_t idB)
+{
+  const PairKey key = canonicalPair(idA, idB);
+  return mManifolds[key];
+}
+
+//==============================================================================
+bool PersistentManifoldCache::ownsContact(
+    std::size_t idA, std::size_t idB, const void* contact) const
+{
+  if (contact == nullptr)
+    return false;
+
+  const PairKey key = canonicalPair(idA, idB);
+  const auto it = mManifolds.find(key);
+  if (it == mManifolds.end())
+    return false;
+
+  const auto& manifold = it->second;
+  for (int i = 0; i < manifold.numContacts; ++i) {
+    if (&manifold.contacts[static_cast<std::size_t>(i)] == contact)
+      return true;
+  }
+
+  return false;
+}
+
+//==============================================================================
+void PersistentManifoldCache::remove(std::size_t idA, std::size_t idB)
+{
+  const PairKey key = canonicalPair(idA, idB);
+  mManifolds.erase(key);
+}
+
+//==============================================================================
+void PersistentManifoldCache::removeObject(std::size_t id)
+{
+  for (auto it = mManifolds.begin(); it != mManifolds.end();) {
+    if (it->first.idA == id || it->first.idB == id) {
+      it = mManifolds.erase(it);
+      continue;
+    }
+
+    ++it;
+  }
+}
+
+//==============================================================================
+void PersistentManifoldCache::refreshAll(
+    const TransformProvider& transformProvider, double breakingThreshold)
+{
+  for (auto it = mManifolds.begin(); it != mManifolds.end();) {
+    const auto transformPair = transformProvider(it->first.idA, it->first.idB);
+    if (!transformPair.has_value()) {
+      ++it;
+      continue;
+    }
+
+    it->second.refresh(
+        transformPair->first, transformPair->second, breakingThreshold);
+    if (it->second.numContacts == 0) {
+      it = mManifolds.erase(it);
+      continue;
+    }
+
+    ++it;
+  }
+}
+
+//==============================================================================
+void PersistentManifoldCache::clear()
+{
+  mManifolds.clear();
+}
+
+//==============================================================================
+std::size_t PersistentManifoldCache::size() const
+{
+  return mManifolds.size();
+}
+
+} // namespace native
+} // namespace collision
+} // namespace dart

--- a/dart/collision/native/PersistentManifoldCache.hpp
+++ b/dart/collision/native/PersistentManifoldCache.hpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_NATIVE_PERSISTENTMANIFOLDCACHE_HPP_
+#define DART_COLLISION_NATIVE_PERSISTENTMANIFOLDCACHE_HPP_
+
+#include <dart/collision/native/Export.hpp>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <array>
+#include <functional>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+#include <cstddef>
+
+namespace dart {
+namespace collision {
+namespace native {
+
+struct DART_COLLISION_NATIVE_API CachedContact
+{
+  Eigen::Vector3d localPointA = Eigen::Vector3d::Zero();
+  Eigen::Vector3d localPointB = Eigen::Vector3d::Zero();
+  Eigen::Vector3d normal = Eigen::Vector3d::UnitZ();
+  double penetrationDepth = 0.0;
+  double cachedNormalImpulse = 0.0;
+  double cachedFrictionImpulse1 = 0.0;
+  double cachedFrictionImpulse2 = 0.0;
+  Eigen::Vector3d cachedFrictionBasis1 = Eigen::Vector3d::Zero();
+  Eigen::Vector3d cachedFrictionBasis2 = Eigen::Vector3d::Zero();
+  bool hasCachedFrictionBasis = false;
+  int lifetime = 0;
+};
+
+struct DART_COLLISION_NATIVE_API PersistentManifold
+{
+  static constexpr int kMaxContacts = 4;
+
+  std::array<CachedContact, kMaxContacts> contacts;
+  int numContacts = 0;
+
+  [[nodiscard]] int findMatch(
+      const Eigen::Vector3d& localPointA, double threshold = 0.02) const;
+
+  void addOrReplace(const CachedContact& contact);
+
+  void reduce();
+
+  void refresh(
+      const Eigen::Isometry3d& tfA,
+      const Eigen::Isometry3d& tfB,
+      double breakingThreshold = 0.04);
+};
+
+struct DART_COLLISION_NATIVE_API PairKey
+{
+  std::size_t idA = 0;
+  std::size_t idB = 0;
+
+  [[nodiscard]] bool operator==(const PairKey& other) const;
+};
+
+struct DART_COLLISION_NATIVE_API PairKeyHash
+{
+  [[nodiscard]] std::size_t operator()(const PairKey& key) const;
+};
+
+class DART_COLLISION_NATIVE_API PersistentManifoldCache
+{
+public:
+  using TransformProvider = std::function<
+      std::optional<std::pair<Eigen::Isometry3d, Eigen::Isometry3d>>(
+          std::size_t idA, std::size_t idB)>;
+
+  PersistentManifold& getOrCreate(std::size_t idA, std::size_t idB);
+
+  [[nodiscard]] bool ownsContact(
+      std::size_t idA, std::size_t idB, const void* contact) const;
+
+  void remove(std::size_t idA, std::size_t idB);
+
+  void removeObject(std::size_t id);
+
+  void refreshAll(
+      const TransformProvider& transformProvider,
+      double breakingThreshold = 0.04);
+
+  void clear();
+
+  [[nodiscard]] std::size_t size() const;
+
+private:
+  std::unordered_map<PairKey, PersistentManifold, PairKeyHash> mManifolds;
+};
+
+} // namespace native
+} // namespace collision
+} // namespace dart
+
+#endif // DART_COLLISION_NATIVE_PERSISTENTMANIFOLDCACHE_HPP_

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -33,6 +33,9 @@
 #include "dart/constraint/ContactConstraint.hpp"
 
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/collision/native/NativeCollisionDetector.hpp"
+#include "dart/collision/native/NativeCollisionObject.hpp"
+#include "dart/collision/native/PersistentManifoldCache.hpp"
 #include "dart/common/Console.hpp"
 #include "dart/common/Macros.hpp"
 #include "dart/dynamics/BodyNode.hpp"
@@ -41,7 +44,10 @@
 #include "dart/lcpsolver/dantzig/DantzigLcp.hpp"
 #include "dart/math/Helpers.hpp"
 
+#include <algorithm>
 #include <iostream>
+
+#include <cmath>
 
 #define DART_EPSILON 1e-6
 #define DART_ERROR_ALLOWANCE 0.0
@@ -54,6 +60,12 @@ namespace dart {
 namespace constraint {
 
 namespace {
+
+using NativeFrictionBasisMatrix = Eigen::Matrix<double, 3, 2>;
+
+constexpr double kCachedFrictionBasisTolerance = 1e-6;
+constexpr double kCachedFrictionBasisToleranceSquared
+    = kCachedFrictionBasisTolerance * kCachedFrictionBasisTolerance;
 
 //==============================================================================
 dynamics::BodyNode* getContactBodyNode(
@@ -101,6 +113,103 @@ bool isContactBodyNodeReactive(
   }
 
   return false;
+}
+
+//==============================================================================
+collision::native::CachedContact* getNativeCachedContact(
+    collision::Contact* contact)
+{
+  if (contact == nullptr || contact->userData == nullptr)
+    return nullptr;
+
+  auto* object1 = dynamic_cast<collision::NativeCollisionObject*>(
+      contact->collisionObject1);
+  if (object1 == nullptr)
+    return nullptr;
+
+  auto* object2 = dynamic_cast<collision::NativeCollisionObject*>(
+      contact->collisionObject2);
+  if (object2 == nullptr)
+    return nullptr;
+
+  auto* detector = dynamic_cast<collision::NativeCollisionDetector*>(
+      object1->getCollisionDetector());
+  if (detector == nullptr)
+    return nullptr;
+
+  return detector->getCachedContact(object1, object2, contact->userData);
+}
+
+//==============================================================================
+bool isFiniteVector(const Eigen::Vector3d& vector)
+{
+  return std::isfinite(vector.x()) && std::isfinite(vector.y())
+         && std::isfinite(vector.z());
+}
+
+//==============================================================================
+bool hasMatchingCachedFrictionBasis(
+    const collision::native::CachedContact& cached,
+    const NativeFrictionBasisMatrix& tangentBasis)
+{
+  if (!cached.hasCachedFrictionBasis)
+    return false;
+
+  if (!isFiniteVector(cached.cachedFrictionBasis1)
+      || !isFiniteVector(cached.cachedFrictionBasis2)) {
+    return false;
+  }
+
+  return (cached.cachedFrictionBasis1 - tangentBasis.col(0)).squaredNorm()
+             <= kCachedFrictionBasisToleranceSquared
+         && (cached.cachedFrictionBasis2 - tangentBasis.col(1)).squaredNorm()
+                <= kCachedFrictionBasisToleranceSquared;
+}
+
+//==============================================================================
+void clearCachedFrictionBasis(collision::native::CachedContact* cached)
+{
+  if (!cached)
+    return;
+
+  cached->cachedFrictionImpulse1 = 0.0;
+  cached->cachedFrictionImpulse2 = 0.0;
+  cached->cachedFrictionBasis1.setZero();
+  cached->cachedFrictionBasis2.setZero();
+  cached->hasCachedFrictionBasis = false;
+}
+
+//==============================================================================
+void seedCachedImpulses(
+    collision::native::CachedContact* cached,
+    ConstraintInfo* info,
+    bool hasFrictionRows,
+    bool seedFriction,
+    const NativeFrictionBasisMatrix* tangentBasis = nullptr)
+{
+  info->x[0] = 0.0;
+  if (hasFrictionRows) {
+    info->x[1] = 0.0;
+    info->x[2] = 0.0;
+  }
+
+  if (!cached)
+    return;
+
+  // Iterative boxed solvers such as PGS consume ConstraintInfo::x as an initial
+  // guess. The default Dantzig solver recomputes x from scratch, but still
+  // writes solved impulses back into the cache for initial-guess-aware solvers.
+  info->x[0] = std::max(0.0, cached->cachedNormalImpulse);
+  if (hasFrictionRows && seedFriction) {
+    if (!tangentBasis
+        || !hasMatchingCachedFrictionBasis(*cached, *tangentBasis)) {
+      clearCachedFrictionBasis(cached);
+      return;
+    }
+
+    info->x[1] = cached->cachedFrictionImpulse1;
+    info->x[2] = cached->cachedFrictionImpulse2;
+  }
 }
 
 } // namespace
@@ -660,11 +769,12 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
       info->b[2] += mContactSurfaceMotionVelocity.z();
     }
 
-    // TODO(JS): Initial guess
-    // x
-    info->x[0] = 0.0;
-    info->x[1] = 0.0;
-    info->x[2] = 0.0;
+    seedCachedImpulses(
+        getNativeCachedContact(mContact),
+        info,
+        true,
+        !isPositionPhase,
+        &mTangentBasis);
   }
   //----------------------------------------------------------------------------
   // Frictionless case
@@ -716,9 +826,7 @@ void ContactConstraint::getInformation(ConstraintInfo* info)
       info->b[0] += mContactSurfaceMotionVelocity.x();
     }
 
-    // TODO(JS): Initial guess
-    // x
-    info->x[0] = 0.0;
+    seedCachedImpulses(getNativeCachedContact(mContact), info, false, false);
   }
 }
 
@@ -943,6 +1051,29 @@ void ContactConstraint::applyImpulse(double* lambda)
   if (!hasValidBodyNodes())
     return;
 
+  const auto updateCachedUserData
+      = [&](double normalImpulse,
+            double frictionImpulse1,
+            double frictionImpulse2,
+            const NativeFrictionBasisMatrix* frictionBasis) {
+          auto* cached = getNativeCachedContact(mContact);
+          if (!cached)
+            return;
+
+          cached->cachedNormalImpulse = normalImpulse;
+          cached->cachedFrictionImpulse1 = frictionImpulse1;
+          cached->cachedFrictionImpulse2 = frictionImpulse2;
+          if (frictionBasis) {
+            cached->cachedFrictionBasis1 = frictionBasis->col(0);
+            cached->cachedFrictionBasis2 = frictionBasis->col(1);
+            cached->hasCachedFrictionBasis = true;
+          } else {
+            cached->cachedFrictionBasis1.setZero();
+            cached->cachedFrictionBasis2.setZero();
+            cached->hasCachedFrictionBasis = false;
+          }
+        };
+
   //----------------------------------------------------------------------------
   // Friction case
   //----------------------------------------------------------------------------
@@ -979,6 +1110,8 @@ void ContactConstraint::applyImpulse(double* lambda)
       mBodyNodeA->addConstraintImpulse(mSpatialNormalA.col(2) * lambda[2]);
     if (mIsReactiveB)
       mBodyNodeB->addConstraintImpulse(mSpatialNormalB.col(2) * lambda[2]);
+
+    updateCachedUserData(lambda[0], lambda[1], lambda[2], &mTangentBasis);
   }
   //----------------------------------------------------------------------------
   // Frictionless case
@@ -993,6 +1126,7 @@ void ContactConstraint::applyImpulse(double* lambda)
 
     // Store contact impulse (force) toward the normal w.r.t. world frame
     mContact->force = mContact->normal * lambda[0] / mTimeStep;
+    updateCachedUserData(lambda[0], 0.0, 0.0, nullptr);
   }
 }
 

--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1-D3 (#3352, #3355, #3358) merged; phase 3 D4 active on `feature/native-ccd` |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1-D4 (#3352, #3355, #3358, #3359) merged; phase 3 D5 active on `feature/native-manifold-cache` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -103,6 +103,7 @@
 - **#3358** phase-3 D3 native `VoxelGridShape`/octree replacement via compound
   voxel boxes and compound collision/distance/raycast routing (merged
   2026-07-09).
+- **#3359** phase-3 D4 native CCD engine support (merged 2026-07-09).
 - **#3283** main-branch dual for the native sphere-sphere binary-check fix
   (merged 2026-07-07).
 
@@ -119,15 +120,14 @@
 
 ### 🔄 Open — monitoring (checked 2026-07-09)
 
-- **Phase 3 D4** `feature/native-ccd` — active local slice for native CCD
-  engine support (rigid sphere/capsule casts, primitive point-triangle/edge-edge
-  CCD, and shape+transform dispatcher entry points). Keep it one PR to reduce
-  CI overhead.
-- **#3353** is open on `release-6.20` for the separate performance-generalization
-  plan parking lane.
+- **Phase 3 D5** `feature/native-manifold-cache` — active local slice for
+  persistent manifold cache/reuse, native detector cached-impulse reuse, and
+  solver cached-impulse write-back. Keep it one PR to reduce CI overhead.
+- **#3353** is merged on `release-6.20` for the separate
+  performance-generalization plan parking lane.
 - The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
-  #3324, #3325, #3357, and #3358 are merged. The perf lane's WP-PG.01 baseline packet
-  **#3263** also merged.
+  #3324, #3325, #3357, #3358, and #3359 are merged. The perf lane's WP-PG.01
+  baseline packet **#3263** also merged.
 
 Related remote heads still visible: `feature/native-occupancy-grid`,
 `task/native-collision-performance-exec`, and six `perf/dart6-*` round-1
@@ -157,10 +157,10 @@ before treating it as an open/active PR.)_
 - **Phase 2 status:** P1-P10 are merged: broadphase, dispatcher, adapter bridge,
   `"native"` registration, sphere/box/capsule/convex/cylinder/mesh/plane
   coverage, distance helpers, mixed-scene parity, and associated parity/
-  performance tests. **Phase 3 D1-D3 are merged (#3352/#3355/#3358):** native
-  detector distance, raycast, and VoxelGrid/compound wiring against the FCL/
-  Bullet incumbents and prior DART 6 support gaps. **Current slice is phase 3
-  D4:** native CCD engine support.
+  performance tests. **Phase 3 D1-D4 are merged (#3352/#3355/#3358/#3359):**
+  native detector distance, raycast, VoxelGrid/compound wiring, and CCD support
+  against the incumbent support gaps. **Current slice is phase 3 D5:**
+  persistent manifold cache/reuse.
 - **Default flip:** still late-phase only. Do not flip defaults until `03`'s full
   A/B packet and gz gate pass.
 - _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
@@ -172,8 +172,8 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `e2e03ffe8ee99cedda2fcda051f6eb30dc102363`; `origin/main` =
-     `a70fc2ed5cb7c3a4c44759ec222ce0338b8507f54`.
+     `1a33843125dde544c1a1c4caa11fae71af35b6e5`; `origin/main` =
+     `a70fc2ed5cb7ea40f72dce68b7d374583ab7feee`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
    - All remote mutations are owned by the maintainer.
@@ -212,9 +212,9 @@ before treating it as an open/active PR.)_
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
 - **Open queue (2026-07-09):** no open native-collision release PRs remain after
-  #3358. Phase 3 D4 is active locally on `feature/native-ccd`; the former
+  #3359. Phase 3 D5 is active locally on `feature/native-manifold-cache`; the former
   #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319, plus
-  #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355/#3358 lane milestones,
+  #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355/#3358/#3359 lane milestones,
   main-branch dual #3283, workflow rename #3357, and MSVC policy #3348 are
   merged.
 - **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -63,11 +63,14 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
   raycast benchmarks.
 - **#3358** phase-3 **D3**: native `VoxelGridShape`/octree replacement via
   compound voxel boxes, plus compound collision/distance/raycast routing.
+- **#3359** phase-3 **D4**: native CCD engine support for rigid sphere/capsule
+  casts, primitive point-triangle/edge-edge CCD, shape+transform dispatcher
+  entry points, and compound-target earliest-hit selection.
 
-`origin/release-6.20` tip at this refresh: `e2e03ffe8ee` (moves as the
+`origin/release-6.20` tip at this refresh: `1a33843125d` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
-## 4. Phase 2 complete; Phase 3 CCD active
+## 4. Phase 2 complete; Phase 3 D5 manifold cache active
 
 Bridge design (see `07` §0–§1): **bypass DART 7's EnTT `CollisionWorld`**; the
 adapter (`NativeCollisionDetector/Group/Object` + `NativeShapeConversion`)
@@ -90,38 +93,40 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **D1** | DART 6 `NativeCollisionDetector::distance()` adapter + native basename normalization | ✅ **merged (#3352)** |
 | **D2** | DART 6 `NativeCollisionDetector::raycast()` adapter + native-vs-Bullet raycast benchmarks | ✅ **merged (#3355)** |
 | **D3** | `VoxelGridShape`/octree replacement via native compound boxes + compound collision/distance/raycast recursion | ✅ **merged (#3358)** |
-| **D4** | Native CCD engine: rigid sphere/capsule casts, primitive point-triangle/edge-edge CCD, and shape+transform dispatcher support | 🔄 **active local branch** `feature/native-ccd` |
-| **D5** | Persistent manifold cache and manifold reuse/reduction follow-up | ⬜ not started |
+| **D4** | Native CCD engine: rigid sphere/capsule casts, primitive point-triangle/edge-edge CCD, and shape+transform dispatcher support | ✅ **merged (#3359)** |
+| **D5** | Persistent manifold cache and manifold reuse/reduction follow-up | 🔄 **active local branch** `feature/native-manifold-cache` |
 
-### Exact next step: finish Phase 3 D4 native CCD
+### Exact next step: finish Phase 3 D5 persistent manifold cache
 
-1. Continue with the **Phase 3 D4** branch `feature/native-ccd`,
-   based on the current `origin/release-6.20`.
-2. Keep it as one PR: port `Ccd` and `PrimitiveCcd` from DART 7 with DART 6
-   PascalCase file names and C++17-compatible includes; expose only
-   shape+transform `NarrowPhase::sphereCast` and `capsuleCast` entry points,
-   not the DART 7 EnTT `CollisionObject` overloads.
-3. Cover rigid sphere/capsule casts, primitive point-triangle/edge-edge CCD,
-   compound-target earliest-hit selection, and the support matrix. Keep the
-   native detector opt-in only.
-4. Leave persistent manifolds, Bullet/ODE/FCL facades, and the default flip for
-   later phase-3/phase-5/phase-6 slices.
+1. Continue with the **Phase 3 D5** branch `feature/native-manifold-cache`,
+   based on `origin/release-6.20` at or after `1a33843125d`.
+2. Keep it as one PR: port DART 7's persistent manifold cache with DART 6
+   PascalCase file names, wire native detector cached-impulse reuse, and seed/
+   write back cached impulses through `ContactConstraint` for solvers that
+   honor `ConstraintInfo::x` initial guesses.
+3. Cover cache matching/reduction/refresh, native detector cached-impulse reuse
+   for same-group and cross-group contacts, and solver cached-impulse
+   write-back.
+4. Keep FCL as the default detector; do not touch `World`,
+   `ConstraintSolver` detector defaults, `WorldConfig`, or dependency/package
+   metadata in this slice.
 5. Gates for **every** native-collision capability PR:
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
    UNIT_collision_native --output-on-failure` (`pixi run test-all` only *builds*);
-   full `pixi run check-lint`; guard-row hashes unchanged;
+   full `pixi run check-lint`; contact-rich benchmark comparison evidence;
    `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz` (199 + 4 + 1); portability
-   `rg 'entt|std::span'` on new files → empty; scope-diff touches only
-   `dart/collision/native/**` + its CMakeLists + `tests/**`. Include a scoped
-   performance/complexity note in the PR body; full optimization remains phase 4.
+   `rg 'entt|std::span'` on new files → empty. The D5 scope necessarily also
+   touches `dart/constraint/ContactConstraint.cpp` for native cached-impulse
+   seed/write-back; keep any further scope expansion out. Preserve the public
+   `dart::collision::Contact` layout on this release branch.
 
 ## 5. Open PRs / loose ends
 
-- **Phase 3 D4 native CCD support** — active on `feature/native-ccd` as one
-  PR-sized slice to minimize CI overhead.
-- **#3353** is open on `release-6.20` for the separate performance-generalization
-  plan parking lane.
+- **Phase 3 D5 persistent manifold cache** — active on
+  `feature/native-manifold-cache` as one PR-sized slice to minimize CI overhead.
+- **#3353** is merged on `release-6.20` for the separate
+  performance-generalization plan parking lane.
 - **#3357** is merged; it renamed the DART 6 autonomous AI workflow to
   `dart-ultrawork` and is unrelated to this native-collision code slice.
 - **#3283 (main sphere-sphere `enableContact` fix)** and **#3348** (MSVC

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -20,14 +20,14 @@ Evidence was first collected on 2026-06-19 after fetching `origin/main`,
 `origin/release-6.20`, and `origin/release-6.19`. The native-collision port
 evidence in `03-native-collision-port-scoping.md` and the dashboard state in
 `04-orchestration-dashboard.md` were refreshed on 2026-07-09 after fetching
-`origin/main` and `origin/release-6.20`, and after phase-3 D3 merged.
+`origin/main` and `origin/release-6.20`, and after phase-3 D4 merged.
 
 ## Current Branch State
 
 - `origin/release-6.20` currently points at
-  `e2e03ffe8ee99cedda2fcda051f6eb30dc102363`.
+  `1a33843125dde544c1a1c4caa11fae71af35b6e5`.
 - `origin/main` currently points at
-  `a70fc2ed5cb7c3a4c44759ec222ce0338b8507f54`.
+  `a70fc2ed5cb7ea40f72dce68b7d374583ab7feee`.
 - `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x
   package version (`6.19.3` in the current CMake configure output).
 - DART 6.20 intentionally uses the release lane while package version metadata

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -71,19 +71,22 @@ scope-diff-guarded.
 - **D2** (native detector raycast adapter + native-vs-Bullet raycast
   benchmarks): **#3355** — **merged**.
 - **D3** (native VoxelGrid/compound support): **#3358** — **merged**.
+- **D4** (native CCD support): **#3359** — **merged**.
 
-**Next: Phase 3 D4 — native CCD support** on `feature/native-ccd`. Keep this
-as one PR: port DART 7's rigid sphere/capsule casts and primitive
-point-triangle/edge-edge CCD into `dart/collision/native/narrow_phase/` using
-DART 6 PascalCase file names, expose shape+transform
-`NarrowPhase::sphereCast` and `capsuleCast` entry points, and cover the
-support matrix plus compound-target earliest-hit behavior. Keep the native
-detector opt-in only. **Do not** add a `CollisionDetectorType::Native` enum or
-touch `World`/`ConstraintSolver`/`WorldConfig`; FCL remains the default until
-phase 6.
+**Next: Phase 3 D5 — persistent manifold cache** on
+`feature/native-manifold-cache`. Keep this as one PR: port DART 7's persistent
+manifold cache using DART 6 PascalCase file names, wire native detector
+cached-impulse reuse, and seed/write back cached impulses through
+`ContactConstraint` for solvers that honor `ConstraintInfo::x` initial guesses.
+Cover cache matching/reduction/refresh, native detector cached-impulse reuse
+for same-group and cross-group contacts, and solver cached-impulse write-back.
+Keep the native detector opt-in only. **Do not** add
+a `CollisionDetectorType::Native` enum or touch `World` detector defaults,
+`ConstraintSolver` detector defaults, `WorldConfig`, or dependency/package
+metadata; FCL remains the default until phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
-PRs, worktrees, gotchas, and exact Phase 3 D4 next steps).
+PRs, worktrees, gotchas, and exact Phase 3 D5 next steps).
 
 ## Standing constraints
 

--- a/tests/integration/test_ConstraintSolver.cpp
+++ b/tests/integration/test_ConstraintSolver.cpp
@@ -36,6 +36,9 @@
 #include "dart/collision/CollisionObject.hpp"
 #include "dart/collision/Contact.hpp"
 #include "dart/collision/dart/DARTCollisionDetector.hpp"
+#include "dart/collision/native/NativeCollisionDetector.hpp"
+#include "dart/collision/native/NativeCollisionObject.hpp"
+#include "dart/collision/native/PersistentManifoldCache.hpp"
 #include "dart/constraint/BallJointConstraint.hpp"
 #include "dart/constraint/BoxedLcpConstraintSolver.hpp"
 #include "dart/constraint/ConstrainedGroup.hpp"
@@ -234,8 +237,21 @@ public:
 class ExposedContactConstraint final : public constraint::ContactConstraint
 {
 public:
+  using ContactConstraint::applyImpulse;
   using ContactConstraint::ContactConstraint;
   using ContactConstraint::getInformation;
+};
+
+class ExposedNativeCollisionObject final
+  : public collision::NativeCollisionObject
+{
+public:
+  ExposedNativeCollisionObject(
+      collision::CollisionDetector* detector,
+      const dynamics::ShapeFrame* shapeFrame)
+    : NativeCollisionObject(detector, shapeFrame)
+  {
+  }
 };
 
 class CustomContactSurfaceHandler final
@@ -594,6 +610,27 @@ collision::Contact createContact(
   contact.point = Eigen::Vector3d::Zero();
   contact.normal = Eigen::Vector3d::UnitZ();
   return contact;
+}
+
+Eigen::Vector3d makeContactTangentDirection(
+    const Eigen::Vector3d& normal, const Eigen::Vector3d& seed)
+{
+  Eigen::Vector3d n = normal;
+  if (n.squaredNorm() < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED)
+    n = Eigen::Vector3d::UnitZ();
+  else
+    n.normalize();
+
+  Eigen::Vector3d tangent = seed - n * seed.dot(n);
+  if (tangent.squaredNorm() < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED)
+    tangent = Eigen::Vector3d::UnitX() - n * n.x();
+  if (tangent.squaredNorm() < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED)
+    tangent = Eigen::Vector3d::UnitY() - n * n.y();
+  if (tangent.squaredNorm() < DART_CONTACT_CONSTRAINT_EPSILON_SQUARED)
+    tangent = Eigen::Vector3d::UnitZ() - n * n.z();
+
+  tangent.normalize();
+  return tangent;
 }
 
 template <typename ConstraintT>
@@ -1296,6 +1333,348 @@ TEST(ConstraintSolver, MovingFixedContactSupportContributesRelVelocity)
   constraint.getInformation(&info);
 
   EXPECT_NEAR(0.25, b[0], 1e-12);
+}
+
+//==============================================================================
+TEST(ConstraintSolver, ContactConstraintCachesSolvedImpulse)
+{
+  std::vector<dynamics::SkeletonPtr> skeletons;
+  auto* fixedBody = createFreeBody("fixed", false, skeletons);
+  auto* dynamicBody = createFreeBody("dynamic", true, skeletons);
+
+  auto shape = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones());
+  auto* fixedShapeNode = fixedBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+  auto* dynamicShapeNode = dynamicBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+
+  auto detector = collision::NativeCollisionDetector::create();
+  auto group = detector->createCollisionGroup(dynamicShapeNode, fixedShapeNode);
+
+  collision::CollisionResult result;
+  ASSERT_TRUE(group->collide(collision::CollisionOption(true, 10u), &result));
+  ASSERT_GT(result.getNumContacts(), 0u);
+
+  auto contact = result.getContact(0);
+  ASSERT_NE(nullptr, contact.userData);
+  auto* cachedContact
+      = static_cast<collision::native::CachedContact*>(contact.userData);
+  cachedContact->cachedNormalImpulse = 1.25;
+  cachedContact->cachedFrictionImpulse1 = -0.5;
+  cachedContact->cachedFrictionImpulse2 = 0.75;
+
+  contact.userData = cachedContact;
+
+  ExposedContactConstraint constraint(
+      contact, 0.001, constraint::ContactSurfaceParams{});
+
+  double x[3] = {1.0, 2.0, 3.0};
+  double lo[3] = {0.0, 0.0, 0.0};
+  double hi[3] = {0.0, 0.0, 0.0};
+  double b[3] = {0.0, 0.0, 0.0};
+  double w[3] = {0.0, 0.0, 0.0};
+  int findex[3] = {-1, -1, -1};
+  constraint::ConstraintInfo info;
+  info.x = x;
+  info.lo = lo;
+  info.hi = hi;
+  info.b = b;
+  info.w = w;
+  info.findex = findex;
+  info.invTimeStep = 1000.0;
+  constraint.getInformation(&info);
+
+  EXPECT_NEAR(1.25, x[0], 1e-12);
+  EXPECT_NEAR(0.0, x[1], 1e-12);
+  EXPECT_NEAR(0.0, x[2], 1e-12);
+  EXPECT_NEAR(0.0, cachedContact->cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.0, cachedContact->cachedFrictionImpulse2, 1e-12);
+  EXPECT_FALSE(cachedContact->hasCachedFrictionBasis);
+
+  double lambda[3] = {2.5, -0.25, 0.125};
+  constraint.applyImpulse(lambda);
+
+  EXPECT_NEAR(2.5, cachedContact->cachedNormalImpulse, 1e-12);
+  EXPECT_NEAR(-0.25, cachedContact->cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.125, cachedContact->cachedFrictionImpulse2, 1e-12);
+  EXPECT_TRUE(cachedContact->hasCachedFrictionBasis);
+  EXPECT_FALSE(cachedContact->cachedFrictionBasis1.isZero());
+  EXPECT_FALSE(cachedContact->cachedFrictionBasis2.isZero());
+
+  ExposedContactConstraint warmConstraint(
+      contact, 0.001, constraint::ContactSurfaceParams{});
+  double warmX[3] = {0.0, 0.0, 0.0};
+  double warmLo[3] = {0.0, 0.0, 0.0};
+  double warmHi[3] = {0.0, 0.0, 0.0};
+  double warmB[3] = {0.0, 0.0, 0.0};
+  double warmW[3] = {0.0, 0.0, 0.0};
+  int warmFindex[3] = {-1, -1, -1};
+  constraint::ConstraintInfo warmInfo;
+  warmInfo.x = warmX;
+  warmInfo.lo = warmLo;
+  warmInfo.hi = warmHi;
+  warmInfo.b = warmB;
+  warmInfo.w = warmW;
+  warmInfo.findex = warmFindex;
+  warmInfo.invTimeStep = 1000.0;
+  warmConstraint.getInformation(&warmInfo);
+
+  EXPECT_NEAR(2.5, warmX[0], 1e-12);
+  EXPECT_NEAR(-0.25, warmX[1], 1e-12);
+  EXPECT_NEAR(0.125, warmX[2], 1e-12);
+}
+
+//==============================================================================
+TEST(ConstraintSolver, ContactConstraintClearsFrictionForChangedFrictionBasis)
+{
+  std::vector<dynamics::SkeletonPtr> skeletons;
+  auto* fixedBody = createFreeBody("fixed", false, skeletons);
+  auto* dynamicBody = createFreeBody("dynamic", true, skeletons);
+
+  auto shape = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones());
+  auto* fixedShapeNode = fixedBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+  auto* dynamicShapeNode = dynamicBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+
+  auto detector = collision::NativeCollisionDetector::create();
+  auto group = detector->createCollisionGroup(dynamicShapeNode, fixedShapeNode);
+
+  collision::CollisionResult result;
+  ASSERT_TRUE(group->collide(collision::CollisionOption(true, 10u), &result));
+  ASSERT_GT(result.getNumContacts(), 0u);
+
+  auto contact = result.getContact(0);
+  ASSERT_NE(nullptr, contact.userData);
+  auto* cachedContact
+      = static_cast<collision::native::CachedContact*>(contact.userData);
+
+  constraint::ContactSurfaceParams firstParams;
+  firstParams.mFirstFrictionalDirection
+      = makeContactTangentDirection(contact.normal, Eigen::Vector3d::UnitX());
+  Eigen::Vector3d n = contact.normal;
+  ASSERT_GT(n.squaredNorm(), DART_CONTACT_CONSTRAINT_EPSILON_SQUARED);
+  n.normalize();
+  constraint::ContactSurfaceParams secondParams;
+  secondParams.mFirstFrictionalDirection
+      = n.cross(firstParams.mFirstFrictionalDirection).normalized();
+
+  ExposedContactConstraint solved(contact, 0.001, firstParams);
+  double lambda[3] = {2.5, -0.25, 0.125};
+  solved.applyImpulse(lambda);
+  ASSERT_TRUE(cachedContact->hasCachedFrictionBasis);
+
+  ExposedContactConstraint changed(contact, 0.001, secondParams);
+  double x[3] = {1.0, 2.0, 3.0};
+  double lo[3] = {0.0, 0.0, 0.0};
+  double hi[3] = {0.0, 0.0, 0.0};
+  double b[3] = {0.0, 0.0, 0.0};
+  double w[3] = {0.0, 0.0, 0.0};
+  int findex[3] = {-1, -1, -1};
+  constraint::ConstraintInfo info;
+  info.x = x;
+  info.lo = lo;
+  info.hi = hi;
+  info.b = b;
+  info.w = w;
+  info.findex = findex;
+  info.invTimeStep = 1000.0;
+  changed.getInformation(&info);
+
+  EXPECT_NEAR(2.5, x[0], 1e-12);
+  EXPECT_NEAR(0.0, x[1], 1e-12);
+  EXPECT_NEAR(0.0, x[2], 1e-12);
+  EXPECT_NEAR(0.0, cachedContact->cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.0, cachedContact->cachedFrictionImpulse2, 1e-12);
+  EXPECT_FALSE(cachedContact->hasCachedFrictionBasis);
+}
+
+//==============================================================================
+TEST(ConstraintSolver, ContactConstraintDoesNotSeedFrictionInPositionPhase)
+{
+  std::vector<dynamics::SkeletonPtr> skeletons;
+  auto* fixedBody = createFreeBody("fixed", false, skeletons);
+  auto* dynamicBody = createFreeBody("dynamic", true, skeletons);
+
+  auto shape = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones());
+  auto* fixedShapeNode = fixedBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+  auto* dynamicShapeNode = dynamicBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+
+  auto detector = collision::NativeCollisionDetector::create();
+  auto group = detector->createCollisionGroup(dynamicShapeNode, fixedShapeNode);
+
+  collision::CollisionResult result;
+  ASSERT_TRUE(group->collide(collision::CollisionOption(true, 10u), &result));
+  ASSERT_GT(result.getNumContacts(), 0u);
+
+  auto contact = result.getContact(0);
+  ASSERT_NE(nullptr, contact.userData);
+  auto* cachedContact
+      = static_cast<collision::native::CachedContact*>(contact.userData);
+  contact.userData = cachedContact;
+
+  ExposedContactConstraint velocityConstraint(
+      contact, 0.001, constraint::ContactSurfaceParams{});
+  double lambda[3] = {1.25, -0.5, 0.75};
+  velocityConstraint.applyImpulse(lambda);
+  ASSERT_TRUE(cachedContact->hasCachedFrictionBasis);
+
+  ExposedContactConstraint positionConstraint(
+      contact, 0.001, constraint::ContactSurfaceParams{});
+
+  double x[3] = {1.0, 2.0, 3.0};
+  double lo[3] = {0.0, 0.0, 0.0};
+  double hi[3] = {0.0, 0.0, 0.0};
+  double b[3] = {0.0, 0.0, 0.0};
+  double w[3] = {0.0, 0.0, 0.0};
+  int findex[3] = {-1, -1, -1};
+  constraint::ConstraintInfo info;
+  info.x = x;
+  info.lo = lo;
+  info.hi = hi;
+  info.b = b;
+  info.w = w;
+  info.findex = findex;
+  info.invTimeStep = 1000.0;
+  info.phase = constraint::ConstraintPhase::Position;
+  positionConstraint.getInformation(&info);
+
+  EXPECT_NEAR(1.25, x[0], 1e-12);
+  EXPECT_NEAR(0.0, x[1], 1e-12);
+  EXPECT_NEAR(0.0, x[2], 1e-12);
+  EXPECT_NEAR(-0.5, cachedContact->cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.75, cachedContact->cachedFrictionImpulse2, 1e-12);
+  EXPECT_TRUE(cachedContact->hasCachedFrictionBasis);
+}
+
+//==============================================================================
+TEST(ConstraintSolver, ContactConstraintIgnoresForeignUserData)
+{
+  std::vector<dynamics::SkeletonPtr> skeletons;
+  auto* fixedBody = createFreeBody("fixed", false, skeletons);
+  auto* dynamicBody = createFreeBody("dynamic", true, skeletons);
+
+  auto shape = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones());
+  auto* fixedShapeNode = fixedBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+  auto* dynamicShapeNode = dynamicBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+
+  FakeCollisionDetector detector;
+  FakeCollisionObject fixedObject(&detector, fixedShapeNode);
+  FakeCollisionObject dynamicObject(&detector, dynamicShapeNode);
+
+  struct ForeignPayload
+  {
+    double value1;
+    double value2;
+    double value3;
+  };
+  ForeignPayload payload{10.0, 20.0, 30.0};
+
+  auto contact = createContact(&dynamicObject, &fixedObject);
+  contact.userData = &payload;
+
+  ExposedContactConstraint constraint(
+      contact, 0.001, constraint::ContactSurfaceParams{});
+
+  double x[3] = {1.0, 2.0, 3.0};
+  double lo[3] = {0.0, 0.0, 0.0};
+  double hi[3] = {0.0, 0.0, 0.0};
+  double b[3] = {0.0, 0.0, 0.0};
+  double w[3] = {0.0, 0.0, 0.0};
+  int findex[3] = {-1, -1, -1};
+  constraint::ConstraintInfo info;
+  info.x = x;
+  info.lo = lo;
+  info.hi = hi;
+  info.b = b;
+  info.w = w;
+  info.findex = findex;
+  info.invTimeStep = 1000.0;
+  constraint.getInformation(&info);
+
+  EXPECT_NEAR(0.0, x[0], 1e-12);
+  EXPECT_NEAR(0.0, x[1], 1e-12);
+  EXPECT_NEAR(0.0, x[2], 1e-12);
+
+  double lambda[3] = {2.5, -0.25, 0.125};
+  constraint.applyImpulse(lambda);
+
+  EXPECT_NEAR(10.0, payload.value1, 1e-12);
+  EXPECT_NEAR(20.0, payload.value2, 1e-12);
+  EXPECT_NEAR(30.0, payload.value3, 1e-12);
+}
+
+//==============================================================================
+TEST(ConstraintSolver, ContactConstraintIgnoresForeignNativeUserData)
+{
+  std::vector<dynamics::SkeletonPtr> skeletons;
+  auto* fixedBody = createFreeBody("fixed", false, skeletons);
+  auto* dynamicBody = createFreeBody("dynamic", true, skeletons);
+
+  auto shape = std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones());
+  auto* fixedShapeNode = fixedBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+  auto* dynamicShapeNode = dynamicBody->createShapeNodeWith<
+      dynamics::CollisionAspect,
+      dynamics::DynamicsAspect>(shape);
+
+  auto detector = collision::NativeCollisionDetector::create();
+  ExposedNativeCollisionObject fixedObject(detector.get(), fixedShapeNode);
+  ExposedNativeCollisionObject dynamicObject(detector.get(), dynamicShapeNode);
+
+  struct ForeignPayload
+  {
+    double value1;
+    double value2;
+    double value3;
+  };
+  ForeignPayload payload{10.0, 20.0, 30.0};
+
+  auto contact = createContact(&dynamicObject, &fixedObject);
+  contact.userData = &payload;
+
+  ExposedContactConstraint constraint(
+      contact, 0.001, constraint::ContactSurfaceParams{});
+
+  double x[3] = {1.0, 2.0, 3.0};
+  double lo[3] = {0.0, 0.0, 0.0};
+  double hi[3] = {0.0, 0.0, 0.0};
+  double b[3] = {0.0, 0.0, 0.0};
+  double w[3] = {0.0, 0.0, 0.0};
+  int findex[3] = {-1, -1, -1};
+  constraint::ConstraintInfo info;
+  info.x = x;
+  info.lo = lo;
+  info.hi = hi;
+  info.b = b;
+  info.w = w;
+  info.findex = findex;
+  info.invTimeStep = 1000.0;
+  constraint.getInformation(&info);
+
+  EXPECT_NEAR(0.0, x[0], 1e-12);
+  EXPECT_NEAR(0.0, x[1], 1e-12);
+  EXPECT_NEAR(0.0, x[2], 1e-12);
+
+  double lambda[3] = {2.5, -0.25, 0.125};
+  constraint.applyImpulse(lambda);
+
+  EXPECT_NEAR(10.0, payload.value1, 1e-12);
+  EXPECT_NEAR(20.0, payload.value2, 1e-12);
+  EXPECT_NEAR(30.0, payload.value3, 1e-12);
 }
 
 //==============================================================================

--- a/tests/unit/collision/native/CMakeLists.txt
+++ b/tests/unit/collision/native/CMakeLists.txt
@@ -65,6 +65,11 @@ dart_add_test(
 )
 dart_add_test(
   "unit"
+  UNIT_collision_native_persistent_manifold_cache
+  test_persistent_manifold_cache.cpp
+)
+dart_add_test(
+  "unit"
   UNIT_collision_native_primitive_ccd
   test_primitive_ccd.cpp
 )

--- a/tests/unit/collision/native/test_persistent_manifold_cache.cpp
+++ b/tests/unit/collision/native/test_persistent_manifold_cache.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/PersistentManifoldCache.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <optional>
+
+#include <cmath>
+
+using namespace dart::collision::native;
+
+//==============================================================================
+TEST(PersistentManifoldCache, CreateAndRetrieve)
+{
+  PersistentManifoldCache cache;
+  auto& manifold = cache.getOrCreate(11u, 29u);
+
+  CachedContact contact;
+  contact.localPointA = Eigen::Vector3d(0.1, 0.0, 0.0);
+  contact.localPointB = Eigen::Vector3d(0.1, 0.0, 0.0);
+  contact.penetrationDepth = 0.02;
+  manifold.addOrReplace(contact);
+
+  EXPECT_EQ(1u, cache.size());
+  auto& same = cache.getOrCreate(11u, 29u);
+  EXPECT_EQ(1, same.numContacts);
+  EXPECT_NEAR(0.02, same.contacts[0].penetrationDepth, 1e-12);
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, PairKeySymmetry)
+{
+  PersistentManifoldCache cache;
+
+  auto& manifoldAB = cache.getOrCreate(3u, 9u);
+  auto& manifoldBA = cache.getOrCreate(9u, 3u);
+
+  EXPECT_EQ(&manifoldAB, &manifoldBA);
+  EXPECT_EQ(1u, cache.size());
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, ContactMatchingPreservesCachedImpulses)
+{
+  PersistentManifold manifold;
+
+  CachedContact first;
+  first.localPointA = Eigen::Vector3d(0.1, 0.2, 0.3);
+  first.localPointB = Eigen::Vector3d(0.1, 0.2, 0.3);
+  first.cachedNormalImpulse = 1.2;
+  first.cachedFrictionImpulse1 = -0.3;
+  first.cachedFrictionImpulse2 = 0.7;
+  first.cachedFrictionBasis1 = Eigen::Vector3d::UnitX();
+  first.cachedFrictionBasis2 = Eigen::Vector3d::UnitY();
+  first.hasCachedFrictionBasis = true;
+  manifold.addOrReplace(first);
+
+  CachedContact second;
+  second.localPointA = Eigen::Vector3d(0.1005, 0.2, 0.3005);
+  second.localPointB = Eigen::Vector3d(0.1005, 0.2, 0.3005);
+  second.penetrationDepth = 0.04;
+  manifold.addOrReplace(second);
+
+  ASSERT_EQ(1, manifold.numContacts);
+  EXPECT_NEAR(1.2, manifold.contacts[0].cachedNormalImpulse, 1e-12);
+  EXPECT_NEAR(-0.3, manifold.contacts[0].cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.7, manifold.contacts[0].cachedFrictionImpulse2, 1e-12);
+  EXPECT_TRUE(manifold.contacts[0].hasCachedFrictionBasis);
+  EXPECT_TRUE(manifold.contacts[0].cachedFrictionBasis1.isApprox(
+      Eigen::Vector3d::UnitX()));
+  EXPECT_TRUE(manifold.contacts[0].cachedFrictionBasis2.isApprox(
+      Eigen::Vector3d::UnitY()));
+  EXPECT_EQ(0, manifold.contacts[0].lifetime);
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, ContactMatchingClearsFrictionForChangedNormal)
+{
+  PersistentManifold manifold;
+
+  CachedContact first;
+  first.localPointA = Eigen::Vector3d(0.1, 0.2, 0.3);
+  first.localPointB = Eigen::Vector3d(0.1, 0.2, 0.3);
+  first.normal = Eigen::Vector3d::UnitX();
+  first.cachedNormalImpulse = 1.2;
+  first.cachedFrictionImpulse1 = -0.3;
+  first.cachedFrictionImpulse2 = 0.7;
+  first.cachedFrictionBasis1 = Eigen::Vector3d::UnitY();
+  first.cachedFrictionBasis2 = Eigen::Vector3d::UnitZ();
+  first.hasCachedFrictionBasis = true;
+  manifold.addOrReplace(first);
+
+  CachedContact second;
+  second.localPointA = Eigen::Vector3d(0.1005, 0.2, 0.3005);
+  second.localPointB = Eigen::Vector3d(0.1005, 0.2, 0.3005);
+  second.normal = -Eigen::Vector3d::UnitX();
+  second.penetrationDepth = 0.04;
+  manifold.addOrReplace(second);
+
+  ASSERT_EQ(1, manifold.numContacts);
+  EXPECT_NEAR(1.2, manifold.contacts[0].cachedNormalImpulse, 1e-12);
+  EXPECT_NEAR(0.0, manifold.contacts[0].cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.0, manifold.contacts[0].cachedFrictionImpulse2, 1e-12);
+  EXPECT_FALSE(manifold.contacts[0].hasCachedFrictionBasis);
+  EXPECT_TRUE(manifold.contacts[0].cachedFrictionBasis1.isZero());
+  EXPECT_TRUE(manifold.contacts[0].cachedFrictionBasis2.isZero());
+  EXPECT_EQ(0, manifold.contacts[0].lifetime);
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, ReductionKeepsDeepAndWideContacts)
+{
+  PersistentManifold manifold;
+
+  for (int i = 0; i < 6; ++i) {
+    CachedContact contact;
+    contact.localPointA = Eigen::Vector3d(0.04 * i, 0.03 * (i % 3), 0.0);
+    contact.localPointB = contact.localPointA;
+    contact.penetrationDepth = (i == 4) ? 0.25 : 0.01 * i;
+    manifold.addOrReplace(contact);
+  }
+
+  EXPECT_EQ(4, manifold.numContacts);
+  bool foundDeepest = false;
+  for (int i = 0; i < manifold.numContacts; ++i) {
+    if (std::abs(
+            manifold.contacts[static_cast<std::size_t>(i)].penetrationDepth
+            - 0.25)
+        < 1e-12) {
+      foundDeepest = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(foundDeepest);
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, ReductionCanDropInsertedContact)
+{
+  PersistentManifold manifold;
+
+  std::array<Eigen::Vector3d, PersistentManifold::kMaxContacts> points{
+      Eigen::Vector3d(-1.0, -1.0, 0.0),
+      Eigen::Vector3d(1.0, -1.0, 0.0),
+      Eigen::Vector3d(-1.0, 1.0, 0.0),
+      Eigen::Vector3d(1.0, 1.0, 0.0)};
+
+  for (std::size_t i = 0u; i < points.size(); ++i) {
+    CachedContact contact;
+    contact.localPointA = points[i];
+    contact.localPointB = points[i];
+    contact.penetrationDepth = 0.2 - 0.01 * static_cast<double>(i);
+    manifold.addOrReplace(contact);
+  }
+
+  CachedContact inserted;
+  inserted.localPointA = Eigen::Vector3d::Zero();
+  inserted.localPointB = inserted.localPointA;
+  inserted.penetrationDepth = 0.01;
+  manifold.addOrReplace(inserted);
+
+  EXPECT_EQ(PersistentManifold::kMaxContacts, manifold.numContacts);
+  EXPECT_EQ(-1, manifold.findMatch(inserted.localPointA));
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, RefreshRemovesDriftedContact)
+{
+  PersistentManifold manifold;
+  CachedContact contact;
+  contact.localPointA = Eigen::Vector3d::Zero();
+  contact.localPointB = Eigen::Vector3d::Zero();
+  contact.normal = Eigen::Vector3d::UnitX();
+  manifold.addOrReplace(contact);
+
+  Eigen::Isometry3d tfA = Eigen::Isometry3d::Identity();
+  Eigen::Isometry3d tfB = Eigen::Isometry3d::Identity();
+  tfB.translation() = Eigen::Vector3d(0.1, 0.0, 0.0);
+
+  manifold.refresh(tfA, tfB, 0.04);
+  EXPECT_EQ(0, manifold.numContacts);
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, RefreshAllKeepsUnknownPairsAndDropsDriftedPairs)
+{
+  PersistentManifoldCache cache;
+
+  CachedContact stable;
+  stable.localPointA = Eigen::Vector3d::Zero();
+  stable.localPointB = Eigen::Vector3d::Zero();
+  stable.normal = Eigen::Vector3d::Zero();
+  cache.getOrCreate(1u, 2u).addOrReplace(stable);
+
+  CachedContact missing;
+  missing.localPointA = Eigen::Vector3d::Zero();
+  missing.localPointB = Eigen::Vector3d::Zero();
+  cache.getOrCreate(3u, 4u).addOrReplace(missing);
+
+  CachedContact drifting;
+  drifting.localPointA = Eigen::Vector3d::Zero();
+  drifting.localPointB = Eigen::Vector3d::Zero();
+  drifting.normal = Eigen::Vector3d::UnitX();
+  cache.getOrCreate(5u, 6u).addOrReplace(drifting);
+
+  cache.refreshAll(
+      [](std::size_t idA, std::size_t idB) {
+        if (idA == 3u || idB == 3u) {
+          return std::optional<
+              std::pair<Eigen::Isometry3d, Eigen::Isometry3d>>();
+        }
+
+        Eigen::Isometry3d tfA = Eigen::Isometry3d::Identity();
+        Eigen::Isometry3d tfB = Eigen::Isometry3d::Identity();
+        if (idA == 5u || idB == 5u)
+          tfB.translation() = Eigen::Vector3d(0.2, 0.0, 0.0);
+
+        return std::optional<std::pair<Eigen::Isometry3d, Eigen::Isometry3d>>(
+            std::make_pair(tfA, tfB));
+      },
+      0.04);
+
+  EXPECT_EQ(2u, cache.size());
+  auto& kept = cache.getOrCreate(2u, 1u);
+  ASSERT_EQ(1, kept.numContacts);
+  EXPECT_EQ(1, kept.contacts[0].lifetime);
+
+  auto& unknown = cache.getOrCreate(4u, 3u);
+  ASSERT_EQ(1, unknown.numContacts);
+  EXPECT_EQ(0, unknown.contacts[0].lifetime);
+
+  cache.remove(1u, 2u);
+  EXPECT_EQ(1u, cache.size());
+  cache.remove(3u, 4u);
+  EXPECT_EQ(0u, cache.size());
+  cache.getOrCreate(7u, 8u);
+  EXPECT_EQ(1u, cache.size());
+  cache.clear();
+  EXPECT_EQ(0u, cache.size());
+}
+
+//==============================================================================
+TEST(PersistentManifoldCache, RemoveObjectDropsEveryPairContainingObject)
+{
+  PersistentManifoldCache cache;
+
+  CachedContact contact;
+  contact.localPointA = Eigen::Vector3d::Zero();
+  contact.localPointB = Eigen::Vector3d::Zero();
+
+  cache.getOrCreate(1u, 2u).addOrReplace(contact);
+  cache.getOrCreate(2u, 3u).addOrReplace(contact);
+  cache.getOrCreate(4u, 5u).addOrReplace(contact);
+
+  cache.removeObject(2u);
+
+  EXPECT_EQ(1u, cache.size());
+  auto& kept = cache.getOrCreate(5u, 4u);
+  EXPECT_EQ(1, kept.numContacts);
+  EXPECT_EQ(1u, cache.size());
+}

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -44,6 +44,7 @@
 #include <dart/collision/native/NativeCollisionDetector.hpp>
 #include <dart/collision/native/NativeCollisionGroup.hpp>
 #include <dart/collision/native/NativeCollisionObject.hpp>
+#include <dart/collision/native/PersistentManifoldCache.hpp>
 #include <dart/collision/native/detail/NativeShapeConversion.hpp>
 #include <dart/collision/native/shapes/Shape.hpp>
 
@@ -67,10 +68,13 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <set>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -104,6 +108,7 @@ public:
   ExposedNativeCollisionDetector() = default;
 
   using collision::CollisionDetector::claimCollisionObject;
+  using collision::NativeCollisionDetector::notifyCollisionObjectDestroying;
 
 private:
   std::unique_ptr<collision::CollisionObject> createCollisionObject(
@@ -1218,6 +1223,219 @@ TEST(NativeCollisionDetector, CollidesAcrossGroups)
   ASSERT_EQ(1u, result.getNumContacts());
   EXPECT_EQ(frame1.get(), result.getContact(0).getShapeFrame1());
   EXPECT_EQ(frame2.get(), result.getContact(0).getShapeFrame2());
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, PersistentManifoldReusesCachedSingleContact)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto frame1 = makeFrame(std::make_shared<dynamics::SphereShape>(1.0));
+  auto frame2 = makeFrame(
+      std::make_shared<dynamics::SphereShape>(1.0),
+      Eigen::Vector3d(1.5, 0.0, 0.0));
+  auto group = detector->createCollisionGroup(frame1.get(), frame2.get());
+
+  collision::CollisionOption option(true, 10u);
+  collision::CollisionResult first;
+  ASSERT_TRUE(group->collide(option, &first));
+  ASSERT_GT(first.getNumContacts(), 0u);
+
+  auto& firstContact = first.getContact(0);
+  ASSERT_NE(nullptr, firstContact.userData);
+  auto* cached = static_cast<native::CachedContact*>(firstContact.userData);
+  cached->cachedNormalImpulse = 1.5;
+  cached->cachedFrictionImpulse1 = -0.4;
+  cached->cachedFrictionImpulse2 = 0.2;
+  cached->cachedFrictionBasis1 = Eigen::Vector3d::UnitY();
+  cached->cachedFrictionBasis2 = Eigen::Vector3d::UnitZ();
+  cached->hasCachedFrictionBasis = true;
+
+  collision::CollisionResult second;
+  ASSERT_TRUE(group->collide(option, &second));
+  ASSERT_GT(second.getNumContacts(), 0u);
+  const auto& warm = second.getContact(0);
+  EXPECT_NE(nullptr, warm.userData);
+  auto* warmCached = static_cast<native::CachedContact*>(warm.userData);
+  EXPECT_NEAR(1.5, warmCached->cachedNormalImpulse, 1e-12);
+  EXPECT_NEAR(-0.4, warmCached->cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.2, warmCached->cachedFrictionImpulse2, 1e-12);
+  EXPECT_TRUE(warmCached->hasCachedFrictionBasis);
+  EXPECT_TRUE(
+      warmCached->cachedFrictionBasis1.isApprox(Eigen::Vector3d::UnitY()));
+  EXPECT_TRUE(
+      warmCached->cachedFrictionBasis2.isApprox(Eigen::Vector3d::UnitZ()));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, ManifoldCacheRegistryHandlesConcurrentDetectors)
+{
+  constexpr auto kThreadCount = 8u;
+  constexpr auto kIterations = 20u;
+
+  std::atomic<unsigned int> ready{0u};
+  std::atomic<bool> start{false};
+  std::atomic<bool> failed{false};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreadCount);
+
+  for (auto threadIndex = 0u; threadIndex < kThreadCount; ++threadIndex) {
+    threads.emplace_back([&] {
+      ready.fetch_add(1u, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire))
+        std::this_thread::yield();
+
+      for (auto iteration = 0u; iteration < kIterations; ++iteration) {
+        auto detector = collision::NativeCollisionDetector::create();
+        auto frame1 = makeFrame(std::make_shared<dynamics::SphereShape>(0.5));
+        auto frame2 = makeFrame(
+            std::make_shared<dynamics::SphereShape>(0.5),
+            Eigen::Vector3d(0.75, 0.0, 0.0));
+        auto group = detector->createCollisionGroup(frame1.get(), frame2.get());
+
+        collision::CollisionResult result;
+        if (!group->collide(collision::CollisionOption(true, 4u), &result)
+            || result.getNumContacts() == 0u) {
+          failed.store(true, std::memory_order_release);
+        }
+      }
+    });
+  }
+
+  while (ready.load(std::memory_order_acquire) != kThreadCount)
+    std::this_thread::yield();
+  start.store(true, std::memory_order_release);
+
+  for (auto& thread : threads)
+    thread.join();
+
+  EXPECT_FALSE(failed.load(std::memory_order_acquire));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, DestroyingObjectDropsPersistentManifoldCache)
+{
+  auto detector = std::make_shared<ExposedNativeCollisionDetector>();
+  auto frame1 = makeFrame(std::make_shared<dynamics::SphereShape>(0.5));
+  auto frame2 = makeFrame(
+      std::make_shared<dynamics::SphereShape>(0.5),
+      Eigen::Vector3d(0.8, 0.0, 0.0));
+
+  auto object1 = detector->claimCollisionObject(frame1.get());
+  auto object2 = detector->claimCollisionObject(frame2.get());
+  auto* nativeObject1
+      = dynamic_cast<collision::NativeCollisionObject*>(object1.get());
+  auto* nativeObject2
+      = dynamic_cast<collision::NativeCollisionObject*>(object2.get());
+  ASSERT_NE(nullptr, nativeObject1);
+  ASSERT_NE(nullptr, nativeObject2);
+
+  auto group = detector->createCollisionGroup(frame1.get(), frame2.get());
+  collision::CollisionOption option(true, 4u, nullptr);
+  collision::CollisionResult result;
+  ASSERT_TRUE(detector->collide(group.get(), option, &result));
+  ASSERT_GT(result.getNumContacts(), 0u);
+
+  void* userData = result.getContact(0).userData;
+  ASSERT_NE(nullptr, userData);
+  ASSERT_NE(
+      nullptr,
+      detector->getCachedContact(nativeObject1, nativeObject2, userData));
+
+  detector->notifyCollisionObjectDestroying(nativeObject1);
+
+  EXPECT_EQ(
+      nullptr,
+      detector->getCachedContact(nativeObject1, nativeObject2, userData));
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, PersistentManifoldClearsFrictionAcrossGroupOrder)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto groupA = detector->createCollisionGroup();
+  auto groupB = detector->createCollisionGroup();
+
+  auto frame1 = makeFrame(std::make_shared<dynamics::SphereShape>(1.0));
+  auto frame2 = makeFrame(
+      std::make_shared<dynamics::SphereShape>(1.0),
+      Eigen::Vector3d(1.5, 0.0, 0.0));
+  groupA->addShapeFrame(frame1.get());
+  groupB->addShapeFrame(frame2.get());
+
+  collision::CollisionOption option(true, 10u);
+  collision::CollisionResult first;
+  ASSERT_TRUE(detector->collide(groupB.get(), groupA.get(), option, &first));
+  ASSERT_GT(first.getNumContacts(), 0u);
+
+  auto& firstContact = first.getContact(0);
+  ASSERT_NE(nullptr, firstContact.userData);
+  auto* cached = static_cast<native::CachedContact*>(firstContact.userData);
+  cached->cachedNormalImpulse = 2.5;
+  cached->cachedFrictionImpulse1 = -0.6;
+  cached->cachedFrictionImpulse2 = 0.3;
+  cached->cachedFrictionBasis1 = Eigen::Vector3d::UnitY();
+  cached->cachedFrictionBasis2 = Eigen::Vector3d::UnitZ();
+  cached->hasCachedFrictionBasis = true;
+
+  collision::CollisionResult second;
+  ASSERT_TRUE(detector->collide(groupA.get(), groupB.get(), option, &second));
+  ASSERT_GT(second.getNumContacts(), 0u);
+  const auto& warm = second.getContact(0);
+  EXPECT_NE(nullptr, warm.userData);
+  EXPECT_LT(firstContact.normal.dot(warm.normal), -0.99);
+  auto* warmCached = static_cast<native::CachedContact*>(warm.userData);
+  EXPECT_NEAR(2.5, warmCached->cachedNormalImpulse, 1e-12);
+  EXPECT_NEAR(0.0, warmCached->cachedFrictionImpulse1, 1e-12);
+  EXPECT_NEAR(0.0, warmCached->cachedFrictionImpulse2, 1e-12);
+  EXPECT_FALSE(warmCached->hasCachedFrictionBasis);
+  EXPECT_TRUE(warmCached->cachedFrictionBasis1.isZero());
+  EXPECT_TRUE(warmCached->cachedFrictionBasis2.isZero());
+}
+
+//==============================================================================
+TEST(NativeCollisionDetector, PersistentManifoldReusesCachedMultipleContacts)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto frame1 = makeFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones()));
+  auto frame2 = makeFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones()),
+      Eigen::Vector3d(0.8, 0.0, 0.0));
+  auto group = detector->createCollisionGroup(frame1.get(), frame2.get());
+
+  collision::CollisionOption option(true, 10u);
+  option.maxNumContactsPerPair = 10u;
+
+  collision::CollisionResult first;
+  ASSERT_TRUE(group->collide(option, &first));
+  ASSERT_GT(first.getNumContacts(), 1u);
+
+  std::vector<double> expectedImpulses;
+  expectedImpulses.reserve(first.getNumContacts());
+  for (std::size_t i = 0u; i < first.getNumContacts(); ++i) {
+    auto& contact = first.getContact(i);
+    ASSERT_NE(nullptr, contact.userData);
+    auto* cached = static_cast<native::CachedContact*>(contact.userData);
+    cached->cachedNormalImpulse = static_cast<double>(i + 1u);
+    expectedImpulses.push_back(cached->cachedNormalImpulse);
+  }
+  std::sort(expectedImpulses.begin(), expectedImpulses.end());
+
+  collision::CollisionResult second;
+  ASSERT_TRUE(group->collide(option, &second));
+  ASSERT_EQ(first.getNumContacts(), second.getNumContacts());
+
+  std::vector<double> actualImpulses;
+  actualImpulses.reserve(second.getNumContacts());
+  for (std::size_t i = 0u; i < second.getNumContacts(); ++i) {
+    const auto& contact = second.getContact(i);
+    ASSERT_NE(nullptr, contact.userData);
+    auto* cached = static_cast<native::CachedContact*>(contact.userData);
+    actualImpulses.push_back(cached->cachedNormalImpulse);
+  }
+  std::sort(actualImpulses.begin(), actualImpulses.end());
+
+  EXPECT_EQ(expectedImpulses, actualImpulses);
 }
 
 //==============================================================================


### PR DESCRIPTION
## Summary

- Add an opt-in native persistent manifold cache for `NativeCollisionDetector`.
- Carry cached native contact impulses through the existing `Contact::userData` payload, gated to contacts produced and owned by the native detector cache.
- Preserve the public `dart::collision::Contact` layout/ABI and the installed `NativeCollisionDetector` class layout on the release branch.
- Seed `ConstraintInfo::x` for solvers that honor initial guesses and write solved impulses back to the native cache. The default Dantzig path still recomputes `x` from scratch.
- Keep uncached, FCL, foreign/custom `userData`, changed-basis friction, and position-phase split-impulse friction rows initialized safely before any native-cache seeding.

## Motivation

This is phase 3 D5 of the DART 6.20 native collision port. DART 6.20 still keeps FCL as the default detector; this PR only improves the opt-in `"native"` detector and keeps gz-physics / gz-sim compatibility intact.

## Key Changes

- Adds `dart/collision/native/PersistentManifoldCache.{hpp,cpp}` using DART 6 PascalCase file naming.
- Tracks native contact manifolds by collision-object pair and reduces refreshed contacts deterministically.
- Stores per-detector manifold caches out of line in the implementation file, so no data member is added to the public `NativeCollisionDetector` layout.
- Preserves detector-wide manifolds that are outside the currently queried collision group instead of erasing another group's warm-start state.
- Drops all cached manifold pairs touching a native collision object when the detector receives the existing `notifyCollisionObjectDestroying` hook, preventing stale pointer-keyed cache entries after object lifetime ends.
- Attaches cached impulse storage to native-produced contacts through the existing `Contact::userData` pointer.
- Leaves native `Contact::userData` unset when manifold reduction drops the newly observed point instead of aliasing another cached slot.
- Validates `Contact::userData` through native detector/cache ownership before casting or writing cached impulses.
- Gates `ContactConstraint` cache reads/writes to contacts whose collision objects and payload are owned by the same native detector cache, so foreign/custom `userData` payloads are ignored.
- Stores the solved tangent/friction basis with cached friction impulses and seeds tangential rows only when the current `ContactSurfaceParams` produces the same basis.
- Seeds solver initial guesses for PGS/other `ConstraintInfo::x` consumers and stores solved impulses back in the native cached contact record.
- Clears cached friction impulses when a refreshed matched contact changes or flips its normal/friction basis, while preserving the cached normal impulse.
- Leaves cached friction impulses at zero during position-phase split-impulse solves while still preserving the velocity-phase friction cache.
- Adds focused unit and integration coverage for cache behavior, detector cache propagation, solver write-back, changed friction-basis clearing, foreign `userData` protection, native-object foreign `userData` protection, uncached-contact zero initialization, dropped inserted contacts after manifold reduction, unknown-pair refresh preservation, object-destruction cache cleanup, group-order friction-basis clearing, and position-phase friction seeding.

## Performance Evidence

Compared this branch (`01b6457208c`) against parent `origin/release-6.20` (`1a33843125dd`) with the same contact-rich benchmark rows. The final comparison used direct benchmark binary runs to avoid wrapper rebuild noise. The benchmark emitted the usual CPU-scaling warning and workstation load was non-trivial, so these are treated as PR comparison evidence rather than a hard throughput claim. Parent load was `[6.93, 8.42, 6.69]`; current load was `[3.85, 3.04, 3.78]`.

Current branch command:

```bash
build/default/cpp/Release/bin/BM_INTEGRATION_contact_container --benchmark_filter='BM_ContactContainerActive/60/0/(1|16)$' --benchmark_min_time=0.20s --benchmark_repetitions=5 --benchmark_report_aggregates_only=true --benchmark_out=.benchmark_results/native-manifold-cache/current-direct-friction-basis-metadata.json --benchmark_out_format=json
```

Parent command, from a detached temp worktree at `1a33843125dd`:

```bash
build/default/cpp/Release/bin/BM_INTEGRATION_contact_container --benchmark_filter='BM_ContactContainerActive/60/0/(1|16)$' --benchmark_min_time=0.20s --benchmark_repetitions=5 --benchmark_report_aggregates_only=true --benchmark_out=/home/js/dev/dartsim/dart/task_1/.benchmark_results/native-manifold-cache/parent-direct-friction-basis-gate.json --benchmark_out_format=json
```

| Row | Parent CPU mean | Current CPU mean | Mean change | Parent CPU median | Current CPU median | Median change | Current CPU CV | Counters |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `BM_ContactContainerActive/60/0/1` | 182.8 ms | 179.4 ms | -1.85% | 182.8 ms | 179.8 ms | -1.63% | 3.58% | contacts 81/81, mobile 60/60, resting 0/0 |
| `BM_ContactContainerActive/60/0/16` | 198.0 ms | 184.5 ms | -6.82% | 196.5 ms | 184.9 ms | -5.87% | 3.94% | contacts 81/81, mobile 60/60, resting 0/0 |

## Local Verification

- `git diff --check`
- `rg -n "cachedNormalImpulse|cachedFrictionImpulse" dart/collision/Contact.hpp dart/collision/Contact.cpp` returned no matches.
- `rg -n "entt|std::span" dart/collision/native/PersistentManifoldCache.hpp dart/collision/native/PersistentManifoldCache.cpp dart/collision/native/NativeCollisionDetector.cpp dart/collision/native/NativeCollisionDetector.hpp tests/unit/collision/native/test_persistent_manifold_cache.cpp tests/unit/collision/test_NativeCollisionDetector.cpp tests/integration/test_ConstraintSolver.cpp dart/constraint/ContactConstraint.cpp` returned no matches.
- `pixi run clang-format-14 -i dart/collision/native/PersistentManifoldCache.hpp dart/collision/native/PersistentManifoldCache.cpp dart/constraint/ContactConstraint.cpp tests/unit/collision/native/test_persistent_manifold_cache.cpp tests/unit/collision/test_NativeCollisionDetector.cpp tests/integration/test_ConstraintSolver.cpp`
- `pixi run cmake --build build/default/cpp/Release --target test_ConstraintSolver UNIT_collision_native_persistent_manifold_cache UNIT_collision_native_detector_adapter --parallel 8`
- `ctest --test-dir build/default/cpp/Release -R '^(UNIT_collision_native_persistent_manifold_cache|UNIT_collision_native_detector_adapter|test_ConstraintSolver)$' --output-on-failure` (3/3)
- `pixi run cmake --build build/default/cpp/Debug --target test_ConstraintSolver UNIT_collision_native_persistent_manifold_cache UNIT_collision_native_detector_adapter --parallel 8`
- `ctest --test-dir build/default/cpp/Debug -R '^(UNIT_collision_native_persistent_manifold_cache|UNIT_collision_native_detector_adapter|test_ConstraintSolver)$' --output-on-failure` (3/3)
- `pixi run check-lint`
- `pixi run test` (151/151)
- `DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run -e gazebo test-gz`
  - gz-physics: 199/199 tests passed.
  - gz-physics performance checks: 4/4 passed.
  - Source-built DART plugin link check passed.
  - gz-sim: `INTEGRATION_entity_system` 1/1 passed against the source-built DART plugin.
- Benchmark commands listed above.
- Pre-commit hook `pixi run check-lint-quick` passed during the final amend.

## Compatibility

- FCL remains the default detector.
- The native detector remains opt-in through the existing `"native"` factory key.
- No new dependency, no EnTT, and no C++20 `std::span` usage in this slice.
- Public `dart::collision::Contact` layout is preserved.
- Public `NativeCollisionDetector` object layout is preserved; detector-owned cache storage lives out of line, and the destruction cleanup overrides an existing base-class virtual hook without adding a data member.
- Foreign/custom `Contact::userData` payloads are ignored unless the same native detector cache owns the payload address for that contact pair.
- Native contacts whose inserted point is dropped during manifold reduction do not get a stale or aliased cached-impulse payload.
- Cached friction impulses are reused only when the matched contact keeps a compatible normal and the current constraint keeps the same stored tangent basis; flipped normals or changed custom friction directions reset tangential warm-start state.
- Cached impulse seeding is scoped to solvers that honor `ConstraintInfo::x`; default Dantzig behavior is not overclaimed.
- Position-phase split-impulse solves keep tangential cached friction rows zero without destroying the velocity-phase friction cache.
