### PR TITLE
Expose native contact benchmark rows

### DIFF
--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 D1-D4 (#3352, #3355, #3358, #3359) merged; phase 3 D5 active on `feature/native-manifold-cache` |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 (#3352, #3355, #3358, #3359, #3360) merged; phase 4 active on `feature/native-phase4-performance` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -104,6 +104,8 @@
   voxel boxes and compound collision/distance/raycast routing (merged
   2026-07-09).
 - **#3359** phase-3 D4 native CCD engine support (merged 2026-07-09).
+- **#3360** phase-3 D5 native persistent manifold cache, contact reduction,
+  and cached-impulse seed/write-back (merged 2026-07-09).
 - **#3283** main-branch dual for the native sphere-sphere binary-check fix
   (merged 2026-07-07).
 
@@ -120,14 +122,15 @@
 
 ### 🔄 Open — monitoring (checked 2026-07-09)
 
-- **Phase 3 D5** `feature/native-manifold-cache` — active local slice for
-  persistent manifold cache/reuse, native detector cached-impulse reuse, and
-  solver cached-impulse write-back. Keep it one PR to reduce CI overhead.
+- **Phase 4** `feature/native-phase4-performance` — active local slice for
+  native contact-rich benchmark surfacing and measured native hot-path
+  optimization. Keep it cohesive to reduce CI overhead, and require
+  parent-vs-PR plus detector-vs-detector performance tables in the PR report.
 - **#3353** is merged on `release-6.20` for the separate
   performance-generalization plan parking lane.
 - The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
-  #3324, #3325, #3357, #3358, and #3359 are merged. The perf lane's WP-PG.01
-  baseline packet **#3263** also merged.
+  #3324, #3325, #3357, #3358, #3359, and #3360 are merged. The perf lane's
+  WP-PG.01 baseline packet **#3263** also merged.
 
 Related remote heads still visible: `feature/native-occupancy-grid`,
 `task/native-collision-performance-exec`, and six `perf/dart6-*` round-1
@@ -159,8 +162,9 @@ before treating it as an open/active PR.)_
   coverage, distance helpers, mixed-scene parity, and associated parity/
   performance tests. **Phase 3 D1-D4 are merged (#3352/#3355/#3358/#3359):**
   native detector distance, raycast, VoxelGrid/compound wiring, and CCD support
-  against the incumbent support gaps. **Current slice is phase 3 D5:**
-  persistent manifold cache/reuse.
+  against the incumbent support gaps. **Phase 3 D5 is merged (#3360):**
+  persistent manifold cache/reuse and cached-impulse seed/write-back.
+  **Current slice is phase 4:** measured native performance optimization.
 - **Default flip:** still late-phase only. Do not flip defaults until `03`'s full
   A/B packet and gz gate pass.
 - _Hold each follow-up to `03`'s bar: gz-compat (`pixi run -e gazebo test-gz`),
@@ -172,7 +176,7 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `1a33843125dde544c1a1c4caa11fae71af35b6e5`; `origin/main` =
+     `5ee4095fd52d0346b8bc634c5b349050649c2137`; `origin/main` =
      `a70fc2ed5cb7ea40f72dce68b7d374583ab7feee`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
@@ -189,7 +193,7 @@ before treating it as an open/active PR.)_
    failures are infra flakes that clear on re-run.
 4. **Native-collision lane: stay inside the active phase.** The #3056
    performance stack is useful evidence, but the DART 7 native default flip is
-   still a later phase. Phase 3 capability parity is active; do not treat
+   still a later phase. Phase 4 measured performance work is active; do not treat
    `feature/native-occupancy-grid` or `task/native-collision-performance-exec`
    as release-branch PRs unless a live PR exists and is based on
    `release-6.20`.
@@ -212,11 +216,11 @@ before treating it as an open/active PR.)_
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
 - **Open queue (2026-07-09):** no open native-collision release PRs remain after
-  #3359. Phase 3 D5 is active locally on `feature/native-manifold-cache`; the former
+  #3360. Phase 4 is active locally on `feature/native-phase4-performance`; the former
   #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319, plus
-  #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355/#3358/#3359 lane milestones,
-  main-branch dual #3283, workflow rename #3357, and MSVC policy #3348 are
-  merged.
+  #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355/#3358/#3359/#3360 lane
+  milestones, main-branch dual #3283, workflow rename #3357, and MSVC policy
+  #3348 are merged.
 - **Largest remaining win:** native-collision port → makes FCL/Bullet/ODE
   optional and eventually drops `fcl` from core. The DART 7 native engine is
   only partially ported to DART 6.20; default-flip is still a late-phase

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -26,8 +26,8 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 | 0 | Baseline evidence packet (incumbent A/B envelope + default-flip verdict) | ✅ merged (#3271) |
 | 1 | Native math core (Aabb/Gjk/Mpr/BoxBox/SphereSphere/shapes/Span shim) internal-only | ✅ merged (#3281) |
 | 2 | DART 6 detector adapter over the native core (bridge, sliced P1–P9 + P10 coverage) | ✅ complete (#3350) |
-| 3 | Capability parity (distance→FCL, raycast→Bullet, CCD, manifolds, voxel) | 🔄 **in progress** — see §4 |
-| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | ⬜ not started |
+| 3 | Capability parity (distance→FCL, raycast→Bullet, CCD, manifolds, voxel) | ✅ complete (#3360) |
+| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — see §4 |
 | 5 | Bullet/ODE/FCL facade decision (must keep gz subclassing) | ⬜ not started |
 | 6 | Default flip in both `ConstraintSolver` ctors (point of no return) | ⬜ not started |
 | 7 | FCL decoupling from core (the dependency win) + retire this task folder | ⬜ not started |
@@ -66,11 +66,13 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 - **#3359** phase-3 **D4**: native CCD engine support for rigid sphere/capsule
   casts, primitive point-triangle/edge-edge CCD, shape+transform dispatcher
   entry points, and compound-target earliest-hit selection.
+- **#3360** phase-3 **D5**: native persistent manifold cache, contact reduction,
+  cache refresh/removal, and native cached-impulse seed/write-back plumbing.
 
-`origin/release-6.20` tip at this refresh: `1a33843125d` (moves as the
+`origin/release-6.20` tip at this refresh: `5ee4095fd52` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
-## 4. Phase 2 complete; Phase 3 D5 manifold cache active
+## 4. Phases 2 and 3 complete; Phase 4 performance active
 
 Bridge design (see `07` §0–§1): **bypass DART 7's EnTT `CollisionWorld`**; the
 adapter (`NativeCollisionDetector/Group/Object` + `NativeShapeConversion`)
@@ -94,37 +96,37 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **D2** | DART 6 `NativeCollisionDetector::raycast()` adapter + native-vs-Bullet raycast benchmarks | ✅ **merged (#3355)** |
 | **D3** | `VoxelGridShape`/octree replacement via native compound boxes + compound collision/distance/raycast recursion | ✅ **merged (#3358)** |
 | **D4** | Native CCD engine: rigid sphere/capsule casts, primitive point-triangle/edge-edge CCD, and shape+transform dispatcher support | ✅ **merged (#3359)** |
-| **D5** | Persistent manifold cache and manifold reuse/reduction follow-up | 🔄 **active local branch** `feature/native-manifold-cache` |
+| **D5** | Persistent manifold cache, manifold reduction/reuse, and solver cached-impulse seed/write-back | ✅ **merged (#3360)** |
 
-### Exact next step: finish Phase 3 D5 persistent manifold cache
+### Exact next step: execute Phase 4 measured optimization
 
-1. Continue with the **Phase 3 D5** branch `feature/native-manifold-cache`,
-   based on `origin/release-6.20` at or after `1a33843125d`.
-2. Keep it as one PR: port DART 7's persistent manifold cache with DART 6
-   PascalCase file names, wire native detector cached-impulse reuse, and seed/
-   write back cached impulses through `ContactConstraint` for solvers that
-   honor `ConstraintInfo::x` initial guesses.
-3. Cover cache matching/reduction/refresh, native detector cached-impulse reuse
-   for same-group and cross-group contacts, and solver cached-impulse
-   write-back.
+1. Continue with the **Phase 4** branch `feature/native-phase4-performance`,
+   based on `origin/release-6.20` at or after `5ee4095fd52`.
+2. Keep the next PR cohesive: expose `"native"` in the durable contact-rich
+   benchmark surfaces, then optimize only measured native hot paths whose
+   before/after data justifies the code change.
+3. Candidate optimization areas are the `03` Phase 4 list: data layout,
+   scratch caches, broadphase pair pruning, manifold reuse, scene-local
+   allocation control, optional SIMD from #3229, and thread-safe contact
+   aggregation. Do not mix in phase-5 facade decisions or phase-6 defaults.
 4. Keep FCL as the default detector; do not touch `World`,
    `ConstraintSolver` detector defaults, `WorldConfig`, or dependency/package
    metadata in this slice.
-5. Gates for **every** native-collision capability PR:
+5. Gates for **every** native-collision performance PR:
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
    UNIT_collision_native --output-on-failure` (`pixi run test-all` only *builds*);
    full `pixi run check-lint`; contact-rich benchmark comparison evidence;
    `DART_PARALLEL_JOBS=8 pixi run -e gazebo test-gz` (199 + 4 + 1); portability
-   `rg 'entt|std::span'` on new files → empty. The D5 scope necessarily also
-   touches `dart/constraint/ContactConstraint.cpp` for native cached-impulse
-   seed/write-back; keep any further scope expansion out. Preserve the public
-   `dart::collision::Contact` layout on this release branch.
+   `rg 'entt|std::span'` on new files → empty. Each performance PR must report
+   parent-vs-PR and native-vs-incumbent rows in the style of #3307. Preserve the
+   public `dart::collision::Contact` layout on this release branch.
 
 ## 5. Open PRs / loose ends
 
-- **Phase 3 D5 persistent manifold cache** — active on
-  `feature/native-manifold-cache` as one PR-sized slice to minimize CI overhead.
+- **Phase 4 native performance** — active on
+  `feature/native-phase4-performance` as a cohesive benchmark/optimization
+  slice to minimize CI overhead.
 - **#3353** is merged on `release-6.20` for the separate
   performance-generalization plan parking lane.
 - **#3357** is merged; it renamed the DART 6 autonomous AI workflow to

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -72,21 +72,22 @@ scope-diff-guarded.
   benchmarks): **#3355** — **merged**.
 - **D3** (native VoxelGrid/compound support): **#3358** — **merged**.
 - **D4** (native CCD support): **#3359** — **merged**.
+- **D5** (native persistent manifold cache + cached-impulse seed/write-back):
+  **#3360** — **merged**.
 
-**Next: Phase 3 D5 — persistent manifold cache** on
-`feature/native-manifold-cache`. Keep this as one PR: port DART 7's persistent
-manifold cache using DART 6 PascalCase file names, wire native detector
-cached-impulse reuse, and seed/write back cached impulses through
-`ContactConstraint` for solvers that honor `ConstraintInfo::x` initial guesses.
-Cover cache matching/reduction/refresh, native detector cached-impulse reuse
-for same-group and cross-group contacts, and solver cached-impulse write-back.
-Keep the native detector opt-in only. **Do not** add
-a `CollisionDetectorType::Native` enum or touch `World` detector defaults,
-`ConstraintSolver` detector defaults, `WorldConfig`, or dependency/package
-metadata; FCL remains the default until phase 6.
+**Next: Phase 4 — evidence-driven native performance optimization** on
+`feature/native-phase4-performance`. Keep this cohesive: first expose
+`"native"` in the durable contact-rich benchmark surfaces, then optimize only
+measured native hot paths with parent-vs-PR and detector-vs-detector evidence in
+the style of #3307. Candidate areas are broadphase pair pruning, scratch/cache
+reuse, manifold reuse, scene-local allocation control, optional SIMD from
+#3229, and thread-safe contact aggregation. Keep the native detector opt-in
+only. **Do not** add a `CollisionDetectorType::Native` enum or touch `World`
+detector defaults, `ConstraintSolver` detector defaults, `WorldConfig`, or
+dependency/package metadata; FCL remains the default until phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
-PRs, worktrees, gotchas, and exact Phase 3 D5 next steps).
+PRs, worktrees, gotchas, and exact Phase 4 next steps).
 
 ## Standing constraints
 

--- a/examples/contact_benchmark/main.cpp
+++ b/examples/contact_benchmark/main.cpp
@@ -50,6 +50,7 @@
 #include <dart/collision/bullet/BulletCollisionDetector.hpp>
 #include <dart/collision/dart/DARTCollisionDetector.hpp>
 #include <dart/collision/fcl/FCLCollisionDetector.hpp>
+#include <dart/collision/native/NativeCollisionDetector.hpp>
 #include <dart/collision/ode/OdeCollisionDetector.hpp>
 
 #include <dart/dynamics/BoxShape.hpp>
@@ -122,6 +123,7 @@ enum class CollisionEngine
 {
   Default,
   Dart,
+  Native,
   Fcl,
   Bullet,
   Ode,
@@ -303,7 +305,7 @@ void printUsage(const std::string& programName)
       << "  --gui                     Open an OSG viewer instead of "
          "benchmarking.\n"
       << "  --profile                 Dump DART text profiler summary.\n"
-      << "  --collision default|dart|fcl|bullet|ode\n"
+      << "  --collision default|dart|native|fcl|bullet|ode\n"
       << "  --lcp-solver default|dantzig|pgs\n"
       << "                            Set the boxed-LCP primary solver for "
          "measurement.\n"
@@ -450,6 +452,8 @@ CollisionEngine parseCollisionEngine(const std::string& value)
     return CollisionEngine::Default;
   if (value == "dart")
     return CollisionEngine::Dart;
+  if (value == "native")
+    return CollisionEngine::Native;
   if (value == "fcl")
     return CollisionEngine::Fcl;
   if (value == "bullet")
@@ -467,6 +471,8 @@ const char* collisionEngineName(CollisionEngine engine)
       return "default";
     case CollisionEngine::Dart:
       return "dart";
+    case CollisionEngine::Native:
+      return "native";
     case CollisionEngine::Fcl:
       return "fcl";
     case CollisionEngine::Bullet:
@@ -748,6 +754,8 @@ dart::collision::CollisionDetectorPtr makeCollisionDetector(
 
   if (engine == CollisionEngine::Dart)
     return dart::collision::DARTCollisionDetector::create();
+  if (engine == CollisionEngine::Native)
+    return dart::collision::NativeCollisionDetector::create();
   if (engine == CollisionEngine::Bullet)
     return dart::collision::BulletCollisionDetector::create();
   if (engine == CollisionEngine::Fcl) {
@@ -1927,12 +1935,14 @@ int collisionEngineToIndex(CollisionEngine engine)
       return 0;
     case CollisionEngine::Dart:
       return 1;
-    case CollisionEngine::Fcl:
+    case CollisionEngine::Native:
       return 2;
-    case CollisionEngine::Bullet:
+    case CollisionEngine::Fcl:
       return 3;
-    case CollisionEngine::Ode:
+    case CollisionEngine::Bullet:
       return 4;
+    case CollisionEngine::Ode:
+      return 5;
   }
 
   return 0;
@@ -1944,10 +1954,12 @@ CollisionEngine collisionEngineFromIndex(int index)
     case 1:
       return CollisionEngine::Dart;
     case 2:
-      return CollisionEngine::Fcl;
+      return CollisionEngine::Native;
     case 3:
-      return CollisionEngine::Bullet;
+      return CollisionEngine::Fcl;
     case 4:
+      return CollisionEngine::Bullet;
+    case 5:
       return CollisionEngine::Ode;
     default:
       return CollisionEngine::Default;
@@ -1956,7 +1968,7 @@ CollisionEngine collisionEngineFromIndex(int index)
 
 bool collisionEngineAllowsPrimitiveShapes(int index)
 {
-  return index == 0 || index == 2;
+  return index == 0 || index == 3;
 }
 
 class ContactBenchmarkGuiEventHandler final : public ::osgGA::GUIEventHandler
@@ -2321,8 +2333,8 @@ private:
         ImGui::SliderFloat("Drop height", &mDropHeight, 0.0f, 4.0f, "%.2f m"));
 
     static const char* kCollisionItems[]
-        = {"default", "dart", "fcl", "bullet", "ode"};
-    if (ImGui::Combo("Collision", &mCollisionIndex, kCollisionItems, 5)) {
+        = {"default", "dart", "native", "fcl", "bullet", "ode"};
+    if (ImGui::Combo("Collision", &mCollisionIndex, kCollisionItems, 6)) {
       if (!collisionEngineAllowsPrimitiveShapes(mCollisionIndex))
         mPrimitiveShapes = false;
       noteEdit(true);

--- a/scripts/run_performance_dashboard_benchmarks.py
+++ b/scripts/run_performance_dashboard_benchmarks.py
@@ -56,8 +56,8 @@ BENCHMARK_SPECS = [
         surface="contact-container",
         target="BM_INTEGRATION_contact_container",
         benchmark_filter=(
-            "BM_ContactContainerActive/(60|120)/(0|1|2|3)/(1|4|16)$|"
-            "BM_ContactContainerDeactivation/60/(0|1)/16/iterations:1$"
+            "BM_ContactContainerActive/(60|120)/(0|1|2|3|4)/(1|4|16)$|"
+            "BM_ContactContainerDeactivation/60/(0|1|4)/16/iterations:1$"
         ),
         output_name="dashboard_contact_container.json",
     ),

--- a/tests/benchmark/integration/bm_contact_container.cpp
+++ b/tests/benchmark/integration/bm_contact_container.cpp
@@ -37,6 +37,7 @@
 #endif
 #include <dart/collision/dart/DARTCollisionDetector.hpp>
 #include <dart/collision/fcl/FCLCollisionDetector.hpp>
+#include <dart/collision/native/NativeCollisionDetector.hpp>
 #include <dart/collision/ode/OdeCollisionDetector.hpp>
 
 #include <benchmark/benchmark.h>
@@ -49,6 +50,7 @@ enum Engine
   ODE = 1,
   FCL = 2,
   BULLET = 3,
+  NATIVE = 4,
 };
 
 dart::collision::CollisionDetectorPtr makeDetector(int engine)
@@ -58,6 +60,8 @@ dart::collision::CollisionDetectorPtr makeDetector(int engine)
       return dart::collision::OdeCollisionDetector::create();
     case FCL:
       return dart::collision::FCLCollisionDetector::create();
+    case NATIVE:
+      return dart::collision::NativeCollisionDetector::create();
 #ifdef DART_CONTACT_CONTAINER_BENCHMARK_HAS_BULLET
     case BULLET:
       return dart::collision::BulletCollisionDetector::create();
@@ -75,6 +79,8 @@ const char* engineName(int engine)
       return "ode";
     case FCL:
       return "fcl";
+    case NATIVE:
+      return "native";
     case BULLET:
       return "bullet";
     case DART:
@@ -175,10 +181,14 @@ void BM_ContactContainerDeactivation(benchmark::State& state)
 BENCHMARK(BM_ContactContainerActive)
     ->Args({60, DART, 1})
     ->Args({60, DART, 16})
+    ->Args({60, NATIVE, 1})
+    ->Args({60, NATIVE, 16})
     ->Args({60, ODE, 1})
     ->Args({60, ODE, 16})
     ->Args({120, DART, 1})
     ->Args({120, DART, 16})
+    ->Args({120, NATIVE, 1})
+    ->Args({120, NATIVE, 16})
     ->Args({120, ODE, 1})
     ->Args({120, ODE, 16})
     ->Args({60, FCL, 1})
@@ -192,6 +202,7 @@ BENCHMARK(BM_ContactContainerActive)
     ->Args({120, BULLET, 16})
 #endif
     ->Args({120, DART, 4})
+    ->Args({120, NATIVE, 4})
     ->Args({120, ODE, 4})
     ->Args({120, FCL, 4})
 #ifdef DART_CONTACT_CONTAINER_BENCHMARK_HAS_BULLET
@@ -201,12 +212,14 @@ BENCHMARK(BM_ContactContainerActive)
 
 BENCHMARK(BM_ContactContainerLargeActive)
     ->Args({900, DART, 16})
+    ->Args({900, NATIVE, 16})
     ->Args({900, ODE, 16})
     ->Iterations(1)
     ->Unit(benchmark::kMillisecond);
 
 BENCHMARK(BM_ContactContainerDeactivation)
     ->Args({60, DART, 16})
+    ->Args({60, NATIVE, 16})
     ->Args({60, ODE, 16})
     ->Iterations(1)
     ->Unit(benchmark::kMillisecond);

--- a/tests/test_performance_dashboard_benchmarks.py
+++ b/tests/test_performance_dashboard_benchmarks.py
@@ -1,0 +1,48 @@
+"""Tests for the DART 6 performance dashboard benchmark runner."""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "scripts" / "run_performance_dashboard_benchmarks.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "run_performance_dashboard_benchmarks", RUNNER
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _contact_container_filter() -> re.Pattern[str]:
+    runner = _load_runner()
+    specs = [
+        spec for spec in runner.BENCHMARK_SPECS if spec.surface == "contact-container"
+    ]
+    assert len(specs) == 1
+    return re.compile(specs[0].benchmark_filter)
+
+
+def test_contact_container_dashboard_filter_selects_native_rows():
+    pattern = _contact_container_filter()
+
+    assert pattern.fullmatch("BM_ContactContainerActive/60/4/1")
+    assert pattern.fullmatch("BM_ContactContainerActive/60/4/16")
+    assert pattern.fullmatch("BM_ContactContainerActive/120/4/4")
+    assert pattern.fullmatch("BM_ContactContainerDeactivation/60/4/16/iterations:1")
+
+
+def test_contact_container_dashboard_filter_keeps_incumbent_rows():
+    pattern = _contact_container_filter()
+
+    assert pattern.fullmatch("BM_ContactContainerActive/60/0/1")
+    assert pattern.fullmatch("BM_ContactContainerActive/60/1/16")
+    assert pattern.fullmatch("BM_ContactContainerActive/120/2/4")
+    assert pattern.fullmatch("BM_ContactContainerActive/120/3/16")
+    assert pattern.fullmatch("BM_ContactContainerDeactivation/60/0/16/iterations:1")


### PR DESCRIPTION
## Summary

- Add `native` as a selectable collision backend in `contact_benchmark`, including the CLI and generated-scene GUI selector.
- Add native rows to `BM_INTEGRATION_contact_container` and the DART 6 performance-dashboard contact-container filter so Phase 4 can report native-vs-incumbent contact-rich performance with the same generated scene and contact caps.
- Refresh the dependency-minimization handoff docs now that #3360 completed Phase 3 D5 and Phase 4 is active.

## Motivation / Problem

Phase 4 optimization needs the same level of performance evidence used by prior performance PRs, but the contact-rich benchmark surfaces only exposed DART/FCL/Bullet/ODE. Native was available through the detector factory but could not be selected in the durable contact-container benchmark rows or dashboard runner, which made native-vs-incumbent reporting ad hoc.

## Changes / Key Changes

- `examples/contact_benchmark`: supports `--collision native`, reports the native selector in summaries, and exposes native in the GUI collision combo.
- `BM_INTEGRATION_contact_container`: adds native engine rows for 60/120 active scenes, 120/4-thread rows, the 900-object large row, and the deactivation row.
- `scripts/run_performance_dashboard_benchmarks.py`: includes native engine `4` in the contact-container dashboard slice, covered by a focused pytest.
- Task docs now mark #3360 as merged, update the release tip to `5ee4095fd52`, and set `feature/native-phase4-performance` as the Phase 4 branch.

## Before / After

| Area | Before | After |
| --- | --- | --- |
| Contact benchmark CLI | `--collision default|dart|fcl|bullet|ode` | `--collision default|dart|native|fcl|bullet|ode` |
| Contact-container benchmarks | Native detector absent from incumbent rows | Native appears as engine `4` with `engine=native` labels |
| Performance dashboard slice | Contact-container filter selected only incumbent engine IDs | Contact-container filter also selects native active/deactivation rows |
| Phase handoff docs | Still pointed at active D5 manifold-cache work | Phase 3 complete via #3360; Phase 4 measured optimization active |

## Performance Evidence

Release build, local workstation, CPU scaling warning present; use these as bounded Phase 4 baseline rows, not final tuned results.

60 objects, 1 thread, 200 steps:

| Engine | Time | Contacts | sim_s/s |
| --- | ---: | ---: | ---: |
| dart | 180 ms | 81 | 1.11179/s |
| native | 205 ms | 84 | 0.977448/s |
| ode | 613 ms | 205 | 0.326489/s |
| fcl | 178 ms | 81 | 1.1234/s |
| bullet | 195 ms | 90 | 1.02644/s |

120 objects, 4 threads, 200 steps:

| Engine | Time | Contacts | sim_s/s |
| --- | ---: | ---: | ---: |
| dart | 1465 ms | 242 | 0.136526/s |
| native | 2199 ms | 282 | 0.090959/s |
| ode | 3092 ms | 443 | 0.0646987/s |
| fcl | 1506 ms | 243 | 0.13281/s |
| bullet | 1560 ms | 256 | 0.128212/s |

Profile smoke for the native 120-object row shows the gap is dominated by boxed-LCP solve pressure from native's higher contact count, not broadphase dispatch. That points the next Phase 4 optimization toward manifold/contact reduction rather than default changes.

## Testing

- `pixi run cmake --build build/default/cpp/Release --target contact_benchmark BM_INTEGRATION_contact_container --parallel 8`
- `build/default/cpp/Release/bin/contact_benchmark --generate-container 60 --steps 50 --warmup 0 --checkpoint 0 --quiet --collision native --world-threads 1 --max-contacts 20000 --max-contacts-per-pair 4`
  - Final state finite: true
  - Final contact cap hit: false
  - Final state hash: `0x92556ab565d0be8d`
- `build/default/cpp/Release/bin/BM_INTEGRATION_contact_container --benchmark_filter='BM_ContactContainerActive/60/(0|1|2|3|4)/1$' --benchmark_min_time=0.01s --benchmark_repetitions=1`
- `build/default/cpp/Release/bin/BM_INTEGRATION_contact_container --benchmark_filter='BM_ContactContainerActive/120/(0|1|2|3|4)/4$' --benchmark_min_time=0.01s --benchmark_repetitions=1`
- `build/default/cpp/Release/bin/contact_benchmark --generate-container 120 --steps 200 --warmup 0 --checkpoint 0 --quiet --collision native --world-threads 4 --max-contacts 20000 --max-contacts-per-pair 4 --profile`
- `ctest --test-dir build/default/cpp/Release -R '^UNIT_collision_native' --output-on-failure`
- `.pixi/envs/default/bin/python -m pytest tests/test_performance_dashboard_benchmarks.py`
- `.pixi/envs/default/bin/python scripts/run_performance_dashboard_benchmarks.py --surface contact-container --dry-run`
- `pixi run check-lint`
- `pixi run lint`
- `git diff --check`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follows #3360.
- Uses the contact-rich benchmark lane from #3209 and supports Phase 4 reporting in the style requested for performance PRs.

---

#### Checklist

- [x] Milestone set (`DART 6.20.0`)
- [x] CHANGELOG.md updated if required (N/A: benchmark/dev-task evidence surface, no public API or dependency change)
- [x] Add unit tests for new functionality (focused dashboard-filter pytest plus CLI/benchmark smoke)
- [x] Document new methods and classes (N/A: no new public class/method)
- [x] Add Python bindings (dartpy) if applicable (N/A)
