### PR TITLE
Fix dartpy DegreeOfFreedom ownership in getDofs bindings

### DIFF
--- a/python/dartpy/dynamics/BodyNode.cpp
+++ b/python/dartpy/dynamics/BodyNode.cpp
@@ -971,7 +971,8 @@ void BodyNode(py::module& m)
           +[](const dart::dynamics::BodyNode* self)
               -> const std::vector<const dart::dynamics::DegreeOfFreedom*> {
             return self->getChainDofs();
-          })
+          },
+          ::py::return_value_policy::reference_internal)
       .def(
           "addExtForce",
           +[](dart::dynamics::BodyNode* self, const Eigen::Vector3d& _force) {

--- a/python/dartpy/dynamics/JacobianNode.cpp
+++ b/python/dartpy/dynamics/JacobianNode.cpp
@@ -100,7 +100,8 @@ void JacobianNode(py::module& m)
           +[](const dart::dynamics::JacobianNode* self)
               -> const std::vector<const dart::dynamics::DegreeOfFreedom*> {
             return self->getChainDofs();
-          })
+          },
+          ::py::return_value_policy::reference_internal)
       .def(
           "getJacobian",
           +[](const dart::dynamics::JacobianNode* self,

--- a/python/dartpy/dynamics/ReferentialSkeleton.cpp
+++ b/python/dartpy/dynamics/ReferentialSkeleton.cpp
@@ -195,7 +195,8 @@ void ReferentialSkeleton(py::module& m)
           +[](const dart::dynamics::ReferentialSkeleton* self)
               -> std::vector<const dart::dynamics::DegreeOfFreedom*> {
             return self->getDofs();
-          })
+          },
+          ::py::return_value_policy::reference_internal)
       .def(
           "getIndexOf",
           +[](const dart::dynamics::ReferentialSkeleton* self,

--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -530,7 +530,8 @@ void Skeleton(py::module& m)
           +[](const dart::dynamics::Skeleton* self)
               -> std::vector<const dart::dynamics::DegreeOfFreedom*> {
             return self->getDofs();
-          })
+          },
+          ::py::return_value_policy::reference_internal)
       .def(
           "getIndexOf",
           +[](const dart::dynamics::Skeleton* self,

--- a/python/tests/unit/dynamics/test_degree_of_freedom_ownership.py
+++ b/python/tests/unit/dynamics/test_degree_of_freedom_ownership.py
@@ -1,0 +1,65 @@
+import gc
+import subprocess
+import sys
+import textwrap
+
+import dartpy as dart
+
+
+def test_getdofs_does_not_take_ownership():
+    # Regression: Skeleton.getDofs (and the getChainDofs variants) used to be
+    # bound without a return-value policy, so pybind11 took ownership of the
+    # joint-owned DegreeOfFreedom pointers and deleted them with the Python
+    # wrappers, corrupting the heap.
+    world = dart.utils.MjcfParser.readWorld("dart://sample/mjcf/openai/reacher.xml")
+    assert world is not None
+
+    skel = world.getSkeleton(0)
+    num_dofs = skel.getNumDofs()
+    names_before = [skel.getDof(i).getName() for i in range(num_dofs)]
+
+    dofs = skel.getDofs()
+    assert len(dofs) == num_dofs
+    del dofs
+    gc.collect()
+
+    assert skel.getNumDofs() == num_dofs
+    assert [skel.getDof(i).getName() for i in range(num_dofs)] == names_before
+
+    for _ in range(10):
+        world.step()
+    assert all(abs(v) < 1e6 for v in skel.getPositions())
+
+
+def test_getdofs_survives_simulation_and_interpreter_exit():
+    # The heap corruption typically surfaced as a SIGSEGV when the objects
+    # were finally destroyed, so run the full reproducer in a subprocess and
+    # require a clean exit code.
+    script = textwrap.dedent(
+        """
+        import dartpy as dart
+
+        world = dart.utils.MjcfParser.readWorld(
+            "dart://sample/mjcf/openai/reacher.xml")
+        dofs = {}
+        for i in range(world.getNumSkeletons()):
+            for dof in world.getSkeleton(i).getDofs():
+                dofs[dof.getName()] = dof
+        for _ in range(2000):
+            for dof in dofs.values():
+                dof.setForce(0.1)
+            world.step()
+        print("done")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        f"subprocess exited with {result.returncode}\n"
+        f"stdout: {result.stdout[-2000:]}\nstderr: {result.stderr[-2000:]}"
+    )
+    assert "done" in result.stdout


### PR DESCRIPTION
## Summary

- `Skeleton.getDofs`, `ReferentialSkeleton.getDofs`, `BodyNode.getChainDofs`, and `JacobianNode.getChainDofs` were bound without a return-value policy. pybind11's default policy takes ownership of returned raw pointers, so the Python wrappers deleted the joint-owned `DegreeOfFreedom` objects when collected, corrupting the heap. The typical symptom is a SIGSEGV at interpreter exit (or any later teardown) after contact-rich simulations that touched `getDofs()`.
- Fix: `::py::return_value_policy::reference_internal` on all four bindings, matching the existing (correct) `MetaSkeleton.getDofs` binding in the same tree.
- Adds regression coverage: an in-process test that collects the `getDofs()` wrappers and asserts the skeleton's DOFs survive, plus a subprocess reproducer (2000-step torque-driven `mjcf/openai/reacher.xml` run) that must exit cleanly. The subprocess test reproduced the crash deterministically (`rc=139`) before the fix and passes after.

## Reproduction

```python
import dartpy as dart
world = dart.utils.MjcfParser.readWorld('dart://sample/mjcf/openai/reacher.xml')
dofs = [d for i in range(world.getNumSkeletons()) for d in world.getSkeleton(i).getDofs()]
for _ in range(2000):
    world.step()
# segfaults during teardown before this fix
```

## Dual-PR note

`main` is not affected: its nanobind `meta_skeleton.cpp` binding already uses `nb::rv_policy::reference_internal` (python/dartpy/dynamics/meta_skeleton.cpp:98).

## Validation

- `pixi run build-py-dev` and `python -m pytest python/tests/unit/dynamics/test_degree_of_freedom_ownership.py` → 2 passed (fails with SIGSEGV subprocess exit before the fix).
- `pixi run lint` + `pixi run check-lint` clean.