### PR TITLE
Fix native dashboard Python test expectations

### DIFF
--- a/python/tests/unit/test_run_performance_dashboard_benchmarks.py
+++ b/python/tests/unit/test_run_performance_dashboard_benchmarks.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -50,9 +51,12 @@ def test_dashboard_surface_runner_dry_run_lists_bounded_specs(tmp_path):
     assert "dashboard_boxes.json" in result.stdout
     assert "BM_RunBoxes/(2|4|8)$" in result.stdout
     assert "dashboard_contact_container.json" in result.stdout
-    assert "BM_ContactContainerActive/(60|120)/(0|1|2|3)/(1|4|16)$" in result.stdout
     assert (
-        "BM_ContactContainerDeactivation/60/(0|1)/16/iterations:1$"
+        "BM_ContactContainerActive/(60|120)/(0|1|2|3|4)/(1|4|16)$"
+        in result.stdout
+    )
+    assert (
+        "BM_ContactContainerDeactivation/60/(0|1|4)/16/iterations:1$"
         in result.stdout
     )
     assert "dashboard_soft_body.json" in result.stdout
@@ -95,6 +99,35 @@ def test_contact_container_surface_is_required():
 
     assert spec.target == "BM_INTEGRATION_contact_container"
     assert not spec.optional
+
+
+def test_contact_container_surface_filter_selects_native_rows():
+    runner = _load_runner_module()
+    spec = next(
+        spec for spec in runner.BENCHMARK_SPECS if spec.surface == "contact-container"
+    )
+
+    pattern = re.compile(spec.benchmark_filter)
+
+    assert pattern.fullmatch("BM_ContactContainerActive/60/4/1")
+    assert pattern.fullmatch("BM_ContactContainerActive/60/4/16")
+    assert pattern.fullmatch("BM_ContactContainerActive/120/4/4")
+    assert pattern.fullmatch("BM_ContactContainerDeactivation/60/4/16/iterations:1")
+
+
+def test_contact_container_surface_filter_keeps_incumbent_rows():
+    runner = _load_runner_module()
+    spec = next(
+        spec for spec in runner.BENCHMARK_SPECS if spec.surface == "contact-container"
+    )
+
+    pattern = re.compile(spec.benchmark_filter)
+
+    assert pattern.fullmatch("BM_ContactContainerActive/60/0/1")
+    assert pattern.fullmatch("BM_ContactContainerActive/60/1/16")
+    assert pattern.fullmatch("BM_ContactContainerActive/120/2/4")
+    assert pattern.fullmatch("BM_ContactContainerActive/120/3/16")
+    assert pattern.fullmatch("BM_ContactContainerDeactivation/60/0/16/iterations:1")
 
 
 def test_dashboard_surface_runner_fails_when_output_has_no_rows(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Update the Python dashboard-runner test expectations for the native contact-container benchmark rows that landed in #3362.
- Keep the merged standalone native-filter test intact and add equivalent coverage to the Python test suite that runs in CI.

## Motivation / Problem

#3362 expanded the DART 6 performance-dashboard contact-container filter to include native engine `4`, but an existing Python unit test still asserted the old `0|1|2|3` filter. Hosted `CI macOS / arm64-Release` then failed in `python/tests/unit/test_run_performance_dashboard_benchmarks.py::test_dashboard_surface_runner_dry_run_lists_bounded_specs` even though the C++ tests in that job passed.

## Changes / Key Changes

- Update the stale dry-run assertions to expect `0|1|2|3|4` for active rows and `0|1|4` for deactivation rows.
- Add regex-level assertions that the contact-container dashboard filter selects native rows and keeps incumbent rows.

## Testing

- `.pixi/envs/default/bin/python -m pytest python/tests/unit/test_run_performance_dashboard_benchmarks.py tests/test_performance_dashboard_benchmarks.py` (11 passed)
- `.pixi/envs/default/bin/python scripts/run_performance_dashboard_benchmarks.py --surface contact-container --dry-run`
- `git diff --check`
- `pixi run lint`
- Pre-commit `pixi run check-lint-quick`

## Breaking Changes

- [x] None
- Test-only CI expectation fix.

## Related Issues / PRs (backports)

- Follows #3362.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, DART 6.16.x for `release-6.16`)
- [x] CHANGELOG.md updated if required: N/A, test-only CI fix
- [x] Add unit tests for new functionality
- [x] Document new methods and classes: N/A, no API/docs change
- [x] Add Python bindings (dartpy) if applicable: N/A, no binding change
