### PR TITLE
Optimize native solver-facing manifolds

### DIFF
--- a/dart/collision/native/NativeCollisionDetector.cpp
+++ b/dart/collision/native/NativeCollisionDetector.cpp
@@ -59,6 +59,11 @@ namespace collision {
 namespace {
 
 //==============================================================================
+// Three non-collinear contacts define a stable planar patch while avoiding a
+// fourth redundant solver row on contact-rich native scenes.
+constexpr std::size_t kSolverFacingManifoldContactTarget = 3u;
+
+//==============================================================================
 bool checkGroupValidity(
     const NativeCollisionDetector* detector, CollisionGroup* group)
 {
@@ -85,9 +90,13 @@ native::CollisionOption makeNativeOption(
 {
   native::CollisionOption nativeOption;
   nativeOption.enableContact = option.enableContact && result != nullptr;
-  nativeOption.maxNumContacts = nativeOption.enableContact
-                                    ? option.getEffectiveMaxNumContactsPerPair()
-                                    : 1u;
+  if (nativeOption.enableContact) {
+    nativeOption.maxNumContacts = std::min(
+        option.getEffectiveMaxNumContactsPerPair(),
+        kSolverFacingManifoldContactTarget);
+  } else {
+    nativeOption.maxNumContacts = 1u;
+  }
   nativeOption.collisionFilter = nullptr;
 
   return nativeOption;

--- a/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/04-orchestration-dashboard.md
@@ -20,7 +20,7 @@
 | --- | --- | --- |
 | **Dependency-reduction lane** (this one) | Optimizer removal; default-env analysis; **now orchestration/monitoring** | Own removals **complete**; running this board |
 | **Native-replacement lane** | `dart/external/*` → native built-ins; **GUI/OSG + GLUT removal** | External replacements + **GLUT/lodepng removal done** (#3116 merged) |
-| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 (#3352, #3355, #3358, #3359, #3360) merged; phase 4 active on `feature/native-phase4-performance` |
+| **Native-collision-port lane** | Port DART 7 `dart/collision/native/` → DART 6.20 (make FCL/Bullet/ODE optional) | Phase 0 (#3271), phase 1 (#3281), phase 2 (#3303, #3306, #3318, #3319, #3321, #3322, #3324, #3325, #3343, #3350), and phase 3 (#3352, #3355, #3358, #3359, #3360) merged; phase 4 active on `feature/native-phase4-solver-manifolds` |
 | **Perf / parallelism lane** (issue #3056) | Island deactivation, parallel-safe solves, benchmarks | Round 1 landed through #3199/#3203 (guardrails); **round 2 active in `docs/dev_tasks/dart6_performance_generalization/`** — WP-PG.01 baseline packet **#3263 merged** (tracks the native-collision port as its WS-F lane, external owner) |
 
 ## PR tracker
@@ -122,10 +122,11 @@
 
 ### 🔄 Open — monitoring (checked 2026-07-09)
 
-- **Phase 4** `feature/native-phase4-performance` — active local slice for
-  native contact-rich benchmark surfacing and measured native hot-path
-  optimization. Keep it cohesive to reduce CI overhead, and require
-  parent-vs-PR plus detector-vs-detector performance tables in the PR report.
+- **Phase 4** `feature/native-phase4-solver-manifolds` — active local slice for
+  solver-facing native manifold contact reduction. Local dashboard evidence on
+  the 120-object contact-container row improves native from 2268.942 ms to
+  1118.032 ms while reducing contacts from 282 to 251; the PR report must carry
+  the full parent-vs-PR and detector-vs-detector tables.
 - **#3353** is merged on `release-6.20` for the separate
   performance-generalization plan parking lane.
 - The earlier monitoring queue has landed: #3283, #3317, #3319, #3321, #3322,
@@ -176,7 +177,7 @@ before treating it as an open/active PR.)_
 
 1. **Base / conflict status**:
    - Current planning baseline: `origin/release-6.20` =
-     `5ee4095fd52d0346b8bc634c5b349050649c2137`; `origin/main` =
+     `43e4196389863f7405cd81f4ab501b45f02ae479`; `origin/main` =
      `a70fc2ed5cb7ea40f72dce68b7d374583ab7feee`.
    - Open PRs routinely fall behind as the base advances; a maintainer merge-up
      clears it. Exact behind-counts aren't tracked here (too volatile).
@@ -216,7 +217,8 @@ before treating it as an open/active PR.)_
   native-collision **#3123** (primitive plane contacts + broadphase pruning) — first
   piece of the native collision port.
 - **Open queue (2026-07-09):** no open native-collision release PRs remain after
-  #3360. Phase 4 is active locally on `feature/native-phase4-performance`; the former
+  #3360. Phase 4 is active locally on
+  `feature/native-phase4-solver-manifolds`; the former
   #3263/#3271/#3281/#3302/#3303/#3306/#3318/#3319, plus
   #3321/#3322/#3324/#3325/#3343/#3350/#3352/#3355/#3358/#3359/#3360 lane
   milestones, main-branch dual #3283, workflow rename #3357, and MSVC policy

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -27,7 +27,7 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 | 1 | Native math core (Aabb/Gjk/Mpr/BoxBox/SphereSphere/shapes/Span shim) internal-only | ✅ merged (#3281) |
 | 2 | DART 6 detector adapter over the native core (bridge, sliced P1–P9 + P10 coverage) | ✅ complete (#3350) |
 | 3 | Capability parity (distance→FCL, raycast→Bullet, CCD, manifolds, voxel) | ✅ complete (#3360) |
-| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — see §4 |
+| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — solver-facing manifold slice ready; see §4 |
 | 5 | Bullet/ODE/FCL facade decision (must keep gz subclassing) | ⬜ not started |
 | 6 | Default flip in both `ConstraintSolver` ctors (point of no return) | ⬜ not started |
 | 7 | FCL decoupling from core (the dependency win) + retire this task folder | ⬜ not started |
@@ -69,7 +69,7 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 - **#3360** phase-3 **D5**: native persistent manifold cache, contact reduction,
   cache refresh/removal, and native cached-impulse seed/write-back plumbing.
 
-`origin/release-6.20` tip at this refresh: `5ee4095fd52` (moves as the
+`origin/release-6.20` tip at this refresh: `43e419638986` (moves as the
 maintainer merges; **always re-fetch before branching/capturing**).
 
 ## 4. Phases 2 and 3 complete; Phase 4 performance active
@@ -98,21 +98,42 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 | **D4** | Native CCD engine: rigid sphere/capsule casts, primitive point-triangle/edge-edge CCD, and shape+transform dispatcher support | ✅ **merged (#3359)** |
 | **D5** | Persistent manifold cache, manifold reduction/reuse, and solver cached-impulse seed/write-back | ✅ **merged (#3360)** |
 
-### Exact next step: execute Phase 4 measured optimization
+### Exact next step: publish Phase 4 solver-facing manifold optimization
 
-1. Continue with the **Phase 4** branch `feature/native-phase4-performance`,
-   based on `origin/release-6.20` at or after `5ee4095fd52`.
-2. Keep the next PR cohesive: expose `"native"` in the durable contact-rich
-   benchmark surfaces, then optimize only measured native hot paths whose
-   before/after data justifies the code change.
-3. Candidate optimization areas are the `03` Phase 4 list: data layout,
+1. Continue with the **Phase 4** branch
+   `feature/native-phase4-solver-manifolds`, based on `origin/release-6.20`
+   `43e419638986`.
+2. The implemented slice caps solver-facing native manifolds at three contacts
+   while honoring stricter user per-pair caps. It is intentionally scoped to the
+   opt-in `"native"` detector and leaves defaults/package metadata untouched.
+3. Parent-vs-slice benchmark evidence:
+
+   | Benchmark row | Parent native | Slice native | Delta | Contacts |
+   | --- | ---: | ---: | ---: | ---: |
+   | `BM_ContactContainerActive/60/4/1_mean` | 202.383 ms | 202.918 ms | -0.3% | 84 -> 80 |
+   | `BM_ContactContainerActive/60/4/16_mean` | 204.547 ms | 203.067 ms | +0.7% | 84 -> 80 |
+   | `BM_ContactContainerActive/120/4/1_mean` | 2268.942 ms | 1118.032 ms | +50.7% | 282 -> 251 |
+   | `BM_ContactContainerActive/120/4/16_mean` | 2202.924 ms | 1124.906 ms | +48.9% | 282 -> 251 |
+   | `BM_ContactContainerActive/120/4/4_mean` | 2193.106 ms | 1167.577 ms | +46.8% | 282 -> 251 |
+   | `BM_ContactContainerDeactivation/60/4/16/iterations:1_mean` | 30.589 ms | 29.391 ms | +3.9% | 101 -> 97 |
+
+4. Post-slice detector comparison on `BM_ContactContainerActive/120/*/1_mean`:
+   native 1118.032 ms / 251 contacts, DART 1452.013 ms / 242 contacts, FCL
+   1475.995 ms / 243 contacts, Bullet 1544.000 ms / 256 contacts.
+5. Local gates already captured for this slice:
+   `pixi run check-lint`, `pixi run build`, Release
+   `ctest -R 'UNIT_collision_native|test_ConstraintSolver$'`, Debug
+   `UNIT_collision_native_detector_adapter`, `rg 'entt|std::span'
+   dart/collision/native tests/unit/collision/test_NativeCollisionDetector.cpp`,
+   and `DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run -e gazebo test-gz`.
+6. Candidate follow-up optimization areas are the `03` Phase 4 list: data layout,
    scratch caches, broadphase pair pruning, manifold reuse, scene-local
    allocation control, optional SIMD from #3229, and thread-safe contact
    aggregation. Do not mix in phase-5 facade decisions or phase-6 defaults.
-4. Keep FCL as the default detector; do not touch `World`,
+7. Keep FCL as the default detector; do not touch `World`,
    `ConstraintSolver` detector defaults, `WorldConfig`, or dependency/package
    metadata in this slice.
-5. Gates for **every** native-collision performance PR:
+8. Gates for **every** native-collision performance PR:
    Release build + **explicit Debug build** (`pixi run build` is Release-only);
    **run** the tests with `ctest --test-dir build/default/cpp/Release -R
    UNIT_collision_native --output-on-failure` (`pixi run test-all` only *builds*);
@@ -125,8 +146,8 @@ reuses DART 6's existing `shared_ptr`-based `CollisionObjectManager`, driving
 ## 5. Open PRs / loose ends
 
 - **Phase 4 native performance** — active on
-  `feature/native-phase4-performance` as a cohesive benchmark/optimization
-  slice to minimize CI overhead.
+  `feature/native-phase4-solver-manifolds` as a cohesive
+  benchmark/optimization slice to minimize CI overhead.
 - **#3353** is merged on `release-6.20` for the separate
   performance-generalization plan parking lane.
 - **#3357** is merged; it renamed the DART 6 autonomous AI workflow to

--- a/docs/dev_tasks/dart6_dependency_minimization/README.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/README.md
@@ -20,12 +20,13 @@ Evidence was first collected on 2026-06-19 after fetching `origin/main`,
 `origin/release-6.20`, and `origin/release-6.19`. The native-collision port
 evidence in `03-native-collision-port-scoping.md` and the dashboard state in
 `04-orchestration-dashboard.md` were refreshed on 2026-07-09 after fetching
-`origin/main` and `origin/release-6.20`, and after phase-3 D4 merged.
+`origin/main` and `origin/release-6.20`, and after phase-3 D5 plus the native
+dashboard fix (#3363) merged.
 
 ## Current Branch State
 
 - `origin/release-6.20` currently points at
-  `1a33843125dde544c1a1c4caa11fae71af35b6e5`.
+  `43e4196389863f7405cd81f4ab501b45f02ae479`.
 - `origin/main` currently points at
   `a70fc2ed5cb7ea40f72dce68b7d374583ab7feee`.
 - `package.xml` and `pixi.toml` on `origin/release-6.20` still report a 6.19.x

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -75,16 +75,35 @@ scope-diff-guarded.
 - **D5** (native persistent manifold cache + cached-impulse seed/write-back):
   **#3360** — **merged**.
 
-**Next: Phase 4 — evidence-driven native performance optimization** on
-`feature/native-phase4-performance`. Keep this cohesive: first expose
-`"native"` in the durable contact-rich benchmark surfaces, then optimize only
-measured native hot paths with parent-vs-PR and detector-vs-detector evidence in
-the style of #3307. Candidate areas are broadphase pair pruning, scratch/cache
-reuse, manifold reuse, scene-local allocation control, optional SIMD from
-#3229, and thread-safe contact aggregation. Keep the native detector opt-in
-only. **Do not** add a `CollisionDetectorType::Native` enum or touch `World`
-detector defaults, `ConstraintSolver` detector defaults, `WorldConfig`, or
-dependency/package metadata; FCL remains the default until phase 6.
+**Next: Phase 4 — evidence-driven native performance optimization.** The first
+performance slice is on `feature/native-phase4-solver-manifolds`: cap
+solver-facing native manifolds at three contacts while honoring stricter
+per-pair caps. This targets the measured solver row overhead from native's
+fourth contact on contact-rich scenes and keeps the native detector opt-in.
+
+Measured on `origin/release-6.20` parent `43e419638986` vs this local slice:
+
+| Benchmark row | Parent native | Slice native | Delta | Contacts |
+| --- | ---: | ---: | ---: | ---: |
+| `BM_ContactContainerActive/60/4/1_mean` | 202.383 ms | 202.918 ms | -0.3% | 84 -> 80 |
+| `BM_ContactContainerActive/60/4/16_mean` | 204.547 ms | 203.067 ms | +0.7% | 84 -> 80 |
+| `BM_ContactContainerActive/120/4/1_mean` | 2268.942 ms | 1118.032 ms | +50.7% | 282 -> 251 |
+| `BM_ContactContainerActive/120/4/16_mean` | 2202.924 ms | 1124.906 ms | +48.9% | 282 -> 251 |
+| `BM_ContactContainerActive/120/4/4_mean` | 2193.106 ms | 1167.577 ms | +46.8% | 282 -> 251 |
+| `BM_ContactContainerDeactivation/60/4/16/iterations:1_mean` | 30.589 ms | 29.391 ms | +3.9% | 101 -> 97 |
+
+Post-slice detector comparison on `BM_ContactContainerActive/120/*/1_mean`:
+native 1118.032 ms / 251 contacts, DART 1452.013 ms / 242 contacts, FCL
+1475.995 ms / 243 contacts, Bullet 1544.000 ms / 256 contacts.
+
+Remaining Phase 4 work after this PR merges: continue with measured native hot
+paths only, using parent-vs-PR and detector-vs-detector evidence in the style of
+#3307. Candidate areas are broadphase pair pruning, scratch/cache reuse,
+manifold reuse, scene-local allocation control, optional SIMD from #3229, and
+thread-safe contact aggregation. **Do not** add a
+`CollisionDetectorType::Native` enum or touch `World` detector defaults,
+`ConstraintSolver` detector defaults, `WorldConfig`, or dependency/package
+metadata; FCL remains the default until phase 6.
 
 See [HANDOFF.md](HANDOFF.md) for the full session handoff (merged/open
 PRs, worktrees, gotchas, and exact Phase 4 next steps).

--- a/tests/unit/collision/test_NativeCollisionDetector.cpp
+++ b/tests/unit/collision/test_NativeCollisionDetector.cpp
@@ -585,6 +585,32 @@ TEST(NativeCollisionDetector, RespectsGlobalContactLimit)
 }
 
 //==============================================================================
+TEST(NativeCollisionDetector, CapsSolverFacingManifoldContacts)
+{
+  auto detector = collision::NativeCollisionDetector::create();
+  auto frame1 = makeFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones()));
+  auto frame2 = makeFrame(
+      std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones()),
+      Eigen::Vector3d(0.8, 0.0, 0.0));
+  auto group = detector->createCollisionGroup(frame1.get(), frame2.get());
+
+  collision::CollisionOption wideOption(true, 10u);
+  wideOption.maxNumContactsPerPair = 10u;
+
+  collision::CollisionResult wideResult;
+  ASSERT_TRUE(group->collide(wideOption, &wideResult));
+  EXPECT_EQ(3u, wideResult.getNumContacts());
+
+  collision::CollisionOption strictOption(true, 10u);
+  strictOption.maxNumContactsPerPair = 2u;
+
+  collision::CollisionResult strictResult;
+  ASSERT_TRUE(group->collide(strictOption, &strictResult));
+  EXPECT_EQ(2u, strictResult.getNumContacts());
+}
+
+//==============================================================================
 TEST(NativeCollisionDetector, RespectsCollisionFilter)
 {
   auto detector = collision::NativeCollisionDetector::create();


### PR DESCRIPTION
## Summary

- Cap opt-in native detector solver-facing manifolds at three contacts while still honoring stricter user `maxNumContactsPerPair` limits.
- Add native detector coverage for wide per-pair caps and stricter per-pair caps.
- Refresh the DART 6.20 dependency-minimization handoff/dashboard notes with the Phase 4 benchmark evidence.

This keeps FCL as the default detector and does not touch `World`, `ConstraintSolver` defaults, `WorldConfig`, dependency metadata, or package metadata.

## Performance Evidence

Parent: `43e419638986` (`origin/release-6.20` after #3363)
Slice: `74e972dccdd`

Command:

```bash
.pixi/envs/default/bin/python scripts/run_performance_dashboard_benchmarks.py \
  --surface contact-container \
  --output-dir .benchmark_results/native_phase4_pruned \
  --benchmark-min-time=1ms \
  --benchmark-repetitions=3
```

Parent comparison used the same command with `--output-dir .benchmark_results/native_phase4_base` before the change.

| Benchmark row | Parent native | PR native | Delta | Contacts |
| --- | ---: | ---: | ---: | ---: |
| `BM_ContactContainerActive/60/4/1_mean` | 202.383 ms | 202.918 ms | -0.3% | 84 -> 80 |
| `BM_ContactContainerActive/60/4/16_mean` | 204.547 ms | 203.067 ms | +0.7% | 84 -> 80 |
| `BM_ContactContainerActive/120/4/1_mean` | 2268.942 ms | 1118.032 ms | +50.7% | 282 -> 251 |
| `BM_ContactContainerActive/120/4/16_mean` | 2202.924 ms | 1124.906 ms | +48.9% | 282 -> 251 |
| `BM_ContactContainerActive/120/4/4_mean` | 2193.106 ms | 1167.577 ms | +46.8% | 282 -> 251 |
| `BM_ContactContainerDeactivation/60/4/16/iterations:1_mean` | 30.589 ms | 29.391 ms | +3.9% | 101 -> 97 |

Post-PR detector comparison on `BM_ContactContainerActive/120/*/1_mean`:

| Detector | Mean time | Contacts | Native delta |
| --- | ---: | ---: | ---: |
| native | 1118.032 ms | 251 | baseline |
| dart | 1452.013 ms | 242 | native 23.0% faster |
| fcl | 1475.995 ms | 243 | native 24.3% faster |
| bullet | 1544.000 ms | 256 | native 27.6% faster |

Profile check on `contact_benchmark --generate-container 120 --steps 200 --warmup 0 --checkpoint 0 --quiet --collision native --world-threads 1 --max-contacts 20000 --max-contacts-per-pair 4 --profile`:

| Metric | Parent native | PR native |
| --- | ---: | ---: |
| Average step | 11.1892 ms | 5.615 ms |
| Final contacts | 282 | 251 |
| Mean constraints | 300.6 | 269.8 |
| Mean LCP rows | 901.8 | 809.4 |
| `primarySolve` | 1.705 s | 659.71 ms |

## Testing

- `cmake --build build/default/cpp/Release --target UNIT_collision_native_detector_adapter -j$(python3 scripts/parallel_jobs.py)`
- `ctest --test-dir build/default/cpp/Release -R 'UNIT_collision_native_detector_adapter$' --output-on-failure`
- `ctest --test-dir build/default/cpp/Release -R 'UNIT_collision_native|test_ConstraintSolver$' --output-on-failure`
- `pixi run check-lint`
- `pixi run build`
- `cmake --build build/default/cpp/Debug --target UNIT_collision_native_detector_adapter -j$(python3 scripts/parallel_jobs.py)`
- `ctest --test-dir build/default/cpp/Debug -R 'UNIT_collision_native_detector_adapter$' --output-on-failure`
- `rg -n 'entt|std::span' dart/collision/native tests/unit/collision/test_NativeCollisionDetector.cpp` (no matches)
- `DART_PARALLEL_JOBS=8 CTEST_PARALLEL_LEVEL=8 pixi run -e gazebo test-gz`

Gazebo gate result: gz-physics 199/199 tests passed, 4/4 performance/symbol tests passed, and gz-sim `INTEGRATION_entity_system` passed against the source-built DART plugin. Display-dependent gz-sim tests were skipped by the existing gate because this runner has no valid DRI display.
