### PR TITLE
Add AABB-tree broadphase to the native collision detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,11 @@
 
 * Collision
 
+  * Speed up many-object DART-native collision queries by replacing the
+    quadratic brute-force broadphase with a dynamic AABB tree, while preserving
+    deterministic result ordering and streaming boolean-query early exits:
+    [#3368](https://github.com/dartsim/dart/pull/3368)
+
   * Speed up the DART-native collision backend by caching collision-object
     shape metadata and local bounds, refreshing the cache only when the
     associated `ShapeFrame` geometry version changes:

--- a/dart/collision/native/CMakeLists.txt
+++ b/dart/collision/native/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/shapes/Shape.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sdf/SignedDistanceField.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/BroadPhase.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/AabbTree.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/BruteForce.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Gjk.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/Gjk-impl.hpp
@@ -102,6 +103,7 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/PrimitiveCcd.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereBox.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/narrow_phase/SphereSphere.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/AabbTree.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/broad_phase/BruteForce.cpp
 )
 

--- a/dart/collision/native/NativeCollisionDetector.cpp
+++ b/dart/collision/native/NativeCollisionDetector.cpp
@@ -799,12 +799,23 @@ bool NativeCollisionDetector::collide(
   bool collisionFound = false;
   {
     DART_PROFILE_SCOPED_N("Native::visitPairs+narrowphase");
-    nativeGroup->mBroadPhase->visitPairs([&](std::size_t id1, std::size_t id2) {
+    const auto pairVisitor = [&](std::size_t id1, std::size_t id2) {
       auto* object1 = nativeGroup->mIdToObject.at(id1);
       auto* object2 = nativeGroup->mIdToObject.at(id2);
       return !processNativePair(
           object1, object2, option, result, collisionFound);
-    });
+    };
+    if (result) {
+      // Result-carrying queries need the sorted, deduplicated visitation
+      // order: which contacts survive a maxNumContacts cap is part of the
+      // observable behavior, and the ordered walk reproduces BruteForce
+      // bit-for-bit.
+      nativeGroup->mBroadPhase->visitPairs(pairVisitor);
+    } else {
+      // Boolean existence queries return no per-pair data, so traversal
+      // order cannot leak; stream the tree walk and stop at the first hit.
+      nativeGroup->mBroadPhase->visitPairsAnyOrder(pairVisitor);
+    }
   }
 
   if (option.enableContact) {

--- a/dart/collision/native/NativeCollisionDetector.cpp
+++ b/dart/collision/native/NativeCollisionDetector.cpp
@@ -41,6 +41,7 @@
 #include "dart/collision/native/PersistentManifoldCache.hpp"
 #include "dart/collision/native/narrow_phase/NarrowPhase.hpp"
 #include "dart/common/Console.hpp"
+#include "dart/common/Profile.hpp"
 
 #include <algorithm>
 #include <array>
@@ -785,19 +786,31 @@ bool NativeCollisionDetector::collide(
     return false;
 
   auto* nativeGroup = static_cast<NativeCollisionGroup*>(group);
-  nativeGroup->updateEngineData();
+  {
+    DART_PROFILE_SCOPED_N("Native::updateEngineData");
+    nativeGroup->updateEngineData();
+  }
   auto& manifoldCache = getOrCreateManifoldCache(this);
-  refreshManifoldCache(nativeGroup->mCollisionObjects, &manifoldCache);
+  {
+    DART_PROFILE_SCOPED_N("Native::refreshManifoldCache");
+    refreshManifoldCache(nativeGroup->mCollisionObjects, &manifoldCache);
+  }
 
   bool collisionFound = false;
-  nativeGroup->mBroadPhase->visitPairs([&](std::size_t id1, std::size_t id2) {
-    auto* object1 = nativeGroup->mIdToObject.at(id1);
-    auto* object2 = nativeGroup->mIdToObject.at(id2);
-    return !processNativePair(object1, object2, option, result, collisionFound);
-  });
+  {
+    DART_PROFILE_SCOPED_N("Native::visitPairs+narrowphase");
+    nativeGroup->mBroadPhase->visitPairs([&](std::size_t id1, std::size_t id2) {
+      auto* object1 = nativeGroup->mIdToObject.at(id1);
+      auto* object2 = nativeGroup->mIdToObject.at(id2);
+      return !processNativePair(
+          object1, object2, option, result, collisionFound);
+    });
+  }
 
-  if (option.enableContact)
+  if (option.enableContact) {
+    DART_PROFILE_SCOPED_N("Native::attachCachedImpulses");
     attachCachedContactImpulses(result, &manifoldCache);
+  }
 
   return collisionFound;
 }

--- a/dart/collision/native/NativeCollisionGroup.cpp
+++ b/dart/collision/native/NativeCollisionGroup.cpp
@@ -43,7 +43,7 @@ namespace collision {
 NativeCollisionGroup::NativeCollisionGroup(
     const CollisionDetectorPtr& collisionDetector)
   : CollisionGroup(collisionDetector),
-    mBroadPhase(std::make_unique<native::BruteForceBroadPhase>())
+    mBroadPhase(std::make_unique<native::AabbTreeBroadPhase>())
 {
   // Do nothing
 }

--- a/dart/collision/native/NativeCollisionGroup.cpp
+++ b/dart/collision/native/NativeCollisionGroup.cpp
@@ -110,11 +110,11 @@ void NativeCollisionGroup::removeAllCollisionObjectsFromEngine()
 //==============================================================================
 void NativeCollisionGroup::updateCollisionGroupEngineData()
 {
-  for (auto* object : mCollisionObjects) {
-    auto* nativeObject = static_cast<NativeCollisionObject*>(object);
-    const auto search = mObjectToId.find(object);
-    if (search != mObjectToId.end())
-      mBroadPhase->update(search->second, nativeObject->getNativeAabb());
+  // Iterate the id map directly instead of hashing every object through
+  // mObjectToId each step; broadphase update order cannot leak into results
+  // because pair queries are normalized and sorted before visitation.
+  for (const auto& entry : mIdToObject) {
+    mBroadPhase->update(entry.first, entry.second->getNativeAabb());
   }
 }
 

--- a/dart/collision/native/NativeCollisionGroup.hpp
+++ b/dart/collision/native/NativeCollisionGroup.hpp
@@ -80,7 +80,9 @@ protected:
 private:
   std::size_t assignId(NativeCollisionObject* object);
 
-  std::unique_ptr<native::BroadPhase> mBroadPhase;
+  // Keep the concrete type so NativeCollisionDetector can use AABB-tree-only
+  // fast paths without extending the release-line BroadPhase vtable.
+  std::unique_ptr<native::AabbTreeBroadPhase> mBroadPhase;
   std::vector<CollisionObject*> mCollisionObjects;
   std::unordered_map<std::size_t, NativeCollisionObject*> mIdToObject;
   std::unordered_map<CollisionObject*, std::size_t> mObjectToId;

--- a/dart/collision/native/NativeCollisionGroup.hpp
+++ b/dart/collision/native/NativeCollisionGroup.hpp
@@ -34,7 +34,7 @@
 #define DART_COLLISION_NATIVE_NATIVECOLLISIONGROUP_HPP_
 
 #include <dart/collision/CollisionGroup.hpp>
-#include <dart/collision/native/broad_phase/BruteForce.hpp>
+#include <dart/collision/native/broad_phase/AabbTree.hpp>
 
 #include <memory>
 #include <unordered_map>

--- a/dart/collision/native/NativeCollisionObject.cpp
+++ b/dart/collision/native/NativeCollisionObject.cpp
@@ -85,8 +85,7 @@ void NativeCollisionObject::updateEngineData()
 
   mNativeTransform = getTransform();
   if (mNativeShape) {
-    mNativeAabb = native::Aabb::transformed(
-        mNativeShape->computeLocalAabb(), mNativeTransform);
+    mNativeAabb = native::Aabb::transformed(mNativeLocalAabb, mNativeTransform);
   } else {
     mNativeAabb = native::Aabb();
   }
@@ -101,11 +100,14 @@ void NativeCollisionObject::rebuildNativeShape()
 
   if (!shape) {
     mNativeShape.reset();
+    mNativeLocalAabb = native::Aabb();
     mNativeAabb = native::Aabb();
     return;
   }
 
   mNativeShape = detail::NativeShapeConversion::create(*shape);
+  mNativeLocalAabb
+      = mNativeShape ? mNativeShape->computeLocalAabb() : native::Aabb();
 }
 
 } // namespace collision

--- a/dart/collision/native/NativeCollisionObject.hpp
+++ b/dart/collision/native/NativeCollisionObject.hpp
@@ -75,6 +75,10 @@ private:
 
   std::unique_ptr<native::Shape> mNativeShape;
   Eigen::Isometry3d mNativeTransform{Eigen::Isometry3d::Identity()};
+  /// Local-space AABB of mNativeShape, recomputed only when the native shape
+  /// is rebuilt; shapes are immutable between version bumps, so recomputing
+  /// it per step (a virtual call per object per step) is wasted work.
+  native::Aabb mNativeLocalAabb;
   native::Aabb mNativeAabb;
   std::size_t mLastKnownShapeId{std::numeric_limits<std::size_t>::max()};
   std::size_t mLastKnownShapeVersion{0u};

--- a/dart/collision/native/broad_phase/AabbTree.cpp
+++ b/dart/collision/native/broad_phase/AabbTree.cpp
@@ -134,6 +134,15 @@ void AabbTreeBroadPhase::queryPairs(std::vector<BroadPhasePair>& out) const
 
 bool AabbTreeBroadPhase::visitPairs(const BroadPhasePairVisitor& visitor) const
 {
+  // Materializing and sorting the candidate pairs before visiting is
+  // load-bearing, not incidental: callers that stop early (contact caps,
+  // boolean queries) terminate on whichever pair they see first, so the
+  // visitation order is behavior. Sorted (min,max) order reproduces
+  // BruteForceBroadPhase's ordered scan bit-for-bit, which is what keeps the
+  // native detector's results independent of tree topology. Collection costs
+  // O(k log k) in the number of overlapping candidates; the previous
+  // BruteForce scan was O(n^2) in object count regardless of overlap, so
+  // even early-exit queries do not regress asymptotically.
   const auto pairs = queryPairs();
   for (const auto& pair : pairs) {
     if (!visitor(pair.first, pair.second)) {

--- a/dart/collision/native/broad_phase/AabbTree.cpp
+++ b/dart/collision/native/broad_phase/AabbTree.cpp
@@ -132,6 +132,67 @@ void AabbTreeBroadPhase::queryPairs(std::vector<BroadPhasePair>& out) const
   out.erase(std::unique(out.begin(), out.end()), out.end());
 }
 
+bool AabbTreeBroadPhase::visitPairsAnyOrder(
+    const BroadPhasePairVisitor& visitor) const
+{
+  // Streams candidates straight out of the tree walk with no sort/dedup, so
+  // an early visitor rejection (e.g. a boolean query's first hit) aborts the
+  // traversal without materializing the pair set. The tree self-query may
+  // visit a pair more than once; callers must be idempotent and
+  // order-independent (see BroadPhase::visitPairsAnyOrder).
+  if (root_ == kNullNode) {
+    return true;
+  }
+
+  return visitPairsRecursiveAnyOrder(root_, root_, visitor);
+}
+
+bool AabbTreeBroadPhase::visitPairsRecursiveAnyOrder(
+    std::size_t nodeA,
+    std::size_t nodeB,
+    const BroadPhasePairVisitor& visitor) const
+{
+  if (nodeA == kNullNode || nodeB == kNullNode) {
+    return true;
+  }
+
+  if (nodeA == nodeB) {
+    if (nodes_[nodeA].isLeaf()) {
+      return true;
+    }
+
+    return visitPairsRecursiveAnyOrder(
+               nodes_[nodeA].left, nodes_[nodeA].right, visitor)
+           && visitPairsRecursiveAnyOrder(
+               nodes_[nodeA].left, nodes_[nodeA].left, visitor)
+           && visitPairsRecursiveAnyOrder(
+               nodes_[nodeA].right, nodes_[nodeA].right, visitor);
+  }
+
+  if (!nodes_[nodeA].fatAabb.overlaps(nodes_[nodeB].fatAabb)) {
+    return true;
+  }
+
+  if (nodes_[nodeA].isLeaf() && nodes_[nodeB].isLeaf()) {
+    if (nodes_[nodeA].tightAabb.overlaps(nodes_[nodeB].tightAabb)) {
+      const std::size_t id1 = nodes_[nodeA].objectId;
+      const std::size_t id2 = nodes_[nodeB].objectId;
+      return visitor(std::min(id1, id2), std::max(id1, id2));
+    }
+    return true;
+  }
+
+  if (nodes_[nodeB].isLeaf()
+      || (!nodes_[nodeA].isLeaf()
+          && nodes_[nodeA].height > nodes_[nodeB].height)) {
+    return visitPairsRecursiveAnyOrder(nodes_[nodeA].left, nodeB, visitor)
+           && visitPairsRecursiveAnyOrder(nodes_[nodeA].right, nodeB, visitor);
+  }
+
+  return visitPairsRecursiveAnyOrder(nodeA, nodes_[nodeB].left, visitor)
+         && visitPairsRecursiveAnyOrder(nodeA, nodes_[nodeB].right, visitor);
+}
+
 bool AabbTreeBroadPhase::visitPairs(const BroadPhasePairVisitor& visitor) const
 {
   // Materializing and sorting the candidate pairs before visiting is

--- a/dart/collision/native/broad_phase/AabbTree.cpp
+++ b/dart/collision/native/broad_phase/AabbTree.cpp
@@ -195,19 +195,31 @@ bool AabbTreeBroadPhase::visitPairsRecursiveAnyOrder(
 
 bool AabbTreeBroadPhase::visitPairs(const BroadPhasePairVisitor& visitor) const
 {
-  // Materializing and sorting the candidate pairs before visiting is
-  // load-bearing, not incidental: callers that stop early (contact caps,
-  // boolean queries) terminate on whichever pair they see first, so the
-  // visitation order is behavior. Sorted (min,max) order reproduces
-  // BruteForceBroadPhase's ordered scan bit-for-bit, which is what keeps the
-  // native detector's results independent of tree topology. Collection costs
-  // O(k log k) in the number of overlapping candidates; the previous
-  // BruteForce scan was O(n^2) in object count regardless of overlap, so
-  // even early-exit queries do not regress asymptotically.
-  const auto pairs = queryPairs();
-  for (const auto& pair : pairs) {
-    if (!visitor(pair.first, pair.second)) {
-      return false;
+  // Visit in the same lexicographic (min,max) order as BruteForceBroadPhase,
+  // but materialize only one object's higher-id overlaps at a time. This keeps
+  // capped result queries deterministic while allowing the first visitor
+  // rejection to avoid collecting and sorting the full pair set.
+  std::vector<std::size_t> orderedIds;
+  orderedIds.reserve(objectToNode_.size());
+  for (const auto& entry : objectToNode_) {
+    orderedIds.push_back(entry.first);
+  }
+  std::sort(orderedIds.begin(), orderedIds.end());
+
+  std::vector<std::size_t> overlaps;
+  overlaps.reserve(objectToNode_.size());
+  for (const std::size_t id : orderedIds) {
+    overlaps.clear();
+    const Node& leaf = nodes_[objectToNode_.at(id)];
+    queryOverlappingRecursive(root_, leaf.tightAabb, overlaps);
+    std::sort(overlaps.begin(), overlaps.end());
+
+    for (auto it = std::upper_bound(overlaps.begin(), overlaps.end(), id);
+         it != overlaps.end();
+         ++it) {
+      if (!visitor(id, *it)) {
+        return false;
+      }
     }
   }
 

--- a/dart/collision/native/broad_phase/AabbTree.cpp
+++ b/dart/collision/native/broad_phase/AabbTree.cpp
@@ -33,14 +33,30 @@
 #include <dart/collision/native/broad_phase/AabbTree.hpp>
 
 #include <algorithm>
+#include <stdexcept>
 #include <unordered_set>
 
 #include <cassert>
+#include <cmath>
 
 namespace dart::collision::native {
 
+namespace {
+
+double validateFatAabbMargin(double margin)
+{
+  if (!std::isfinite(margin) || margin < 0.0) {
+    throw std::invalid_argument(
+        "AabbTreeBroadPhase fat AABB margin must be finite and non-negative");
+  }
+
+  return margin;
+}
+
+} // namespace
+
 AabbTreeBroadPhase::AabbTreeBroadPhase(double fatAabbMargin)
-  : fatAabbMargin_(fatAabbMargin)
+  : fatAabbMargin_(validateFatAabbMargin(fatAabbMargin))
 {
 }
 
@@ -139,7 +155,7 @@ bool AabbTreeBroadPhase::visitPairsAnyOrder(
   // an early visitor rejection (e.g. a boolean query's first hit) aborts the
   // traversal without materializing the pair set. The tree self-query may
   // visit a pair more than once; callers must be idempotent and
-  // order-independent (see BroadPhase::visitPairsAnyOrder).
+  // order-independent.
   if (root_ == kNullNode) {
     return true;
   }
@@ -334,7 +350,7 @@ double AabbTreeBroadPhase::getFatAabbMargin() const
 
 void AabbTreeBroadPhase::setFatAabbMargin(double margin)
 {
-  fatAabbMargin_ = margin;
+  fatAabbMargin_ = validateFatAabbMargin(margin);
 }
 
 std::size_t AabbTreeBroadPhase::getHeight() const

--- a/dart/collision/native/broad_phase/AabbTree.cpp
+++ b/dart/collision/native/broad_phase/AabbTree.cpp
@@ -1,0 +1,665 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/broad_phase/AabbTree.hpp>
+
+#include <algorithm>
+#include <unordered_set>
+
+#include <cassert>
+
+namespace dart::collision::native {
+
+AabbTreeBroadPhase::AabbTreeBroadPhase(double fatAabbMargin)
+  : fatAabbMargin_(fatAabbMargin)
+{
+}
+
+void AabbTreeBroadPhase::clear()
+{
+  nodes_.clear();
+  root_ = kNullNode;
+  nodeCount_ = 0;
+  freeList_ = kNullNode;
+  objectToNode_.clear();
+}
+
+void AabbTreeBroadPhase::add(std::size_t id, const Aabb& aabb)
+{
+  if (objectToNode_.find(id) != objectToNode_.end()) {
+    update(id, aabb);
+    return;
+  }
+
+  const std::size_t leafIndex = allocateNode();
+  Node& leaf = nodes_[leafIndex];
+
+  leaf.tightAabb = aabb;
+  leaf.fatAabb = aabb;
+  leaf.fatAabb.expand(fatAabbMargin_);
+  leaf.objectId = id;
+  leaf.height = 0;
+
+  objectToNode_[id] = leafIndex;
+
+  insertLeaf(leafIndex);
+}
+
+void AabbTreeBroadPhase::update(std::size_t id, const Aabb& aabb)
+{
+  const auto it = objectToNode_.find(id);
+  if (it == objectToNode_.end()) {
+    return;
+  }
+
+  const std::size_t leafIndex = it->second;
+  Node& leaf = nodes_[leafIndex];
+
+  if (leaf.fatAabb.contains(aabb)) {
+    leaf.tightAabb = aabb;
+    return;
+  }
+
+  removeLeaf(leafIndex);
+
+  leaf.tightAabb = aabb;
+  leaf.fatAabb = aabb;
+  leaf.fatAabb.expand(fatAabbMargin_);
+
+  insertLeaf(leafIndex);
+}
+
+void AabbTreeBroadPhase::remove(std::size_t id)
+{
+  const auto it = objectToNode_.find(id);
+  if (it == objectToNode_.end()) {
+    return;
+  }
+
+  const std::size_t leafIndex = it->second;
+  objectToNode_.erase(it);
+  removeLeaf(leafIndex);
+  freeNode(leafIndex);
+}
+
+std::vector<BroadPhasePair> AabbTreeBroadPhase::queryPairs() const
+{
+  std::vector<BroadPhasePair> pairs;
+  queryPairs(pairs);
+  return pairs;
+}
+
+void AabbTreeBroadPhase::queryPairs(std::vector<BroadPhasePair>& out) const
+{
+  out.clear();
+
+  if (root_ == kNullNode) {
+    return;
+  }
+
+  queryPairsRecursive(root_, root_, out);
+
+  std::sort(out.begin(), out.end());
+  out.erase(std::unique(out.begin(), out.end()), out.end());
+}
+
+bool AabbTreeBroadPhase::visitPairs(const BroadPhasePairVisitor& visitor) const
+{
+  const auto pairs = queryPairs();
+  for (const auto& pair : pairs) {
+    if (!visitor(pair.first, pair.second)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void AabbTreeBroadPhase::buildDebugSnapshot(BroadPhaseDebugSnapshot& out) const
+{
+  out.clear();
+  out.candidatePairs = queryPairs();
+  out.numObjects = size();
+  out.hasTreeTopology = true;
+  out.rootNode = root_;
+
+  if (root_ == kNullNode) {
+    return;
+  }
+
+  std::vector<std::size_t> stack{root_};
+  std::unordered_set<std::size_t> visited;
+  visited.reserve(nodeCount_);
+
+  while (!stack.empty()) {
+    const std::size_t nodeIndex = stack.back();
+    stack.pop_back();
+
+    if (nodeIndex == kNullNode || nodeIndex >= nodes_.size()) {
+      continue;
+    }
+    if (!visited.insert(nodeIndex).second) {
+      continue;
+    }
+
+    const Node& node = nodes_[nodeIndex];
+    BroadPhaseDebugNode debugNode;
+    debugNode.nodeId = nodeIndex;
+    debugNode.parent = node.parent;
+    debugNode.left = node.left;
+    debugNode.right = node.right;
+    debugNode.objectId = node.objectId;
+    debugNode.aabb = node.fatAabb;
+    debugNode.tightAabb = node.isLeaf() ? node.tightAabb : node.fatAabb;
+    debugNode.height = node.height;
+    out.nodes.push_back(debugNode);
+
+    if (!node.isLeaf()) {
+      stack.push_back(node.left);
+      stack.push_back(node.right);
+    }
+  }
+
+  std::sort(
+      out.nodes.begin(),
+      out.nodes.end(),
+      [](const BroadPhaseDebugNode& lhs, const BroadPhaseDebugNode& rhs) {
+        return lhs.nodeId < rhs.nodeId;
+      });
+}
+
+void AabbTreeBroadPhase::build(
+    span<const std::size_t> ids, span<const Aabb> aabbs)
+{
+  clear();
+
+  const std::size_t n = std::min(ids.size(), aabbs.size());
+  if (n == 0u) {
+    return;
+  }
+
+  nodes_.reserve(2u * n);
+
+  for (std::size_t i = 0; i < n; ++i) {
+    add(ids[i], aabbs[i]);
+  }
+}
+
+void AabbTreeBroadPhase::updateRange(
+    span<const std::size_t> ids, span<const Aabb> aabbs)
+{
+  const std::size_t n = std::min(ids.size(), aabbs.size());
+
+  for (std::size_t i = 0; i < n; ++i) {
+    update(ids[i], aabbs[i]);
+  }
+}
+
+std::vector<std::size_t> AabbTreeBroadPhase::queryOverlapping(
+    const Aabb& aabb) const
+{
+  std::vector<std::size_t> results;
+
+  if (root_ == kNullNode) {
+    return results;
+  }
+
+  queryOverlappingRecursive(root_, aabb, results);
+
+  std::sort(results.begin(), results.end());
+
+  return results;
+}
+
+std::size_t AabbTreeBroadPhase::size() const
+{
+  return objectToNode_.size();
+}
+
+double AabbTreeBroadPhase::getFatAabbMargin() const
+{
+  return fatAabbMargin_;
+}
+
+void AabbTreeBroadPhase::setFatAabbMargin(double margin)
+{
+  fatAabbMargin_ = margin;
+}
+
+std::size_t AabbTreeBroadPhase::getHeight() const
+{
+  if (root_ == kNullNode) {
+    return 0;
+  }
+
+  return nodes_[root_].height;
+}
+
+bool AabbTreeBroadPhase::validate() const
+{
+  if (root_ == kNullNode) {
+    return nodeCount_ == 0u;
+  }
+
+  return validateStructure(root_);
+}
+
+std::size_t AabbTreeBroadPhase::allocateNode()
+{
+  if (freeList_ != kNullNode) {
+    const std::size_t nodeIndex = freeList_;
+    freeList_ = nodes_[nodeIndex].parent;
+    nodes_[nodeIndex] = Node{};
+    ++nodeCount_;
+    return nodeIndex;
+  }
+
+  const std::size_t nodeIndex = nodes_.size();
+  nodes_.emplace_back();
+  ++nodeCount_;
+  return nodeIndex;
+}
+
+void AabbTreeBroadPhase::freeNode(std::size_t nodeIndex)
+{
+  assert(nodeIndex < nodes_.size());
+  nodes_[nodeIndex].parent = freeList_;
+  nodes_[nodeIndex].height = kNullNode;
+  freeList_ = nodeIndex;
+  --nodeCount_;
+}
+
+void AabbTreeBroadPhase::insertLeaf(std::size_t leafIndex)
+{
+  if (root_ == kNullNode) {
+    root_ = leafIndex;
+    nodes_[leafIndex].parent = kNullNode;
+    return;
+  }
+
+  // Copy values before allocateNode(), which may reallocate nodes_.
+  const Aabb leafAabb = nodes_[leafIndex].fatAabb;
+  const std::size_t siblingIndex = findBestSibling(leafAabb);
+  const Aabb siblingAabb = nodes_[siblingIndex].fatAabb;
+  const std::size_t oldParent = nodes_[siblingIndex].parent;
+  const std::size_t newParent = allocateNode();
+
+  nodes_[newParent].parent = oldParent;
+  nodes_[newParent].fatAabb = combine(leafAabb, siblingAabb);
+  nodes_[newParent].height = nodes_[siblingIndex].height + 1u;
+
+  if (oldParent != kNullNode) {
+    if (nodes_[oldParent].left == siblingIndex) {
+      nodes_[oldParent].left = newParent;
+    } else {
+      nodes_[oldParent].right = newParent;
+    }
+    nodes_[newParent].left = siblingIndex;
+    nodes_[newParent].right = leafIndex;
+    nodes_[siblingIndex].parent = newParent;
+    nodes_[leafIndex].parent = newParent;
+  } else {
+    nodes_[newParent].left = siblingIndex;
+    nodes_[newParent].right = leafIndex;
+    nodes_[siblingIndex].parent = newParent;
+    nodes_[leafIndex].parent = newParent;
+    root_ = newParent;
+  }
+
+  rebalance(nodes_[leafIndex].parent);
+}
+
+void AabbTreeBroadPhase::removeLeaf(std::size_t leafIndex)
+{
+  if (leafIndex == root_) {
+    root_ = kNullNode;
+    return;
+  }
+
+  const std::size_t parent = nodes_[leafIndex].parent;
+  const std::size_t grandParent = nodes_[parent].parent;
+  const std::size_t sibling = (nodes_[parent].left == leafIndex)
+                                  ? nodes_[parent].right
+                                  : nodes_[parent].left;
+
+  if (grandParent != kNullNode) {
+    if (nodes_[grandParent].left == parent) {
+      nodes_[grandParent].left = sibling;
+    } else {
+      nodes_[grandParent].right = sibling;
+    }
+    nodes_[sibling].parent = grandParent;
+    freeNode(parent);
+    rebalance(grandParent);
+  } else {
+    root_ = sibling;
+    nodes_[sibling].parent = kNullNode;
+    freeNode(parent);
+  }
+}
+
+std::size_t AabbTreeBroadPhase::findBestSibling(const Aabb& aabb) const
+{
+  std::size_t index = root_;
+
+  while (!nodes_[index].isLeaf()) {
+    const std::size_t left = nodes_[index].left;
+    const std::size_t right = nodes_[index].right;
+
+    const double area = surfaceArea(nodes_[index].fatAabb);
+    const double combinedArea
+        = surfaceArea(combine(nodes_[index].fatAabb, aabb));
+    const double cost = 2.0 * combinedArea;
+    const double inheritanceCost = 2.0 * (combinedArea - area);
+
+    double costLeft;
+    if (nodes_[left].isLeaf()) {
+      costLeft
+          = surfaceArea(combine(aabb, nodes_[left].fatAabb)) + inheritanceCost;
+    } else {
+      const double oldArea = surfaceArea(nodes_[left].fatAabb);
+      const double newArea = surfaceArea(combine(aabb, nodes_[left].fatAabb));
+      costLeft = (newArea - oldArea) + inheritanceCost;
+    }
+
+    double costRight;
+    if (nodes_[right].isLeaf()) {
+      costRight
+          = surfaceArea(combine(aabb, nodes_[right].fatAabb)) + inheritanceCost;
+    } else {
+      const double oldArea = surfaceArea(nodes_[right].fatAabb);
+      const double newArea = surfaceArea(combine(aabb, nodes_[right].fatAabb));
+      costRight = (newArea - oldArea) + inheritanceCost;
+    }
+
+    if (cost < costLeft && cost < costRight) {
+      break;
+    }
+
+    index = (costLeft < costRight) ? left : right;
+  }
+
+  return index;
+}
+
+void AabbTreeBroadPhase::rebalance(std::size_t nodeIndex)
+{
+  while (nodeIndex != kNullNode) {
+    nodeIndex = balance(nodeIndex);
+
+    const std::size_t left = nodes_[nodeIndex].left;
+    const std::size_t right = nodes_[nodeIndex].right;
+
+    assert(left != kNullNode);
+    assert(right != kNullNode);
+
+    nodes_[nodeIndex].height
+        = 1u + std::max(nodes_[left].height, nodes_[right].height);
+    nodes_[nodeIndex].fatAabb
+        = combine(nodes_[left].fatAabb, nodes_[right].fatAabb);
+
+    nodeIndex = nodes_[nodeIndex].parent;
+  }
+}
+
+std::size_t AabbTreeBroadPhase::balance(std::size_t nodeIndex)
+{
+  assert(nodeIndex != kNullNode);
+
+  Node& A = nodes_[nodeIndex];
+  if (A.isLeaf() || A.height < 2u) {
+    return nodeIndex;
+  }
+
+  const std::size_t iB = A.left;
+  const std::size_t iC = A.right;
+  assert(iB < nodes_.size());
+  assert(iC < nodes_.size());
+
+  Node& B = nodes_[iB];
+  Node& C = nodes_[iC];
+
+  const int balance = static_cast<int>(C.height) - static_cast<int>(B.height);
+
+  if (balance > 1) {
+    const std::size_t iF = C.left;
+    const std::size_t iG = C.right;
+    assert(iF < nodes_.size());
+    assert(iG < nodes_.size());
+    Node& F = nodes_[iF];
+    Node& G = nodes_[iG];
+
+    C.left = nodeIndex;
+    C.parent = A.parent;
+    A.parent = iC;
+
+    if (C.parent != kNullNode) {
+      if (nodes_[C.parent].left == nodeIndex) {
+        nodes_[C.parent].left = iC;
+      } else {
+        assert(nodes_[C.parent].right == nodeIndex);
+        nodes_[C.parent].right = iC;
+      }
+    } else {
+      root_ = iC;
+    }
+
+    if (F.height > G.height) {
+      C.right = iF;
+      A.right = iG;
+      G.parent = nodeIndex;
+      A.fatAabb = combine(B.fatAabb, G.fatAabb);
+      C.fatAabb = combine(A.fatAabb, F.fatAabb);
+      A.height = 1u + std::max(B.height, G.height);
+      C.height = 1u + std::max(A.height, F.height);
+    } else {
+      C.right = iG;
+      A.right = iF;
+      F.parent = nodeIndex;
+      A.fatAabb = combine(B.fatAabb, F.fatAabb);
+      C.fatAabb = combine(A.fatAabb, G.fatAabb);
+      A.height = 1u + std::max(B.height, F.height);
+      C.height = 1u + std::max(A.height, G.height);
+    }
+
+    return iC;
+  }
+
+  if (balance < -1) {
+    const std::size_t iD = B.left;
+    const std::size_t iE = B.right;
+    assert(iD < nodes_.size());
+    assert(iE < nodes_.size());
+    Node& D = nodes_[iD];
+    Node& E = nodes_[iE];
+
+    B.left = nodeIndex;
+    B.parent = A.parent;
+    A.parent = iB;
+
+    if (B.parent != kNullNode) {
+      if (nodes_[B.parent].left == nodeIndex) {
+        nodes_[B.parent].left = iB;
+      } else {
+        assert(nodes_[B.parent].right == nodeIndex);
+        nodes_[B.parent].right = iB;
+      }
+    } else {
+      root_ = iB;
+    }
+
+    if (D.height > E.height) {
+      B.right = iD;
+      A.left = iE;
+      E.parent = nodeIndex;
+      A.fatAabb = combine(C.fatAabb, E.fatAabb);
+      B.fatAabb = combine(A.fatAabb, D.fatAabb);
+      A.height = 1u + std::max(C.height, E.height);
+      B.height = 1u + std::max(A.height, D.height);
+    } else {
+      B.right = iE;
+      A.left = iD;
+      D.parent = nodeIndex;
+      A.fatAabb = combine(C.fatAabb, D.fatAabb);
+      B.fatAabb = combine(A.fatAabb, E.fatAabb);
+      A.height = 1u + std::max(C.height, D.height);
+      B.height = 1u + std::max(A.height, E.height);
+    }
+
+    return iB;
+  }
+
+  return nodeIndex;
+}
+
+Aabb AabbTreeBroadPhase::combine(const Aabb& a, const Aabb& b)
+{
+  return Aabb(a.min.cwiseMin(b.min), a.max.cwiseMax(b.max));
+}
+
+double AabbTreeBroadPhase::surfaceArea(const Aabb& aabb)
+{
+  const Eigen::Vector3d d = aabb.max - aabb.min;
+  return 2.0 * (d.x() * d.y() + d.y() * d.z() + d.z() * d.x());
+}
+
+void AabbTreeBroadPhase::queryPairsRecursive(
+    std::size_t nodeA,
+    std::size_t nodeB,
+    std::vector<BroadPhasePair>& pairs) const
+{
+  if (nodeA == kNullNode || nodeB == kNullNode) {
+    return;
+  }
+
+  if (nodeA == nodeB) {
+    if (nodes_[nodeA].isLeaf()) {
+      return;
+    }
+
+    queryPairsRecursive(nodes_[nodeA].left, nodes_[nodeA].right, pairs);
+    queryPairsRecursive(nodes_[nodeA].left, nodes_[nodeA].left, pairs);
+    queryPairsRecursive(nodes_[nodeA].right, nodes_[nodeA].right, pairs);
+    return;
+  }
+
+  if (!nodes_[nodeA].fatAabb.overlaps(nodes_[nodeB].fatAabb)) {
+    return;
+  }
+
+  if (nodes_[nodeA].isLeaf() && nodes_[nodeB].isLeaf()) {
+    if (nodes_[nodeA].tightAabb.overlaps(nodes_[nodeB].tightAabb)) {
+      const std::size_t id1 = nodes_[nodeA].objectId;
+      const std::size_t id2 = nodes_[nodeB].objectId;
+      pairs.emplace_back(std::min(id1, id2), std::max(id1, id2));
+    }
+    return;
+  }
+
+  if (nodes_[nodeB].isLeaf()
+      || (!nodes_[nodeA].isLeaf()
+          && nodes_[nodeA].height > nodes_[nodeB].height)) {
+    queryPairsRecursive(nodes_[nodeA].left, nodeB, pairs);
+    queryPairsRecursive(nodes_[nodeA].right, nodeB, pairs);
+  } else {
+    queryPairsRecursive(nodeA, nodes_[nodeB].left, pairs);
+    queryPairsRecursive(nodeA, nodes_[nodeB].right, pairs);
+  }
+}
+
+void AabbTreeBroadPhase::queryOverlappingRecursive(
+    std::size_t nodeIndex,
+    const Aabb& aabb,
+    std::vector<std::size_t>& results) const
+{
+  if (nodeIndex == kNullNode) {
+    return;
+  }
+
+  if (!nodes_[nodeIndex].fatAabb.overlaps(aabb)) {
+    return;
+  }
+
+  if (nodes_[nodeIndex].isLeaf()) {
+    if (nodes_[nodeIndex].tightAabb.overlaps(aabb)) {
+      results.push_back(nodes_[nodeIndex].objectId);
+    }
+    return;
+  }
+
+  queryOverlappingRecursive(nodes_[nodeIndex].left, aabb, results);
+  queryOverlappingRecursive(nodes_[nodeIndex].right, aabb, results);
+}
+
+bool AabbTreeBroadPhase::validateStructure(std::size_t nodeIndex) const
+{
+  if (nodeIndex == kNullNode) {
+    return true;
+  }
+
+  if (nodeIndex == root_ && nodes_[nodeIndex].parent != kNullNode) {
+    return false;
+  }
+
+  const Node& node = nodes_[nodeIndex];
+
+  if (node.isLeaf()) {
+    if (node.left != kNullNode || node.right != kNullNode) {
+      return false;
+    }
+    if (node.height != 0u) {
+      return false;
+    }
+    return true;
+  }
+
+  if (node.left == kNullNode || node.right == kNullNode) {
+    return false;
+  }
+
+  if (nodes_[node.left].parent != nodeIndex) {
+    return false;
+  }
+  if (nodes_[node.right].parent != nodeIndex) {
+    return false;
+  }
+
+  const std::size_t expectedHeight
+      = 1u + std::max(nodes_[node.left].height, nodes_[node.right].height);
+  if (node.height != expectedHeight) {
+    return false;
+  }
+
+  return validateStructure(node.left) && validateStructure(node.right);
+}
+
+} // namespace dart::collision::native

--- a/dart/collision/native/broad_phase/AabbTree.hpp
+++ b/dart/collision/native/broad_phase/AabbTree.hpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <dart/collision/native/broad_phase/BroadPhase.hpp>
+
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+namespace dart::collision::native {
+
+/// Dynamic AABB Tree using Surface Area Heuristic (SAH) for O(n log n)
+/// broad-phase. Uses fat AABBs to reduce update frequency when objects move.
+class DART_COLLISION_NATIVE_API AabbTreeBroadPhase : public BroadPhase
+{
+public:
+  static constexpr std::size_t kNullNode
+      = std::numeric_limits<std::size_t>::max();
+  static constexpr double kDefaultFatAabbMargin = 0.1;
+
+  explicit AabbTreeBroadPhase(double fatAabbMargin = kDefaultFatAabbMargin);
+
+  void clear() override;
+  void add(std::size_t id, const Aabb& aabb) override;
+  void update(std::size_t id, const Aabb& aabb) override;
+  void remove(std::size_t id) override;
+
+  [[nodiscard]] std::vector<BroadPhasePair> queryPairs() const override;
+  [[nodiscard]] std::vector<std::size_t> queryOverlapping(
+      const Aabb& aabb) const override;
+  [[nodiscard]] std::size_t size() const override;
+
+  void queryPairs(std::vector<BroadPhasePair>& out) const override;
+  bool visitPairs(const BroadPhasePairVisitor& visitor) const override;
+  void buildDebugSnapshot(BroadPhaseDebugSnapshot& out) const override;
+
+  void build(span<const std::size_t> ids, span<const Aabb> aabbs) override;
+  void updateRange(
+      span<const std::size_t> ids, span<const Aabb> aabbs) override;
+
+  [[nodiscard]] double getFatAabbMargin() const;
+  void setFatAabbMargin(double margin);
+  [[nodiscard]] std::size_t getHeight() const;
+  [[nodiscard]] bool validate() const;
+
+private:
+  struct Node
+  {
+    Aabb fatAabb;
+    Aabb tightAabb;
+    std::size_t parent = kNullNode;
+    std::size_t left = kNullNode;
+    std::size_t right = kNullNode;
+    std::size_t objectId = kNullNode;
+    std::size_t height = 0;
+
+    [[nodiscard]] bool isLeaf() const
+    {
+      return left == kNullNode;
+    }
+  };
+
+  std::vector<Node> nodes_;
+  std::size_t root_ = kNullNode;
+  std::size_t nodeCount_ = 0;
+  std::size_t freeList_ = kNullNode;
+  std::unordered_map<std::size_t, std::size_t> objectToNode_;
+  double fatAabbMargin_;
+
+  [[nodiscard]] std::size_t allocateNode();
+  void freeNode(std::size_t nodeIndex);
+  void insertLeaf(std::size_t leafIndex);
+  void removeLeaf(std::size_t leafIndex);
+  [[nodiscard]] std::size_t findBestSibling(const Aabb& aabb) const;
+  void rebalance(std::size_t nodeIndex);
+  [[nodiscard]] std::size_t balance(std::size_t nodeIndex);
+  [[nodiscard]] static Aabb combine(const Aabb& a, const Aabb& b);
+  [[nodiscard]] static double surfaceArea(const Aabb& aabb);
+
+  void queryPairsRecursive(
+      std::size_t nodeA,
+      std::size_t nodeB,
+      std::vector<BroadPhasePair>& pairs) const;
+
+  void queryOverlappingRecursive(
+      std::size_t nodeIndex,
+      const Aabb& aabb,
+      std::vector<std::size_t>& results) const;
+
+  [[nodiscard]] bool validateStructure(std::size_t nodeIndex) const;
+};
+
+} // namespace dart::collision::native

--- a/dart/collision/native/broad_phase/AabbTree.hpp
+++ b/dart/collision/native/broad_phase/AabbTree.hpp
@@ -63,6 +63,7 @@ public:
 
   void queryPairs(std::vector<BroadPhasePair>& out) const override;
   bool visitPairs(const BroadPhasePairVisitor& visitor) const override;
+  bool visitPairsAnyOrder(const BroadPhasePairVisitor& visitor) const override;
   void buildDebugSnapshot(BroadPhaseDebugSnapshot& out) const override;
 
   void build(span<const std::size_t> ids, span<const Aabb> aabbs) override;
@@ -107,6 +108,11 @@ private:
   [[nodiscard]] std::size_t balance(std::size_t nodeIndex);
   [[nodiscard]] static Aabb combine(const Aabb& a, const Aabb& b);
   [[nodiscard]] static double surfaceArea(const Aabb& aabb);
+
+  bool visitPairsRecursiveAnyOrder(
+      std::size_t nodeA,
+      std::size_t nodeB,
+      const BroadPhasePairVisitor& visitor) const;
 
   void queryPairsRecursive(
       std::size_t nodeA,

--- a/dart/collision/native/broad_phase/AabbTree.hpp
+++ b/dart/collision/native/broad_phase/AabbTree.hpp
@@ -63,7 +63,9 @@ public:
 
   void queryPairs(std::vector<BroadPhasePair>& out) const override;
   bool visitPairs(const BroadPhasePairVisitor& visitor) const override;
-  bool visitPairsAnyOrder(const BroadPhasePairVisitor& visitor) const override;
+  /// Visits candidates without an ordering or uniqueness guarantee, allowing
+  /// order-independent queries to stop without materializing the pair set.
+  bool visitPairsAnyOrder(const BroadPhasePairVisitor& visitor) const;
   void buildDebugSnapshot(BroadPhaseDebugSnapshot& out) const override;
 
   void build(span<const std::size_t> ids, span<const Aabb> aabbs) override;

--- a/dart/collision/native/broad_phase/BroadPhase.hpp
+++ b/dart/collision/native/broad_phase/BroadPhase.hpp
@@ -153,6 +153,16 @@ public:
     return true;
   }
 
+  /// Like visitPairs(), but with no ordering or uniqueness guarantee, so
+  /// implementations may stream candidates and stop at the first visitor
+  /// rejection without materializing the full pair set. Only valid for
+  /// callers whose outcome is order-independent (e.g. boolean existence
+  /// queries); anything that emits per-pair data must use visitPairs().
+  virtual bool visitPairsAnyOrder(const BroadPhasePairVisitor& visitor) const
+  {
+    return visitPairs(visitor);
+  }
+
   template <typename FilterFunc>
   void queryPairsFiltered(
       std::vector<BroadPhasePair>& out, FilterFunc&& filter) const

--- a/dart/collision/native/broad_phase/BroadPhase.hpp
+++ b/dart/collision/native/broad_phase/BroadPhase.hpp
@@ -153,16 +153,6 @@ public:
     return true;
   }
 
-  /// Like visitPairs(), but with no ordering or uniqueness guarantee, so
-  /// implementations may stream candidates and stop at the first visitor
-  /// rejection without materializing the full pair set. Only valid for
-  /// callers whose outcome is order-independent (e.g. boolean existence
-  /// queries); anything that emits per-pair data must use visitPairs().
-  virtual bool visitPairsAnyOrder(const BroadPhasePairVisitor& visitor) const
-  {
-    return visitPairs(visitor);
-  }
-
   template <typename FilterFunc>
   void queryPairsFiltered(
       std::vector<BroadPhasePair>& out, FilterFunc&& filter) const
@@ -191,6 +181,18 @@ public:
     for (std::size_t i = 0; i < n; ++i) {
       update(ids[i], aabbs[i]);
     }
+  }
+
+  /// Like visitPairs(), but with no ordering or uniqueness guarantee, so
+  /// implementations may stream candidates and stop at the first visitor
+  /// rejection without materializing the full pair set. Only valid for
+  /// callers whose outcome is order-independent (e.g. boolean existence
+  /// queries); anything that emits per-pair data must use visitPairs().
+  /// Appended after the DART 6.20 virtual interface to preserve existing
+  /// vtable slots.
+  virtual bool visitPairsAnyOrder(const BroadPhasePairVisitor& visitor) const
+  {
+    return visitPairs(visitor);
   }
 };
 

--- a/dart/collision/native/broad_phase/BroadPhase.hpp
+++ b/dart/collision/native/broad_phase/BroadPhase.hpp
@@ -182,18 +182,6 @@ public:
       update(ids[i], aabbs[i]);
     }
   }
-
-  /// Like visitPairs(), but with no ordering or uniqueness guarantee, so
-  /// implementations may stream candidates and stop at the first visitor
-  /// rejection without materializing the full pair set. Only valid for
-  /// callers whose outcome is order-independent (e.g. boolean existence
-  /// queries); anything that emits per-pair data must use visitPairs().
-  /// Appended after the DART 6.20 virtual interface to preserve existing
-  /// vtable slots.
-  virtual bool visitPairsAnyOrder(const BroadPhasePairVisitor& visitor) const
-  {
-    return visitPairs(visitor);
-  }
 };
 
 } // namespace dart::collision::native

--- a/tests/unit/collision/native/CMakeLists.txt
+++ b/tests/unit/collision/native/CMakeLists.txt
@@ -100,6 +100,11 @@ dart_add_test(
 )
 dart_add_test(
   "unit"
+  UNIT_collision_native_aabb_tree
+  test_aabb_tree.cpp
+)
+dart_add_test(
+  "unit"
   UNIT_collision_native_brute_force
   test_brute_force.cpp
 )

--- a/tests/unit/collision/native/test_aabb_tree.cpp
+++ b/tests/unit/collision/native/test_aabb_tree.cpp
@@ -36,10 +36,12 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <random>
 #include <set>
+#include <stdexcept>
 #include <unordered_map>
 #include <vector>
 
@@ -394,6 +396,30 @@ TEST(AabbTreeBroadPhase, FatAabbOptimization)
 
   EXPECT_EQ(bp.size(), 1u);
   EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, RejectsInvalidFatAabbMargins)
+{
+  EXPECT_THROW(AabbTreeBroadPhase(-0.1), std::invalid_argument);
+  EXPECT_THROW(
+      AabbTreeBroadPhase(std::numeric_limits<double>::infinity()),
+      std::invalid_argument);
+  EXPECT_THROW(
+      AabbTreeBroadPhase(std::numeric_limits<double>::quiet_NaN()),
+      std::invalid_argument);
+
+  AabbTreeBroadPhase bp(0.25);
+  EXPECT_THROW(bp.setFatAabbMargin(-0.1), std::invalid_argument);
+  EXPECT_THROW(
+      bp.setFatAabbMargin(std::numeric_limits<double>::infinity()),
+      std::invalid_argument);
+  EXPECT_THROW(
+      bp.setFatAabbMargin(std::numeric_limits<double>::quiet_NaN()),
+      std::invalid_argument);
+  EXPECT_DOUBLE_EQ(bp.getFatAabbMargin(), 0.25);
+
+  EXPECT_NO_THROW(bp.setFatAabbMargin(0.0));
+  EXPECT_DOUBLE_EQ(bp.getFatAabbMargin(), 0.0);
 }
 
 TEST(AabbTreeBroadPhase, FatAabbDoesNotReportLoosePairs)

--- a/tests/unit/collision/native/test_aabb_tree.cpp
+++ b/tests/unit/collision/native/test_aabb_tree.cpp
@@ -595,6 +595,28 @@ TEST(AabbTreeBroadPhase, VisitPairsCanStopEarly)
   EXPECT_EQ(visited, bp.queryPairs());
 }
 
+//==============================================================================
+TEST(AabbTreeBroadPhase, VisitPairsStopsEarlyInDenseGroup)
+{
+  AabbTreeBroadPhase bp;
+  constexpr std::size_t numObjects = 2048u;
+  for (std::size_t id = 0; id < numObjects; ++id) {
+    bp.add(id, makeAabb(0, 1));
+  }
+
+  std::size_t visited = 0u;
+  const bool completed
+      = bp.visitPairs([&](std::size_t first, std::size_t second) {
+          ++visited;
+          EXPECT_EQ(first, 0u);
+          EXPECT_EQ(second, 1u);
+          return false;
+        });
+
+  EXPECT_FALSE(completed);
+  EXPECT_EQ(visited, 1u);
+}
+
 TEST(AabbTreeBroadPhase, QueryPairsFiltered)
 {
   AabbTreeBroadPhase bp;

--- a/tests/unit/collision/native/test_aabb_tree.cpp
+++ b/tests/unit/collision/native/test_aabb_tree.cpp
@@ -1,0 +1,702 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <dart/collision/native/broad_phase/AabbTree.hpp>
+#include <dart/collision/native/broad_phase/BruteForce.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+using namespace dart::collision::native;
+
+namespace {
+
+Aabb makeAabb(double min, double max)
+{
+  return Aabb(Eigen::Vector3d(min, min, min), Eigen::Vector3d(max, max, max));
+}
+
+Aabb makeAabb(const Eigen::Vector3d& center, const Eigen::Vector3d& halfExtents)
+{
+  return Aabb(center - halfExtents, center + halfExtents);
+}
+
+std::vector<BroadPhasePair> collectVisitedPairs(const BroadPhase& broadPhase)
+{
+  std::vector<BroadPhasePair> visited;
+  const bool completed
+      = broadPhase.visitPairs([&](std::size_t first, std::size_t second) {
+          visited.emplace_back(first, second);
+          return true;
+        });
+
+  EXPECT_TRUE(completed);
+  return visited;
+}
+
+void expectExactBruteForceMatch(
+    const AabbTreeBroadPhase& tree, const BruteForceBroadPhase& brute)
+{
+  EXPECT_TRUE(tree.validate());
+  EXPECT_EQ(tree.size(), brute.size());
+
+  const auto brutePairs = brute.queryPairs();
+  EXPECT_EQ(tree.queryPairs(), brutePairs);
+  EXPECT_EQ(collectVisitedPairs(tree), brutePairs);
+}
+
+} // namespace
+
+TEST(AabbTreeBroadPhase, DefaultConstruction)
+{
+  AabbTreeBroadPhase bp;
+  EXPECT_EQ(bp.size(), 0u);
+  EXPECT_TRUE(bp.queryPairs().empty());
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, AddSingle)
+{
+  AabbTreeBroadPhase bp;
+
+  Aabb aabb(Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 1, 1));
+  bp.add(0, aabb);
+
+  EXPECT_EQ(bp.size(), 1u);
+  EXPECT_TRUE(bp.queryPairs().empty());
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, EmptyAndMissingOperationsAreNoOps)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.remove(123);
+  bp.update(7, makeAabb(0, 1));
+  EXPECT_EQ(bp.size(), 0u);
+  EXPECT_TRUE(bp.validate());
+
+  bp.add(7, makeAabb(2, 3));
+  EXPECT_EQ(bp.size(), 1u);
+  EXPECT_TRUE(bp.queryPairs().empty());
+
+  std::vector<std::size_t> ids;
+  std::vector<Aabb> aabbs;
+  bp.build(ids, aabbs);
+  EXPECT_EQ(bp.size(), 0u);
+  EXPECT_TRUE(bp.queryOverlapping(makeAabb(0, 1)).empty());
+
+  bool visited = false;
+  EXPECT_TRUE(bp.visitPairs([&](std::size_t, std::size_t) {
+    visited = true;
+    return true;
+  }));
+  EXPECT_FALSE(visited);
+}
+
+TEST(AabbTreeBroadPhase, AddTwo_NoOverlap)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 1));
+  bp.add(1, makeAabb(5, 6));
+
+  EXPECT_EQ(bp.size(), 2u);
+  EXPECT_TRUE(bp.queryPairs().empty());
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, AddTwo_Overlap)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 2));
+  bp.add(1, makeAabb(1, 3));
+
+  EXPECT_EQ(bp.size(), 2u);
+
+  auto pairs = bp.queryPairs();
+  ASSERT_EQ(pairs.size(), 1u);
+  EXPECT_EQ(pairs[0].first, 0u);
+  EXPECT_EQ(pairs[0].second, 1u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, AddThree_TwoOverlapping)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 2));
+  bp.add(1, makeAabb(1, 3));
+  bp.add(2, makeAabb(10, 11));
+
+  EXPECT_EQ(bp.size(), 3u);
+
+  auto pairs = bp.queryPairs();
+  ASSERT_EQ(pairs.size(), 1u);
+  EXPECT_EQ(pairs[0].first, 0u);
+  EXPECT_EQ(pairs[0].second, 1u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, AddThree_AllOverlapping)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 3));
+  bp.add(1, makeAabb(1, 4));
+  bp.add(2, makeAabb(2, 5));
+
+  EXPECT_EQ(bp.size(), 3u);
+  EXPECT_EQ(bp.queryPairs().size(), 3u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, Remove)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 2));
+  bp.add(1, makeAabb(1, 3));
+
+  EXPECT_EQ(bp.queryPairs().size(), 1u);
+
+  bp.remove(0);
+
+  EXPECT_EQ(bp.size(), 1u);
+  EXPECT_TRUE(bp.queryPairs().empty());
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, Update)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 2));
+  bp.add(1, makeAabb(10, 11));
+
+  EXPECT_TRUE(bp.queryPairs().empty());
+
+  bp.update(1, makeAabb(1, 3));
+
+  auto pairs = bp.queryPairs();
+  ASSERT_EQ(pairs.size(), 1u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, Clear)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 2));
+  bp.add(1, makeAabb(1, 3));
+
+  bp.clear();
+
+  EXPECT_EQ(bp.size(), 0u);
+  EXPECT_TRUE(bp.queryPairs().empty());
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, QueryOverlapping)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 2));
+  bp.add(1, makeAabb(5, 7));
+  bp.add(2, makeAabb(1, 3));
+
+  auto overlapping = bp.queryOverlapping(
+      Aabb(Eigen::Vector3d(0.5, 0.5, 0.5), Eigen::Vector3d(1.5, 1.5, 1.5)));
+
+  ASSERT_EQ(overlapping.size(), 2u);
+  EXPECT_EQ(overlapping[0], 0u);
+  EXPECT_EQ(overlapping[1], 2u);
+}
+
+TEST(AabbTreeBroadPhase, QueryOverlapping_Empty)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 1));
+
+  EXPECT_TRUE(bp.queryOverlapping(makeAabb(10, 11)).empty());
+}
+
+TEST(AabbTreeBroadPhase, DeterministicPairOrder)
+{
+  for (int trial = 0; trial < 10; ++trial) {
+    AabbTreeBroadPhase bp;
+
+    bp.add(5, makeAabb(0, 5));
+    bp.add(3, makeAabb(1, 6));
+    bp.add(9, makeAabb(2, 7));
+    bp.add(1, makeAabb(3, 8));
+
+    const std::vector<BroadPhasePair> expected{
+        {1, 3}, {1, 5}, {1, 9}, {3, 5}, {3, 9}, {5, 9}};
+
+    EXPECT_EQ(bp.queryPairs(), expected);
+    EXPECT_EQ(collectVisitedPairs(bp), expected);
+    EXPECT_TRUE(bp.validate());
+  }
+}
+
+TEST(AabbTreeBroadPhase, NonContiguousIds)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(100, makeAabb(0, 2));
+  bp.add(200, makeAabb(1, 3));
+  bp.add(50, makeAabb(10, 11));
+
+  EXPECT_EQ(bp.size(), 3u);
+
+  auto pairs = bp.queryPairs();
+  ASSERT_EQ(pairs.size(), 1u);
+  EXPECT_EQ(pairs[0].first, 100u);
+  EXPECT_EQ(pairs[0].second, 200u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, Touching)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, Aabb(Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 1, 1)));
+  bp.add(1, Aabb(Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(2, 1, 1)));
+
+  EXPECT_EQ(bp.queryPairs().size(), 1u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, Polymorphism)
+{
+  std::unique_ptr<BroadPhase> bp = std::make_unique<AabbTreeBroadPhase>();
+
+  bp->add(0, makeAabb(0, 2));
+  bp->add(1, makeAabb(1, 3));
+
+  EXPECT_EQ(bp->size(), 2u);
+  EXPECT_EQ(bp->queryPairs().size(), 1u);
+}
+
+TEST(AabbTreeBroadPhase, DebugSnapshotExposesTreeTopology)
+{
+  AabbTreeBroadPhase bp;
+
+  const std::unordered_map<std::size_t, Aabb> tightAabbs{
+      {10u, makeAabb(0, 2)},
+      {20u, makeAabb(1, 3)},
+      {30u, makeAabb(8, 9)},
+  };
+
+  for (const auto& entry : tightAabbs) {
+    bp.add(entry.first, entry.second);
+  }
+
+  BroadPhaseDebugSnapshot snapshot;
+  bp.buildDebugSnapshot(snapshot);
+
+  EXPECT_TRUE(snapshot.hasTreeTopology);
+  EXPECT_EQ(snapshot.numObjects, tightAabbs.size());
+  EXPECT_NE(snapshot.rootNode, BroadPhaseDebugNode::kInvalidIndex);
+  EXPECT_EQ(snapshot.nodes.size(), 2u * tightAabbs.size() - 1u);
+  ASSERT_EQ(snapshot.candidatePairs.size(), 1u);
+  EXPECT_EQ(snapshot.candidatePairs[0], BroadPhasePair(10u, 20u));
+
+  std::unordered_map<std::size_t, const BroadPhaseDebugNode*> nodesById;
+  std::unordered_map<std::size_t, const BroadPhaseDebugNode*> leavesByObject;
+  for (const auto& node : snapshot.nodes) {
+    nodesById.emplace(node.nodeId, &node);
+    if (node.isLeaf()) {
+      leavesByObject.emplace(node.objectId, &node);
+      EXPECT_TRUE(node.aabb.contains(node.tightAabb));
+    } else {
+      EXPECT_NE(node.left, BroadPhaseDebugNode::kInvalidIndex);
+      EXPECT_NE(node.right, BroadPhaseDebugNode::kInvalidIndex);
+    }
+  }
+
+  ASSERT_NE(nodesById.find(snapshot.rootNode), nodesById.end());
+  EXPECT_EQ(
+      nodesById.at(snapshot.rootNode)->parent,
+      BroadPhaseDebugNode::kInvalidIndex);
+
+  ASSERT_EQ(leavesByObject.size(), tightAabbs.size());
+  for (const auto& entry : tightAabbs) {
+    ASSERT_NE(leavesByObject.find(entry.first), leavesByObject.end());
+    const BroadPhaseDebugNode& leaf = *leavesByObject.at(entry.first);
+    EXPECT_TRUE(leaf.tightAabb.min.isApprox(entry.second.min));
+    EXPECT_TRUE(leaf.tightAabb.max.isApprox(entry.second.max));
+  }
+
+  for (const auto& node : snapshot.nodes) {
+    if (node.isLeaf()) {
+      continue;
+    }
+
+    ASSERT_NE(nodesById.find(node.left), nodesById.end());
+    ASSERT_NE(nodesById.find(node.right), nodesById.end());
+    EXPECT_EQ(nodesById.at(node.left)->parent, node.nodeId);
+    EXPECT_EQ(nodesById.at(node.right)->parent, node.nodeId);
+  }
+}
+
+TEST(AabbTreeBroadPhase, FatAabbOptimization)
+{
+  AabbTreeBroadPhase bp(0.5);
+
+  bp.add(0, makeAabb(0, 1));
+
+  bp.update(
+      0, Aabb(Eigen::Vector3d(0.1, 0.1, 0.1), Eigen::Vector3d(1.1, 1.1, 1.1)));
+  bp.update(
+      0, Aabb(Eigen::Vector3d(0.2, 0.2, 0.2), Eigen::Vector3d(1.2, 1.2, 1.2)));
+  bp.update(
+      0, Aabb(Eigen::Vector3d(0.3, 0.3, 0.3), Eigen::Vector3d(1.3, 1.3, 1.3)));
+
+  EXPECT_EQ(bp.size(), 1u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, FatAabbDoesNotReportLoosePairs)
+{
+  AabbTreeBroadPhase bp(2.0);
+
+  bp.add(0, makeAabb(0, 1));
+  bp.add(1, makeAabb(2.5, 3.5));
+
+  EXPECT_TRUE(bp.queryPairs().empty());
+  EXPECT_TRUE(collectVisitedPairs(bp).empty());
+  EXPECT_TRUE(bp.queryOverlapping(makeAabb(1.4, 1.6)).empty());
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, TreeHeight)
+{
+  AabbTreeBroadPhase bp;
+
+  EXPECT_EQ(bp.getHeight(), 0u);
+
+  bp.add(0, makeAabb(0, 1));
+  EXPECT_EQ(bp.getHeight(), 0u);
+
+  bp.add(1, makeAabb(2, 3));
+  EXPECT_GE(bp.getHeight(), 1u);
+
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, ManyObjects)
+{
+  AabbTreeBroadPhase bp;
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<double> dist(-100.0, 100.0);
+
+  constexpr std::size_t numObjects = 100;
+
+  for (std::size_t i = 0; i < numObjects; ++i) {
+    const double x = dist(rng);
+    const double y = dist(rng);
+    const double z = dist(rng);
+    bp.add(
+        i,
+        Aabb(Eigen::Vector3d(x, y, z), Eigen::Vector3d(x + 1, y + 1, z + 1)));
+  }
+
+  EXPECT_EQ(bp.size(), numObjects);
+  EXPECT_TRUE(bp.validate());
+  (void)bp.queryPairs();
+}
+
+TEST(AabbTreeBroadPhase, RemoveMultiple)
+{
+  AabbTreeBroadPhase bp;
+
+  for (std::size_t i = 0; i < 10u; ++i) {
+    bp.add(i, makeAabb(static_cast<double>(i) * 2.0, i * 2.0 + 1.0));
+  }
+
+  EXPECT_EQ(bp.size(), 10u);
+
+  for (std::size_t i = 0; i < 5u; ++i) {
+    bp.remove(i * 2u);
+  }
+
+  EXPECT_EQ(bp.size(), 5u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, ConsistentWithBruteForce)
+{
+  std::mt19937 rng(123);
+  std::uniform_real_distribution<double> dist(-10.0, 10.0);
+
+  AabbTreeBroadPhase tree;
+  BruteForceBroadPhase brute;
+
+  constexpr std::size_t numObjects = 50;
+
+  for (std::size_t i = 0; i < numObjects; ++i) {
+    const double x = dist(rng);
+    const double y = dist(rng);
+    const double z = dist(rng);
+    const Aabb aabb(
+        Eigen::Vector3d(x, y, z), Eigen::Vector3d(x + 2, y + 2, z + 2));
+
+    tree.add(i, aabb);
+    brute.add(i, aabb);
+  }
+
+  expectExactBruteForceMatch(tree, brute);
+}
+
+TEST(AabbTreeBroadPhase, QueryOverlappingConsistent)
+{
+  std::mt19937 rng(456);
+  std::uniform_real_distribution<double> dist(-10.0, 10.0);
+
+  AabbTreeBroadPhase tree;
+  BruteForceBroadPhase brute;
+
+  constexpr std::size_t numObjects = 30;
+
+  for (std::size_t i = 0; i < numObjects; ++i) {
+    const double x = dist(rng);
+    const double y = dist(rng);
+    const double z = dist(rng);
+    const Aabb aabb(
+        Eigen::Vector3d(x, y, z), Eigen::Vector3d(x + 1, y + 1, z + 1));
+
+    tree.add(i, aabb);
+    brute.add(i, aabb);
+  }
+
+  const Aabb query(Eigen::Vector3d(-5, -5, -5), Eigen::Vector3d(5, 5, 5));
+
+  EXPECT_EQ(tree.queryOverlapping(query), brute.queryOverlapping(query));
+}
+
+TEST(AabbTreeBroadPhase, BulkBuild)
+{
+  const std::vector<std::size_t> ids = {10, 20, 30};
+  const std::vector<Aabb> aabbs
+      = {makeAabb(0, 2), makeAabb(1, 3), makeAabb(10, 11)};
+
+  AabbTreeBroadPhase bp;
+  bp.build(ids, aabbs);
+
+  EXPECT_EQ(bp.size(), 3u);
+
+  auto pairs = bp.queryPairs();
+  ASSERT_EQ(pairs.size(), 1u);
+  EXPECT_EQ(pairs[0].first, 10u);
+  EXPECT_EQ(pairs[0].second, 20u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, BulkUpdateRange)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 1));
+  bp.add(1, makeAabb(10, 11));
+  bp.add(2, makeAabb(20, 21));
+
+  EXPECT_TRUE(bp.queryPairs().empty());
+
+  const std::vector<std::size_t> ids = {1, 2};
+  const std::vector<Aabb> aabbs = {
+      Aabb(Eigen::Vector3d(0.5, 0.5, 0.5), Eigen::Vector3d(1.5, 1.5, 1.5)),
+      Aabb(Eigen::Vector3d(0.8, 0.8, 0.8), Eigen::Vector3d(1.8, 1.8, 1.8)),
+  };
+
+  bp.updateRange(ids, aabbs);
+
+  EXPECT_EQ(bp.queryPairs().size(), 3u);
+  EXPECT_TRUE(bp.validate());
+}
+
+TEST(AabbTreeBroadPhase, QueryPairsWithOutput)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 2));
+  bp.add(1, makeAabb(1, 3));
+
+  std::vector<BroadPhasePair> out;
+  bp.queryPairs(out);
+
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].first, 0u);
+  EXPECT_EQ(out[0].second, 1u);
+}
+
+TEST(AabbTreeBroadPhase, VisitPairsCanStopEarly)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(3, makeAabb(0, 3));
+  bp.add(1, makeAabb(0, 3));
+  bp.add(2, makeAabb(0, 3));
+
+  std::vector<BroadPhasePair> visited;
+  const bool completed = bp.visitPairs([&](std::size_t id1, std::size_t id2) {
+    visited.emplace_back(id1, id2);
+    return false;
+  });
+
+  EXPECT_FALSE(completed);
+  ASSERT_EQ(visited.size(), 1u);
+  EXPECT_EQ(visited[0], BroadPhasePair(1u, 2u));
+
+  visited.clear();
+  EXPECT_TRUE(bp.visitPairs([&](std::size_t id1, std::size_t id2) {
+    visited.emplace_back(id1, id2);
+    return true;
+  }));
+  EXPECT_EQ(visited, bp.queryPairs());
+}
+
+TEST(AabbTreeBroadPhase, QueryPairsFiltered)
+{
+  AabbTreeBroadPhase bp;
+
+  bp.add(0, makeAabb(0, 3));
+  bp.add(1, makeAabb(1, 4));
+  bp.add(2, makeAabb(2, 5));
+
+  auto allPairs = bp.queryPairs();
+  EXPECT_EQ(allPairs.size(), 3u);
+
+  std::vector<BroadPhasePair> filtered;
+  bp.queryPairsFiltered(filtered, [](std::size_t id1, std::size_t id2) {
+    return id1 == 0u || id2 == 0u;
+  });
+
+  EXPECT_EQ(filtered.size(), 2u);
+  for (const auto& pair : filtered) {
+    EXPECT_TRUE(pair.first == 0u || pair.second == 0u);
+  }
+
+  filtered.clear();
+  bp.queryPairsFiltered(
+      filtered, [](std::size_t, std::size_t) { return false; });
+  EXPECT_TRUE(filtered.empty());
+}
+
+TEST(AabbTreeBroadPhase, RandomizedExactEquivalenceWithBruteForce)
+{
+  std::mt19937 rng(20260710);
+  std::uniform_real_distribution<double> centerDist(-25.0, 25.0);
+  std::uniform_real_distribution<double> extentDist(0.05, 1.75);
+  std::uniform_int_distribution<int> objectDist(0, 199);
+
+  constexpr std::size_t numObjects = 200;
+
+  AabbTreeBroadPhase tree;
+  BruteForceBroadPhase brute;
+  std::vector<Aabb> aabbs(numObjects);
+  std::vector<bool> active(numObjects, true);
+  std::vector<std::size_t> ids(numObjects);
+  std::iota(ids.begin(), ids.end(), 0u);
+  std::shuffle(ids.begin(), ids.end(), rng);
+
+  auto randomAabb = [&]() {
+    const Eigen::Vector3d center(
+        centerDist(rng), centerDist(rng), centerDist(rng));
+    const Eigen::Vector3d halfExtents(
+        extentDist(rng), extentDist(rng), extentDist(rng));
+    return makeAabb(center, halfExtents);
+  };
+
+  for (const std::size_t id : ids) {
+    aabbs[id] = randomAabb();
+    tree.add(id, aabbs[id]);
+    brute.add(id, aabbs[id]);
+  }
+
+  expectExactBruteForceMatch(tree, brute);
+
+  for (int step = 0; step < 8; ++step) {
+    for (int update = 0; update < 80; ++update) {
+      const std::size_t id = static_cast<std::size_t>(objectDist(rng));
+      aabbs[id] = randomAabb();
+      tree.update(id, aabbs[id]);
+      brute.update(id, aabbs[id]);
+    }
+
+    expectExactBruteForceMatch(tree, brute);
+
+    for (int remove = 0; remove < 12; ++remove) {
+      const std::size_t id = static_cast<std::size_t>(objectDist(rng));
+      active[id] = false;
+      tree.remove(id);
+      brute.remove(id);
+    }
+
+    expectExactBruteForceMatch(tree, brute);
+
+    std::vector<std::size_t> buildIds;
+    std::vector<Aabb> buildAabbs;
+    for (std::size_t id = 0; id < numObjects; ++id) {
+      if (active[id]) {
+        buildIds.push_back(id);
+        buildAabbs.push_back(aabbs[id]);
+      }
+    }
+
+    tree.build(buildIds, buildAabbs);
+    brute.build(buildIds, buildAabbs);
+    expectExactBruteForceMatch(tree, brute);
+
+    std::vector<std::size_t> updateIds;
+    std::vector<Aabb> updateAabbs;
+    for (int update = 0; update < 60; ++update) {
+      const std::size_t id = static_cast<std::size_t>(objectDist(rng));
+      aabbs[id] = randomAabb();
+      updateIds.push_back(id);
+      updateAabbs.push_back(aabbs[id]);
+    }
+
+    tree.updateRange(updateIds, updateAabbs);
+    brute.updateRange(updateIds, updateAabbs);
+    expectExactBruteForceMatch(tree, brute);
+  }
+}

--- a/tests/unit/collision/native/test_aabb_tree.cpp
+++ b/tests/unit/collision/native/test_aabb_tree.cpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <numeric>
 #include <random>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -698,5 +699,45 @@ TEST(AabbTreeBroadPhase, RandomizedExactEquivalenceWithBruteForce)
     tree.updateRange(updateIds, updateAabbs);
     brute.updateRange(updateIds, updateAabbs);
     expectExactBruteForceMatch(tree, brute);
+  }
+}
+
+//==============================================================================
+TEST(AabbTreeBroadPhase, VisitPairsAnyOrderMatchesPairSetAndStopsEarly)
+{
+  AabbTreeBroadPhase tree;
+  std::mt19937 rng(20260710u);
+  std::uniform_real_distribution<double> pos(-5.0, 5.0);
+  std::uniform_real_distribution<double> extent(0.2, 1.5);
+  for (std::size_t id = 0; id < 128; ++id) {
+    const Eigen::Vector3d center(pos(rng), pos(rng), pos(rng));
+    const Eigen::Vector3d half = Eigen::Vector3d::Constant(extent(rng)) * 0.5;
+    tree.add(id, Aabb(center - half, center + half));
+  }
+
+  const auto ordered = tree.queryPairs();
+  std::set<BroadPhasePair> orderedSet(ordered.begin(), ordered.end());
+
+  // The any-order walk may emit duplicates but must cover exactly the same
+  // pair set as the ordered walk.
+  std::set<BroadPhasePair> streamedSet;
+  const bool completed
+      = tree.visitPairsAnyOrder([&](std::size_t first, std::size_t second) {
+          streamedSet.emplace(first, second);
+          return true;
+        });
+  EXPECT_TRUE(completed);
+  EXPECT_EQ(streamedSet, orderedSet);
+
+  // Early exit: the traversal must stop at the first rejection instead of
+  // materializing/visiting the remaining candidates.
+  if (!orderedSet.empty()) {
+    std::size_t visited = 0;
+    const bool aborted = tree.visitPairsAnyOrder([&](std::size_t, std::size_t) {
+      ++visited;
+      return false;
+    });
+    EXPECT_FALSE(aborted);
+    EXPECT_EQ(visited, 1u);
   }
 }


### PR DESCRIPTION
## Summary

Native-collision-port **Phase 4** optimization: ports DART 7's dynamic AABB tree (SAH build, fat AABBs, incremental add/update/remove) to `dart/collision/native/broad_phase/AabbTree.{hpp,cpp}` (C++17, `detail/Span.hpp` shim, no EnTT) and makes it the `NativeCollisionGroup` broadphase. This replaces the O(n²) BruteForce pair loop that profiling showed dominating many-object scenes (collide stage 28.7 ms/step of native's 51.7 on the 1-thread active-3k scene, vs 4.0 ms for the `dart` detector). BruteForce remains compiled and tested as the reference implementation.

## Determinism (bit-identical by construction and by measurement)

The tree culls with fat AABBs but emits a leaf pair only when **tight** AABBs overlap, normalizes to (min,max) ids, sorts, and deduplicates — reproducing BruteForce's exact pair set and visitation order. A randomized unit test asserts `AabbTree == BruteForce` pair lists (exact order) across add/update/remove/build/updateRange cycles, alongside the ported DART 7 tree tests.

A/B on this branch vs its parent `db255a08e8e` (parent values from the same-day full-matrix audit on the same host): **all eight native guard rows keep bit-identical final-state hashes, contacts, pairs, and resting counts.**

| Row | Parent ms/step | Branch ms/step | Δ | Hash (identical) |
| --- | ---: | ---: | ---: | --- |
| S1 60-object t1 | 1.145 | 1.213 | ~noise | `0x1e227311a3f7188e` |
| S1 120-object t1 | 6.548 | 6.161 | −6% | `0xd6736cd716faf01d` |
| S2 settled 3k t1 | 0.0809 | **0.0340** | **−58%** | `0x266da31836a314a6` |
| S3 active 3k t16 | 34.63 | **12.28** | **−65%** | `0x6088ea0177efa6a` |
| S3 active 3k t1 (100 steps) | 51.7 (profiled) | 22.6 | −56% | `0x5a5dc6511f7b550` |
| S4 generated 900 t16 | 0.1247 | 0.0722 | −42% | `0x55bf77ebc1c491b2` |
| S5 serial 90 t1 | 0.0051 | 0.0066 | µs-scale noise | `0x4f265a803b596035` |
| S6 creep 71 (20k steps) | 6.99 | 6.25 | −11% | `0x8ac15064d89b73ad` |

Untouched-detector spot checks unchanged (`S3_dart = 0xcf0ba6eaa97be038`, `S4_fcl = 0xea9b68f8b062600d`).

`BM_ContactContainerActive` native rows (3-rep means): 60/4/1 236→213 ms, 120/4/1 1404→1232 ms, 120/4/16 1332→1224 ms.

Settled 3k native now matches the `dart` detector (0.0340 vs 0.0346 ms/step); active 3k narrows to 12.3 vs 9.1 ms/step — the remaining gap is narrowphase/manifold-cache side and stays on the Phase 4 list, along with the S6 native resting-profile gap (unchanged by this PR; tracked separately).

## Validation

- `ctest -R UNIT_collision_native` → 23/23 (includes new `test_aabb_tree` + equivalence test).
- `rg 'entt|std::span' dart/collision/native/broad_phase/AabbTree.*` → empty.
- `pixi run lint` + `pixi run check-lint` clean.
- Artifacts: parent `/tmp/audit_head_20260710T011207Z`, branch `/tmp/aabbtree_ab_20260710T022954Z` (i9-13950HX, powersave, GCC Release).