### PR TITLE
MJCF parser fidelity: stacked joint compositions, contype/conaffinity filtering, and geom friction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,11 @@
 
 * Simulation
 
+  * Improve MJCF loading fidelity by supporting stacked hinge/slide joint
+    compositions, enforcing `contype`/`conaffinity` collision filtering, and
+    applying per-geom friction while preserving automatic deactivation:
+    [#3369](https://github.com/dartsim/dart/pull/3369)
+
   * Add World-owned simulation memory management and optional
     `World::enterSimulationMode()` preparation so DART-owned native-collision
     same-shape simulation steps can run without steady-state heap allocations

--- a/dart/collision/CollisionFilter.hpp
+++ b/dart/collision/CollisionFilter.hpp
@@ -124,6 +124,10 @@ public:
       const CollisionObject* object1,
       const CollisionObject* object2) const override;
 
+protected:
+  /// Returns the blacklist-only revision for snapshot tracking in subclasses.
+  std::size_t getBodyNodePairBlackListRevision() const;
+
 private:
   friend class detail::BodyNodeCollisionFilterAccessor;
   friend class constraint::ConstraintSolver;
@@ -141,9 +145,6 @@ private:
   bool areAdjacentBodies(
       const dynamics::BodyNode* bodyNode1,
       const dynamics::BodyNode* bodyNode2) const;
-
-  /// Returns the blacklist-only revision for world-level rest snapshots.
-  std::size_t getBodyNodePairBlackListRevision() const;
 
   /// Returns true if solver-only resting-pair filtering is active on this
   /// thread.

--- a/dart/collision/detail/CollisionFilterSnapshotTracker.hpp
+++ b/dart/collision/detail/CollisionFilterSnapshotTracker.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_COLLISION_DETAIL_COLLISIONFILTERSNAPSHOTTRACKER_HPP_
+#define DART_COLLISION_DETAIL_COLLISIONFILTERSNAPSHOTTRACKER_HPP_
+
+#include <cstddef>
+
+namespace dart {
+namespace collision {
+namespace detail {
+
+/// Internal opt-in contract for collision filters whose decision-changing
+/// state can be represented by a revision. Filters that do not implement this
+/// contract remain conservatively untrackable by simulation snapshots.
+class CollisionFilterSnapshotTracker
+{
+public:
+  virtual ~CollisionFilterSnapshotTracker() = default;
+
+  virtual std::size_t getCollisionFilterSnapshotRevision() const = 0;
+};
+
+} // namespace detail
+} // namespace collision
+} // namespace dart
+
+#endif // DART_COLLISION_DETAIL_COLLISIONFILTERSNAPSHOTTRACKER_HPP_

--- a/dart/simulation/World.cpp
+++ b/dart/simulation/World.cpp
@@ -42,6 +42,7 @@
 #include "dart/collision/CollisionFilter.hpp"
 #include "dart/collision/CollisionGroup.hpp"
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/collision/detail/CollisionFilterSnapshotTracker.hpp"
 #include "dart/collision/fcl/FCLCollisionDetector.hpp"
 #include "dart/common/Console.hpp"
 #include "dart/common/Logging.hpp"
@@ -2296,13 +2297,23 @@ bool World::isCollisionFilterSnapshotTrackable(
   if (filter == nullptr)
     return true;
 
-  return typeid(*filter) == typeid(collision::BodyNodeCollisionFilter);
+  return typeid(*filter) == typeid(collision::BodyNodeCollisionFilter)
+         || dynamic_cast<
+                const collision::detail::CollisionFilterSnapshotTracker*>(
+                filter)
+                != nullptr;
 }
 
 //==============================================================================
 std::size_t World::getCollisionFilterSnapshotRevision(
     const collision::CollisionFilter* filter) const
 {
+  const auto* snapshotTracker
+      = dynamic_cast<const collision::detail::CollisionFilterSnapshotTracker*>(
+          filter);
+  if (snapshotTracker != nullptr)
+    return snapshotTracker->getCollisionFilterSnapshotRevision();
+
   const auto* bodyNodeFilter
       = dynamic_cast<const collision::BodyNodeCollisionFilter*>(filter);
   if (bodyNodeFilter == nullptr)

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -758,6 +758,13 @@ bool populateSkeletonRecurse(
   DART_ASSERT(bodyNode != nullptr);
   DART_ASSERT(joint != nullptr);
 
+  // Expanding a stacked joint inserts synthetic BodyNodes between the MJCF
+  // parent and its real child. Preserve their original adjacency so ordinary
+  // self-collision still suppresses the pair unless adjacent checks are
+  // explicitly enabled.
+  if (parentBodyNode && bodyNode->getParentBodyNode() != parentBodyNode)
+    collisionFilter.addLogicalAdjacentBodyPair(parentBodyNode, bodyNode);
+
   // Create ShapeNodes for the current BodyNode
   if (!createShapeNodes(bodyNode, mjcfBody, mjcfAsset, collisionFilter))
     return false;

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -92,8 +92,12 @@ void createJointCommonProperties(
   // Name
   if (!mjcfJoint.getName().empty()) {
     props.mName = mjcfJoint.getName();
-  } else {
+  } else if (parentBodyNode) {
     props.mName = parentBodyNode->getName() + "_Joint";
+  } else {
+    // Root joint without a name and without a parent BodyNode (e.g. the
+    // first joint of a root body's joint stack).
+    props.mName = "World_Joint";
   }
 }
 
@@ -794,8 +798,23 @@ simulation::WorldPtr createWorld(
     // name rather than skel->getRootBodyNode()->getName(): if mjcfRootBody
     // itself has a stack of joints, DART's actual root BodyNode is one of
     // the synthetic intermediate links created for that stack, not the body
-    // named in the MJCF file.
-    skel->setName(mjcfRootBody.getName());
+    // named in the MJCF file. Unnamed root bodies keep the pre-existing
+    // behavior of inheriting a generated BodyNode name, taken from the last
+    // (real) BodyNode so a synthetic intermediate link never names the
+    // skeleton.
+    if (!mjcfRootBody.getName().empty()) {
+      skel->setName(mjcfRootBody.getName());
+    } else {
+      // Synthetic links are created before the real root body, so the first
+      // BodyNode without the marker is the real one.
+      for (std::size_t i = 0u; i < skel->getNumBodyNodes(); ++i) {
+        const auto* bodyNode = skel->getBodyNode(i);
+        if (bodyNode->getName().find("__mjcf_dof") == std::string::npos) {
+          skel->setName(bodyNode->getName());
+          break;
+        }
+      }
+    }
 
     // Skeleton name should be unique in the World.
     if (world->hasSkeleton(skel->getName())) {

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -255,6 +255,139 @@ dynamics::RevoluteJoint::Properties createRevoluteJointProperties(
 }
 
 //==============================================================================
+bool canChainJointStack(const detail::Body& mjcfBody)
+{
+  // The generic joint-stack chain built by createJointChainForStackedJoints()
+  // below only knows how to translate hinge and slide joints into Revolute-
+  // and PrismaticJoints respectively. Free and ball joints cannot appear
+  // alongside other joints under a valid MJCF <body> in the first place, so
+  // excluding them here just makes that assumption explicit.
+  for (auto i = 0u; i < mjcfBody.getNumJoints(); ++i) {
+    const auto type = mjcfBody.getJoint(i).getType();
+    if (type != detail::JointType::HINGE && type != detail::JointType::SLIDE)
+      return false;
+  }
+  return true;
+}
+
+//==============================================================================
+// Creates a chain of single-DOF joints for a MJCF <body> that lists more
+// <joint> elements than DART has a predefined multi-DOF joint for (i.e. any
+// combination of hinges/slides other than 2 or 3 slides).
+//
+// Per the MuJoCo XML reference, when several joints are defined on the same
+// body, they are applied in listed order (the first joint is closest to the
+// parent body) and every joint's pos/axis is expressed in the same
+// undisplaced frame of the owning body -- not chained relative to whatever
+// the previous joint in the stack did. We reproduce that by threading a chain
+// of massless, shapeless intermediate BodyNodes (one per joint except the
+// last) between the real parent body and the real (final) BodyNode, with one
+// RevoluteJoint per hinge and one PrismaticJoint per slide.
+//
+// Each intermediate BodyNode's local frame is defined to coincide with the
+// owning body's nominal (rest) frame, i.e. mjcfBody.getRelativeTransform()
+// relative to the real parent. That is what lets every sub-joint use its own
+// pos/axis directly as T_ChildBodyToJoint: only the first joint in the chain
+// additionally needs mjcfBody.getRelativeTransform() to reach that nominal
+// frame from the real parent; every later joint's immediate parent already
+// *is* that frame by construction, so its T_ParentBodyToJoint collapses to
+// exactly its own T_ChildBodyToJoint.
+std::pair<dynamics::Joint*, dynamics::BodyNode*>
+createJointChainForStackedJoints(
+    dynamics::SkeletonPtr skel,
+    dynamics::BodyNode* parentBodyNode,
+    const dynamics::BodyNode::Properties& bodyProps,
+    const detail::Body& mjcfBody)
+{
+  const auto numJoints = mjcfBody.getNumJoints();
+  DART_ASSERT(numJoints >= 2u);
+
+  dynamics::BodyNode* currentParent = parentBodyNode;
+  dynamics::Joint* joint = nullptr;
+  dynamics::BodyNode* bodyNode = nullptr;
+
+  for (auto i = 0u; i < numJoints; ++i) {
+    const detail::Joint& mjcfJoint = mjcfBody.getJoint(i);
+    const bool isFinalJoint = (i + 1u == numJoints);
+
+    // Joint pos/axis are given in the owning body's nominal (undisplaced)
+    // local frame, regardless of this joint's position in the stack.
+    Eigen::Isometry3d childBodyToJoint = Eigen::Isometry3d::Identity();
+    childBodyToJoint.translation() = mjcfJoint.getPos();
+    childBodyToJoint.linear()
+        = Eigen::Quaterniond::FromTwoVectors(
+              Eigen::Vector3d::UnitZ(), mjcfJoint.getAxis())
+              .toRotationMatrix();
+
+    const Eigen::Isometry3d parentBodyToJoint
+        = (i == 0u) ? mjcfBody.getRelativeTransform() * childBodyToJoint
+                    : childBodyToJoint;
+
+    dynamics::BodyNode::Properties currentBodyProps;
+    if (isFinalJoint) {
+      currentBodyProps = bodyProps;
+    } else {
+      currentBodyProps.mName
+          = mjcfBody.getName() + "__mjcf_dof" + std::to_string(i);
+      // Intermediate links only exist to carry a single DOF each; they have
+      // no shape and no mass of their own.
+      currentBodyProps.mInertia = dynamics::Inertia(
+          0.0, Eigen::Vector3d::Zero(), Eigen::Matrix3d::Zero());
+    }
+
+    if (mjcfJoint.getType() == detail::JointType::HINGE) {
+      dynamics::RevoluteJoint::Properties props;
+      createJointCommonProperties(props, currentParent, mjcfBody, mjcfJoint);
+
+      props.mAxis = Eigen::Vector3d::UnitZ();
+      props.mT_ChildBodyToJoint = childBodyToJoint;
+      props.mT_ParentBodyToJoint = parentBodyToJoint;
+
+      props.mIsPositionLimitEnforced = mjcfJoint.isLimited();
+      props.mPositionLowerLimits[0] = mjcfJoint.getRange()[0];
+      props.mPositionUpperLimits[0] = mjcfJoint.getRange()[1];
+
+      props.mDampingCoefficients[0] = mjcfJoint.getDamping();
+      props.mRestPositions[0] = mjcfJoint.getSpringRef();
+
+      props.mDofNames[0] = mjcfJoint.getName();
+      props.mPreserveDofNames[0] = true;
+
+      std::tie(joint, bodyNode)
+          = skel->createJointAndBodyNodePair<dynamics::RevoluteJoint>(
+              currentParent, props, currentBodyProps);
+    } else {
+      DART_ASSERT(mjcfJoint.getType() == detail::JointType::SLIDE);
+
+      dynamics::PrismaticJoint::Properties props;
+      createJointCommonProperties(props, currentParent, mjcfBody, mjcfJoint);
+
+      props.mAxis = Eigen::Vector3d::UnitZ();
+      props.mT_ChildBodyToJoint = childBodyToJoint;
+      props.mT_ParentBodyToJoint = parentBodyToJoint;
+
+      props.mIsPositionLimitEnforced = mjcfJoint.isLimited();
+      props.mPositionLowerLimits[0] = mjcfJoint.getRange()[0];
+      props.mPositionUpperLimits[0] = mjcfJoint.getRange()[1];
+
+      props.mDampingCoefficients[0] = mjcfJoint.getDamping();
+      props.mRestPositions[0] = mjcfJoint.getSpringRef();
+
+      props.mDofNames[0] = mjcfJoint.getName();
+      props.mPreserveDofNames[0] = true;
+
+      std::tie(joint, bodyNode)
+          = skel->createJointAndBodyNodePair<dynamics::PrismaticJoint>(
+              currentParent, props, currentBodyProps);
+    }
+
+    currentParent = bodyNode;
+  }
+
+  return std::make_pair(joint, bodyNode);
+}
+
+//==============================================================================
 std::pair<dynamics::Joint*, dynamics::BodyNode*>
 createJointAndBodyNodePairForMultipleJoints(
     dynamics::SkeletonPtr skel,
@@ -381,6 +514,13 @@ createJointAndBodyNodePairForMultipleJoints(
       return skel->createJointAndBodyNodePair<dynamics::TranslationalJoint>(
           parentBodyNode, props, bodyProps);
     }
+  }
+
+  // Fall back to a chain of single-DOF joints for any other stack of
+  // hinge/slide joints (e.g. hinge+hinge, or hinge mixed with slide).
+  if (canChainJointStack(mjcfBody)) {
+    return createJointChainForStackedJoints(
+        skel, parentBodyNode, bodyProps, mjcfBody);
   }
 
   dterr << "[MjcfParser] Attempted to create unsupported joint composition.\n";
@@ -650,8 +790,12 @@ simulation::WorldPtr createWorld(
     // MuJoCo doesn't have a concept that corresponds to DART Skeleton so no
     // name for Skeleton. We use the name of the root body instead. The root
     // body name will be unique anyway because all the MuJoCo body name are
-    // unique in the same <worldbody>.
-    skel->setName(skel->getRootBodyNode()->getName());
+    // unique in the same <worldbody>. Note this must be mjcfRootBody's own
+    // name rather than skel->getRootBodyNode()->getName(): if mjcfRootBody
+    // itself has a stack of joints, DART's actual root BodyNode is one of
+    // the synthetic intermediate links created for that stack, not the body
+    // named in the MJCF file.
+    skel->setName(mjcfRootBody.getName());
 
     // Skeleton name should be unique in the World.
     if (world->hasSkeleton(skel->getName())) {

--- a/dart/utils/mjcf/MjcfParser.cpp
+++ b/dart/utils/mjcf/MjcfParser.cpp
@@ -41,6 +41,7 @@
 #include "dart/utils/CompositeResourceRetriever.hpp"
 #include "dart/utils/DartResourceRetriever.hpp"
 #include "dart/utils/XmlHelpers.hpp"
+#include "dart/utils/mjcf/detail/GeomCollisionFilter.hpp"
 #include "dart/utils/mjcf/detail/MujocoModel.hpp"
 #include "dart/utils/mjcf/detail/Utils.hpp"
 #include "dart/utils/mjcf/detail/Worldbody.hpp"
@@ -611,7 +612,8 @@ dynamics::ShapePtr createShape(
 bool createShapeNodes(
     dynamics::BodyNode* bodyNode,
     const detail::Body& mjcfBody,
-    const detail::Asset& mjcfAsset)
+    const detail::Asset& mjcfAsset,
+    detail::GeomCollisionFilter& collisionFilter)
 {
   // Create ShapeNodes for <geom>s
   for (std::size_t i = 0u; i < mjcfBody.getNumGeoms(); ++i) {
@@ -624,17 +626,35 @@ bool createShapeNodes(
       return false;
     }
 
+    const int contype = geom.getConType();
+    const int conaffinity = geom.getConAffinity();
+
+    // Following MuJoCo, a geom with contype == 0 and conaffinity == 0 can
+    // never take part in any collision pair (see the contype/conaffinity
+    // rule at http://mujoco.org/book/computation.html#coCollision), so it is
+    // created as a visual-only ShapeNode. This also matches mocap bodies,
+    // which MuJoCo never collides.
+    const bool hasCollision
+        = !mjcfBody.getMocap() && ((contype != 0) || (conaffinity != 0));
+
     // Create ShapeNode with the shape created above
     dynamics::ShapeNode* shapeNode = nullptr;
-    if (mjcfBody.getMocap()) {
-      // Disable collision and dynamics for mocap bodies
-      shapeNode = bodyNode->createShapeNodeWith<dynamics::VisualAspect>(
-          shape, geom.getName());
-    } else {
+    if (hasCollision) {
       shapeNode = bodyNode->createShapeNodeWith<
           dynamics::VisualAspect,
           dynamics::CollisionAspect,
           dynamics::DynamicsAspect>(shape, geom.getName());
+
+      // Sliding friction coefficient. MuJoCo's friction attribute is
+      // (sliding, torsional, rolling); DART's DynamicsAspect only models a
+      // single (isotropic) Coulomb friction coefficient, so only the sliding
+      // component is applied.
+      shapeNode->getDynamicsAspect()->setFrictionCoeff(geom.getFriction()[0]);
+
+      collisionFilter.setGeomBitmasks(shapeNode, contype, conaffinity);
+    } else {
+      shapeNode = bodyNode->createShapeNodeWith<dynamics::VisualAspect>(
+          shape, geom.getName());
     }
 
     // RGBA
@@ -681,7 +701,8 @@ bool populateSkeletonRecurse(
     dynamics::SkeletonPtr skel,
     dynamics::BodyNode* parentBodyNode,
     const detail::Body& mjcfBody,
-    const detail::Asset& mjcfAsset)
+    const detail::Asset& mjcfAsset,
+    detail::GeomCollisionFilter& collisionFilter)
 {
   dynamics::BodyNode* bodyNode = nullptr;
   dynamics::Joint* joint = nullptr;
@@ -738,12 +759,16 @@ bool populateSkeletonRecurse(
   DART_ASSERT(joint != nullptr);
 
   // Create ShapeNodes for the current BodyNode
-  if (!createShapeNodes(bodyNode, mjcfBody, mjcfAsset))
+  if (!createShapeNodes(bodyNode, mjcfBody, mjcfAsset, collisionFilter))
     return false;
 
   for (auto i = 0u; i < mjcfBody.getNumChildBodies(); ++i) {
     if (!populateSkeletonRecurse(
-            skel, bodyNode, mjcfBody.getChildBody(i), mjcfAsset)) {
+            skel,
+            bodyNode,
+            mjcfBody.getChildBody(i),
+            mjcfAsset,
+            collisionFilter)) {
       return false;
     }
   }
@@ -753,12 +778,14 @@ bool populateSkeletonRecurse(
 
 //==============================================================================
 dynamics::SkeletonPtr createSkeleton(
-    const detail::Body& mjcfBody, const detail::Asset& mjcfAsset)
+    const detail::Body& mjcfBody,
+    const detail::Asset& mjcfAsset,
+    detail::GeomCollisionFilter& collisionFilter)
 {
   dynamics::SkeletonPtr skel = dynamics::Skeleton::create();
 
-  const bool success
-      = populateSkeletonRecurse(skel, nullptr, mjcfBody, mjcfAsset);
+  const bool success = populateSkeletonRecurse(
+      skel, nullptr, mjcfBody, mjcfAsset, collisionFilter);
   if (!success) {
     const std::string bodyName
         = mjcfBody.getName().empty() ? "(noname)" : mjcfBody.getName();
@@ -780,10 +807,16 @@ simulation::WorldPtr createWorld(
   const detail::Asset& mjcfAsset = mujoco.getAsset();
   const detail::Worldbody& mjcfWorldbody = mujoco.getWorldbody();
 
+  // Collects the contype/conaffinity bitmasks of every ShapeNode created from
+  // an MJCF <geom> so that MuJoCo's collision pair rule can be enforced by a
+  // single World-wide CollisionFilter. See GeomCollisionFilter for details.
+  auto collisionFilter = std::make_shared<detail::GeomCollisionFilter>();
+
   // Parse root <body> elements
   for (std::size_t i = 0; i < mjcfWorldbody.getNumRootBodies(); ++i) {
     const detail::Body& mjcfRootBody = mjcfWorldbody.getRootBody(i);
-    const dynamics::SkeletonPtr& skel = createSkeleton(mjcfRootBody, mjcfAsset);
+    const dynamics::SkeletonPtr& skel
+        = createSkeleton(mjcfRootBody, mjcfAsset, *collisionFilter);
 
     if (skel == nullptr) {
       dterr << "[MjcfParser] Failed to parse a Skeleton. Stop parsing the "
@@ -845,10 +878,24 @@ simulation::WorldPtr createWorld(
 
     joint->setTransformFromParentBodyNode(mjcfGeom.getRelativeTransform());
     dynamics::ShapePtr shape = createShape(mjcfGeom, mjcfAsset);
-    dynamics::ShapeNode* shapeNode = body->createShapeNodeWith<
-        dynamics::VisualAspect,
-        dynamics::CollisionAspect,
-        dynamics::DynamicsAspect>(shape);
+
+    const int contype = mjcfGeom.getConType();
+    const int conaffinity = mjcfGeom.getConAffinity();
+    const bool hasCollision = (contype != 0) || (conaffinity != 0);
+
+    dynamics::ShapeNode* shapeNode = nullptr;
+    if (hasCollision) {
+      shapeNode = body->createShapeNodeWith<
+          dynamics::VisualAspect,
+          dynamics::CollisionAspect,
+          dynamics::DynamicsAspect>(shape);
+      shapeNode->getDynamicsAspect()->setFrictionCoeff(
+          mjcfGeom.getFriction()[0]);
+      collisionFilter->setGeomBitmasks(shapeNode, contype, conaffinity);
+    } else {
+      shapeNode = body->createShapeNodeWith<dynamics::VisualAspect>(shape);
+    }
+
     dynamics::VisualAspect* visualAspect = shapeNode->getVisualAspect();
 
     // TODO(JS): Check whether this object use material instead of RGBA
@@ -891,6 +938,12 @@ simulation::WorldPtr createWorld(
 
     world->addSkeleton(skel);
   }
+
+  // Install the MuJoCo contype/conaffinity pair rule on top of DART's default
+  // collision filtering behavior (self-collision/adjacent-body handling,
+  // etc.), which GeomCollisionFilter inherits from BodyNodeCollisionFilter.
+  world->getConstraintSolver()->getCollisionOption().collisionFilter
+      = collisionFilter;
 
   return world;
 }

--- a/dart/utils/mjcf/detail/Default.cpp
+++ b/dart/utils/mjcf/detail/Default.cpp
@@ -144,8 +144,15 @@ const Default* Defaults::getDefault(const std::string& className) const
 //==============================================================================
 const Default* Defaults::getRootDefault() const
 {
-  DART_ASSERT(hasDefault(mRootClassName));
-  return getDefault(mRootClassName);
+  if (const Default* root = getDefault(mRootClassName)) {
+    return root;
+  }
+
+  // MJCF files are valid without a <default> element; fall back to MuJoCo's
+  // built-in attribute defaults so downstream readers never receive a null
+  // root class.
+  static const Default defaultRoot;
+  return &defaultRoot;
 }
 
 //==============================================================================

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
@@ -34,6 +34,7 @@
 
 #include "dart/collision/CollisionObject.hpp"
 #include "dart/dynamics/BodyNode.hpp"
+#include "dart/dynamics/ShapeNode.hpp"
 #include "dart/dynamics/Skeleton.hpp"
 
 namespace dart {
@@ -48,7 +49,10 @@ void GeomCollisionFilter::setGeomBitmasks(
   if (!shapeFrame)
     return;
 
-  mBitmasks[shapeFrame] = Bitmasks{contype, conaffinity};
+  const auto* shapeNode = shapeFrame->asShapeNode();
+  const auto* bodyNode = shapeNode ? shapeNode->getBodyNode() : nullptr;
+  mBitmasks[shapeFrame] = Bitmasks{
+      contype, conaffinity, dynamics::WeakConstBodyNodePtr(bodyNode)};
   ++mDecisionRevision;
 }
 
@@ -60,6 +64,10 @@ void GeomCollisionFilter::addLogicalAdjacentBodyPair(
     return;
 
   mLogicalAdjacentBodyPairs.addPair(bodyNode1, bodyNode2);
+  mLogicalAdjacentBodyOwners[bodyNode1]
+      = dynamics::WeakConstBodyNodePtr(bodyNode1);
+  mLogicalAdjacentBodyOwners[bodyNode2]
+      = dynamics::WeakConstBodyNodePtr(bodyNode2);
   ++mDecisionRevision;
 }
 
@@ -80,7 +88,10 @@ bool GeomCollisionFilter::ignoresCollision(
     const auto* skeleton = bodyNode1->getSkeletonRawPtr();
     if (skeleton && !skeleton->isEnabledAdjacentBodyCheck()
         && mLogicalAdjacentBodyPairs.contains(bodyNode1, bodyNode2)) {
-      return true;
+      const auto tracked1 = mLogicalAdjacentBodyOwners.at(bodyNode1).lock();
+      const auto tracked2 = mLogicalAdjacentBodyOwners.at(bodyNode2).lock();
+      if (tracked1.get() == bodyNode1 && tracked2.get() == bodyNode2)
+        return true;
     }
   }
 
@@ -91,6 +102,14 @@ bool GeomCollisionFilter::ignoresCollision(
     // default behavior for this pair.
     return false;
   }
+
+  // ShapeFrame and BodyNode addresses can be recycled after a Skeleton is
+  // removed from a mutable World. Only apply a registration while its owning
+  // BodyNode is still the one associated with the current collision object.
+  const auto owner1 = it1->second.mOwner.lock();
+  const auto owner2 = it2->second.mOwner.lock();
+  if (owner1.get() != bodyNode1 || owner2.get() != bodyNode2)
+    return false;
 
   const Bitmasks& b1 = it1->second;
   const Bitmasks& b2 = it2->second;

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dart/utils/mjcf/detail/GeomCollisionFilter.hpp"
+
+#include "dart/collision/CollisionObject.hpp"
+
+namespace dart {
+namespace utils {
+namespace MjcfParser {
+namespace detail {
+
+//==============================================================================
+void GeomCollisionFilter::setGeomBitmasks(
+    const dynamics::ShapeFrame* shapeFrame, int contype, int conaffinity)
+{
+  if (!shapeFrame)
+    return;
+
+  mBitmasks[shapeFrame] = Bitmasks{contype, conaffinity};
+}
+
+//==============================================================================
+bool GeomCollisionFilter::ignoresCollision(
+    const collision::CollisionObject* object1,
+    const collision::CollisionObject* object2) const
+{
+  // Preserve DART's default self-collision/adjacent-body/resting-pair
+  // filtering behavior.
+  if (BodyNodeCollisionFilter::ignoresCollision(object1, object2))
+    return true;
+
+  const auto it1 = mBitmasks.find(object1->getShapeFrame());
+  const auto it2 = mBitmasks.find(object2->getShapeFrame());
+  if (it1 == mBitmasks.end() || it2 == mBitmasks.end()) {
+    // At least one side wasn't created from an MJCF <geom>; defer to the
+    // default behavior for this pair.
+    return false;
+  }
+
+  const Bitmasks& b1 = it1->second;
+  const Bitmasks& b2 = it2->second;
+
+  // MuJoCo pair rule: http://mujoco.org/book/computation.html#coCollision
+  const bool mayCollide = ((b1.mContype & b2.mConaffinity) != 0)
+                           || ((b2.mContype & b1.mConaffinity) != 0);
+
+  return !mayCollide;
+}
+
+} // namespace detail
+} // namespace MjcfParser
+} // namespace utils
+} // namespace dart

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
@@ -47,6 +47,7 @@ void GeomCollisionFilter::setGeomBitmasks(
     return;
 
   mBitmasks[shapeFrame] = Bitmasks{contype, conaffinity};
+  ++mBitmaskRevision;
 }
 
 //==============================================================================
@@ -75,6 +76,14 @@ bool GeomCollisionFilter::ignoresCollision(
                           || ((b2.mContype & b1.mConaffinity) != 0);
 
   return !mayCollide;
+}
+
+//==============================================================================
+std::size_t GeomCollisionFilter::getCollisionFilterSnapshotRevision() const
+{
+  std::size_t seed = getBodyNodePairBlackListRevision();
+  seed ^= mBitmaskRevision + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+  return seed;
 }
 
 } // namespace detail

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
@@ -72,7 +72,7 @@ bool GeomCollisionFilter::ignoresCollision(
 
   // MuJoCo pair rule: http://mujoco.org/book/computation.html#coCollision
   const bool mayCollide = ((b1.mContype & b2.mConaffinity) != 0)
-                           || ((b2.mContype & b1.mConaffinity) != 0);
+                          || ((b2.mContype & b1.mConaffinity) != 0);
 
   return !mayCollide;
 }

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.cpp
@@ -33,6 +33,8 @@
 #include "dart/utils/mjcf/detail/GeomCollisionFilter.hpp"
 
 #include "dart/collision/CollisionObject.hpp"
+#include "dart/dynamics/BodyNode.hpp"
+#include "dart/dynamics/Skeleton.hpp"
 
 namespace dart {
 namespace utils {
@@ -47,7 +49,18 @@ void GeomCollisionFilter::setGeomBitmasks(
     return;
 
   mBitmasks[shapeFrame] = Bitmasks{contype, conaffinity};
-  ++mBitmaskRevision;
+  ++mDecisionRevision;
+}
+
+//==============================================================================
+void GeomCollisionFilter::addLogicalAdjacentBodyPair(
+    const dynamics::BodyNode* bodyNode1, const dynamics::BodyNode* bodyNode2)
+{
+  if (!bodyNode1 || !bodyNode2)
+    return;
+
+  mLogicalAdjacentBodyPairs.addPair(bodyNode1, bodyNode2);
+  ++mDecisionRevision;
 }
 
 //==============================================================================
@@ -59,6 +72,17 @@ bool GeomCollisionFilter::ignoresCollision(
   // filtering behavior.
   if (BodyNodeCollisionFilter::ignoresCollision(object1, object2))
     return true;
+
+  const auto* bodyNode1 = object1->getBodyNode();
+  const auto* bodyNode2 = object2->getBodyNode();
+  if (bodyNode1 && bodyNode2
+      && bodyNode1->getSkeletonRawPtr() == bodyNode2->getSkeletonRawPtr()) {
+    const auto* skeleton = bodyNode1->getSkeletonRawPtr();
+    if (skeleton && !skeleton->isEnabledAdjacentBodyCheck()
+        && mLogicalAdjacentBodyPairs.contains(bodyNode1, bodyNode2)) {
+      return true;
+    }
+  }
 
   const auto it1 = mBitmasks.find(object1->getShapeFrame());
   const auto it2 = mBitmasks.find(object2->getShapeFrame());
@@ -82,7 +106,7 @@ bool GeomCollisionFilter::ignoresCollision(
 std::size_t GeomCollisionFilter::getCollisionFilterSnapshotRevision() const
 {
   std::size_t seed = getBodyNodePairBlackListRevision();
-  seed ^= mBitmaskRevision + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+  seed ^= mDecisionRevision + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
   return seed;
 }
 

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
@@ -36,6 +36,8 @@
 #include <dart/collision/CollisionFilter.hpp>
 #include <dart/collision/detail/CollisionFilterSnapshotTracker.hpp>
 
+#include <dart/dynamics/SmartPointer.hpp>
+
 #include <unordered_map>
 
 namespace dart {
@@ -92,6 +94,7 @@ private:
   {
     int mContype;
     int mConaffinity;
+    dynamics::WeakConstBodyNodePtr mOwner;
   };
 
   /// contype/conaffinity bitmasks keyed by the ShapeFrame of the ShapeNode
@@ -101,6 +104,10 @@ private:
   /// Body pairs that remain logically adjacent across synthetic joint links.
   collision::detail::UnorderedPairs<dynamics::BodyNode>
       mLogicalAdjacentBodyPairs;
+
+  /// Lifetime tokens for BodyNodes referenced by logical-adjacency pairs.
+  std::unordered_map<const dynamics::BodyNode*, dynamics::WeakConstBodyNodePtr>
+      mLogicalAdjacentBodyOwners;
 
   /// Revision for changes to parser-owned collision-filter decisions.
   std::size_t mDecisionRevision = 0u;

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
@@ -34,6 +34,7 @@
 #define DART_UTILS_MJCF_DETAIL_GEOMCOLLISIONFILTER_HPP_
 
 #include <dart/collision/CollisionFilter.hpp>
+#include <dart/collision/detail/CollisionFilterSnapshotTracker.hpp>
 
 #include <unordered_map>
 
@@ -62,7 +63,9 @@ namespace detail {
 /// ShapeNodes that were not registered with setGeomBitmasks() (i.e. not
 /// created from an MJCF <geom>) are unaffected by the bitmask rule: the pair
 /// falls back to the inherited BodyNodeCollisionFilter behavior only.
-class GeomCollisionFilter final : public collision::BodyNodeCollisionFilter
+class GeomCollisionFilter final
+  : public collision::BodyNodeCollisionFilter,
+    public collision::detail::CollisionFilterSnapshotTracker
 {
 public:
   /// Registers the contype/conaffinity bitmasks of the MJCF <geom> that
@@ -76,6 +79,9 @@ public:
       const collision::CollisionObject* object1,
       const collision::CollisionObject* object2) const override;
 
+  // Documentation inherited
+  std::size_t getCollisionFilterSnapshotRevision() const override;
+
 private:
   struct Bitmasks
   {
@@ -86,6 +92,9 @@ private:
   /// contype/conaffinity bitmasks keyed by the ShapeFrame of the ShapeNode
   /// created for the owning MJCF <geom>.
   std::unordered_map<const dynamics::ShapeFrame*, Bitmasks> mBitmasks;
+
+  /// Revision for changes to the parser-owned geom bitmask table.
+  std::size_t mBitmaskRevision = 0u;
 };
 
 } // namespace detail

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
@@ -74,6 +74,11 @@ public:
   void setGeomBitmasks(
       const dynamics::ShapeFrame* shapeFrame, int contype, int conaffinity);
 
+  /// Registers a BodyNode pair that was directly adjacent in the MJCF model
+  /// before a stacked joint was expanded into synthetic intermediate links.
+  void addLogicalAdjacentBodyPair(
+      const dynamics::BodyNode* bodyNode1, const dynamics::BodyNode* bodyNode2);
+
   // Documentation inherited
   bool ignoresCollision(
       const collision::CollisionObject* object1,
@@ -93,8 +98,12 @@ private:
   /// created for the owning MJCF <geom>.
   std::unordered_map<const dynamics::ShapeFrame*, Bitmasks> mBitmasks;
 
-  /// Revision for changes to the parser-owned geom bitmask table.
-  std::size_t mBitmaskRevision = 0u;
+  /// Body pairs that remain logically adjacent across synthetic joint links.
+  collision::detail::UnorderedPairs<dynamics::BodyNode>
+      mLogicalAdjacentBodyPairs;
+
+  /// Revision for changes to parser-owned collision-filter decisions.
+  std::size_t mDecisionRevision = 0u;
 };
 
 } // namespace detail

--- a/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
+++ b/dart/utils/mjcf/detail/GeomCollisionFilter.hpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011, The DART development contributors
+ * All rights reserved.
+ *
+ * The list of contributors can be found at:
+ *   https://github.com/dartsim/dart/blob/main/LICENSE
+ *
+ * This file is provided under the following "BSD-style" License:
+ *   Redistribution and use in source and binary forms, with or
+ *   without modification, are permitted provided that the following
+ *   conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ *   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ *   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ *   AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *   POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DART_UTILS_MJCF_DETAIL_GEOMCOLLISIONFILTER_HPP_
+#define DART_UTILS_MJCF_DETAIL_GEOMCOLLISIONFILTER_HPP_
+
+#include <dart/collision/CollisionFilter.hpp>
+
+#include <unordered_map>
+
+namespace dart {
+
+namespace dynamics {
+class ShapeFrame;
+} // namespace dynamics
+
+namespace utils {
+namespace MjcfParser {
+namespace detail {
+
+/// CollisionFilter that reproduces MuJoCo's contype/conaffinity pair rule
+/// (http://mujoco.org/book/computation.html#coCollision) on top of DART's
+/// default BodyNodeCollisionFilter behavior.
+///
+/// Two geoms are allowed to collide iff
+///   (contype_A & conaffinity_B) != 0 || (contype_B & conaffinity_A) != 0
+///
+/// This is combined with (i.e. logically ANDed with) the inherited
+/// BodyNodeCollisionFilter behavior (self-collision/adjacent-body handling,
+/// resting-pair filtering, etc.), so installing this filter never re-enables
+/// a pair that the base filter already excludes.
+///
+/// ShapeNodes that were not registered with setGeomBitmasks() (i.e. not
+/// created from an MJCF <geom>) are unaffected by the bitmask rule: the pair
+/// falls back to the inherited BodyNodeCollisionFilter behavior only.
+class GeomCollisionFilter final : public collision::BodyNodeCollisionFilter
+{
+public:
+  /// Registers the contype/conaffinity bitmasks of the MJCF <geom> that
+  /// created \c shapeFrame. Overwrites any previously registered bitmasks for
+  /// the same ShapeFrame.
+  void setGeomBitmasks(
+      const dynamics::ShapeFrame* shapeFrame, int contype, int conaffinity);
+
+  // Documentation inherited
+  bool ignoresCollision(
+      const collision::CollisionObject* object1,
+      const collision::CollisionObject* object2) const override;
+
+private:
+  struct Bitmasks
+  {
+    int mContype;
+    int mConaffinity;
+  };
+
+  /// contype/conaffinity bitmasks keyed by the ShapeFrame of the ShapeNode
+  /// created for the owning MJCF <geom>.
+  std::unordered_map<const dynamics::ShapeFrame*, Bitmasks> mBitmasks;
+};
+
+} // namespace detail
+} // namespace MjcfParser
+} // namespace utils
+} // namespace dart
+
+#endif // #ifndef DART_UTILS_MJCF_DETAIL_GEOMCOLLISIONFILTER_HPP_

--- a/data/mjcf/test/contype_conaffinity.xml
+++ b/data/mjcf/test/contype_conaffinity.xml
@@ -1,0 +1,26 @@
+<mujoco model="contype_conaffinity">
+  <!--
+    Three mutually-overlapping static spheres used to exercise MuJoCo's
+    contype/conaffinity collision pair rule in isolation:
+
+      collides(A, B) := (contype_A & conaffinity_B) || (contype_B & conaffinity_A)
+
+    bodyA: contype=1 conaffinity=0
+    bodyB: contype=0 conaffinity=1
+    bodyC: contype=1 conaffinity=0 (same masks as bodyA)
+
+    A vs B: (1 & 1) || (0 & 0) = 1 -> collide
+    A vs C: (1 & 0) || (1 & 0) = 0 -> do not collide
+  -->
+  <worldbody>
+    <body name="bodyA" pos="0 0 0">
+      <geom name="geomA" type="sphere" size="0.5" contype="1" conaffinity="0"/>
+    </body>
+    <body name="bodyB" pos="0 0 0">
+      <geom name="geomB" type="sphere" size="0.5" contype="0" conaffinity="1"/>
+    </body>
+    <body name="bodyC" pos="0 0 0">
+      <geom name="geomC" type="sphere" size="0.5" contype="1" conaffinity="0"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/data/mjcf/test/deactivation_filter.xml
+++ b/data/mjcf/test/deactivation_filter.xml
@@ -1,0 +1,11 @@
+<mujoco model="deactivation_filter">
+  <option timestep="0.001" gravity="0 0 -9.81"/>
+  <worldbody>
+    <geom name="floor" type="plane" size="2 2 0.1" contype="1" conaffinity="1"/>
+    <body name="box" pos="0 0 0.5">
+      <freejoint/>
+      <geom name="box_geom" type="box" size="0.5 0.5 0.5"
+            contype="1" conaffinity="1"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/data/mjcf/test/stacked_joint_adjacency.xml
+++ b/data/mjcf/test/stacked_joint_adjacency.xml
@@ -1,0 +1,14 @@
+<mujoco model="stacked_joint_adjacency">
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="parent">
+      <freejoint/>
+      <geom name="parent_geom" type="sphere" size="0.2"/>
+      <body name="stacked_child" pos="0.1 0 0">
+        <joint name="child_hinge_x" type="hinge" axis="1 0 0"/>
+        <joint name="child_hinge_y" type="hinge" axis="0 1 0"/>
+        <geom name="child_geom" type="sphere" size="0.2"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>

--- a/data/mjcf/test/unnamed_root_joint_stack.xml
+++ b/data/mjcf/test/unnamed_root_joint_stack.xml
@@ -1,0 +1,10 @@
+<mujoco model="unnamed_root_joint_stack">
+  <worldbody>
+    <geom name="floor" type="plane" size="2 2 0.1"/>
+    <body pos="0 0 0.5">
+      <joint type="hinge" axis="1 0 0" pos="0 0 0"/>
+      <joint type="hinge" axis="0 1 0" pos="0 0 0"/>
+      <geom name="rotor" type="capsule" fromto="0 0 0 0 0 0.3" size="0.05"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "TestHelpers.hpp"
+#include "dart/collision/native/NativeCollisionDetector.hpp"
 #include "dart/dart.hpp"
 #include "dart/utils/mjcf/detail/MujocoModel.hpp"
 #include "dart/utils/mjcf/detail/Types.hpp"
@@ -40,6 +41,8 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 using namespace dart;
 using namespace utils::MjcfParser::detail;
@@ -347,4 +350,210 @@ TEST(MjcfParserTest, RoboticsFetch)
   ASSERT_NE(world, nullptr);
 
   ASSERT_EQ(world->getNumSkeletons(), 6);
+}
+
+//==============================================================================
+// Bodies with more <joint>s than DART has a predefined multi-DOF joint for
+// (i.e. anything other than 2 or 3 slide joints) are represented as a chain
+// of single-DOF joints connected by intermediate massless BodyNodes. Those
+// BodyNodes are named "<ownerBodyName>__mjcf_dof<i>" and carry no shapes.
+std::size_t countStackedJointDummyBodies(const dynamics::SkeletonPtr& skel)
+{
+  std::size_t count = 0u;
+  for (auto i = 0u; i < skel->getNumBodyNodes(); ++i) {
+    if (skel->getBodyNode(i)->getName().find("__mjcf_dof")
+        != std::string::npos) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+//==============================================================================
+TEST(MjcfParserTest, HumanoidStackedHingeJoints)
+{
+  // The humanoid model has several bodies with 2 or 3 stacked hinge joints
+  // (lwaist: 2, right_thigh/left_thigh: 3, right_upper_arm/left_upper_arm: 2)
+  // that are not any of the predefined multi-DOF joint compositions.
+  const auto uri = "dart://sample/mjcf/openai/humanoid.xml";
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  ASSERT_EQ(world->getNumSkeletons(), 2);
+
+  auto humanoidSkel = world->getSkeleton("torso");
+  ASSERT_NE(humanoidSkel, nullptr);
+
+  // 6 DOFs from the free root joint + 17 DOFs from the hinge joints.
+  EXPECT_EQ(humanoidSkel->getNumDofs(), 23u);
+
+  // 13 real bodies plus 7 massless intermediate bodies inserted to represent
+  // the joint stacks: lwaist (2 joints -> 1 dummy), right_thigh and
+  // left_thigh (3 joints -> 2 dummies each), right_upper_arm and
+  // left_upper_arm (2 joints -> 1 dummy each).
+  EXPECT_EQ(humanoidSkel->getNumBodyNodes(), 20u);
+  EXPECT_EQ(countStackedJointDummyBodies(humanoidSkel), 7u);
+
+  const std::vector<std::string> realBodyNames
+      = {"torso",
+         "lwaist",
+         "pelvis",
+         "right_thigh",
+         "right_shin",
+         "right_foot",
+         "left_thigh",
+         "left_shin",
+         "left_foot",
+         "right_upper_arm",
+         "right_lower_arm",
+         "left_upper_arm",
+         "left_lower_arm"};
+  for (const auto& name : realBodyNames) {
+    EXPECT_NE(humanoidSkel->getBodyNode(name), nullptr) << name;
+  }
+
+  EXPECT_EQ(
+      humanoidSkel->getRootJoint()->getType(),
+      dynamics::FreeJoint::getStaticType());
+
+  world->getConstraintSolver()->setCollisionDetector(
+      collision::NativeCollisionDetector::create());
+
+  for (auto i = 0; i < 100; ++i) {
+    world->step();
+  }
+
+  EXPECT_TRUE(humanoidSkel->getPositions().allFinite());
+  EXPECT_TRUE(humanoidSkel->getVelocities().allFinite());
+}
+
+//==============================================================================
+TEST(MjcfParserTest, HumanoidStandupStackedHingeJoints)
+{
+  // Same body/joint topology as humanoid.xml, just different geometry.
+  const auto uri = "dart://sample/mjcf/openai/humanoidstandup.xml";
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  ASSERT_EQ(world->getNumSkeletons(), 2);
+
+  auto humanoidSkel = world->getSkeleton("torso");
+  ASSERT_NE(humanoidSkel, nullptr);
+
+  EXPECT_EQ(humanoidSkel->getNumDofs(), 23u);
+  EXPECT_EQ(humanoidSkel->getNumBodyNodes(), 20u);
+  EXPECT_EQ(countStackedJointDummyBodies(humanoidSkel), 7u);
+
+  for (auto i = 0; i < 10; ++i) {
+    world->step();
+  }
+
+  EXPECT_TRUE(humanoidSkel->getPositions().allFinite());
+  EXPECT_TRUE(humanoidSkel->getVelocities().allFinite());
+}
+
+//==============================================================================
+TEST(MjcfParserTest, Walker2dMixedJointStack)
+{
+  // torso has a 2-slide + 1-hinge stack (rootx, rootz, rooty), which is not
+  // the predefined 3-slide TranslationalJoint composition.
+  const auto uri = "dart://sample/mjcf/openai/walker2d.xml";
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  ASSERT_EQ(world->getNumSkeletons(), 2);
+
+  auto skel = world->getSkeleton("torso");
+  ASSERT_NE(skel, nullptr);
+
+  // 7 real bodies (torso, thigh, leg, foot, thigh_left, leg_left, foot_left)
+  // + 2 dummies for the torso's 3-joint stack.
+  EXPECT_EQ(skel->getNumBodyNodes(), 9u);
+  EXPECT_EQ(countStackedJointDummyBodies(skel), 2u);
+
+  // 3 DOFs from torso's stack + 1 DOF from each of the 6 single-hinge bodies.
+  EXPECT_EQ(skel->getNumDofs(), 9u);
+
+  for (auto i = 0; i < 10; ++i) {
+    world->step();
+  }
+
+  EXPECT_TRUE(skel->getPositions().allFinite());
+  EXPECT_TRUE(skel->getVelocities().allFinite());
+}
+
+//==============================================================================
+TEST(MjcfParserTest, HopperMixedJointStack)
+{
+  const auto uri = "dart://sample/mjcf/openai/hopper.xml";
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  ASSERT_EQ(world->getNumSkeletons(), 2);
+
+  auto skel = world->getSkeleton("torso");
+  ASSERT_NE(skel, nullptr);
+
+  // 4 real bodies (torso, thigh, leg, foot) + 2 dummies for torso's stack.
+  EXPECT_EQ(skel->getNumBodyNodes(), 6u);
+  EXPECT_EQ(countStackedJointDummyBodies(skel), 2u);
+  EXPECT_EQ(skel->getNumDofs(), 6u);
+
+  for (auto i = 0; i < 10; ++i) {
+    world->step();
+  }
+
+  EXPECT_TRUE(skel->getPositions().allFinite());
+  EXPECT_TRUE(skel->getVelocities().allFinite());
+}
+
+//==============================================================================
+TEST(MjcfParserTest, HalfCheetahMixedJointStack)
+{
+  const auto uri = "dart://sample/mjcf/openai/half_cheetah.xml";
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  ASSERT_EQ(world->getNumSkeletons(), 2);
+
+  auto skel = world->getSkeleton("torso");
+  ASSERT_NE(skel, nullptr);
+
+  // 7 real bodies (torso, bthigh, bshin, bfoot, fthigh, fshin, ffoot) + 2
+  // dummies for torso's stack.
+  EXPECT_EQ(skel->getNumBodyNodes(), 9u);
+  EXPECT_EQ(countStackedJointDummyBodies(skel), 2u);
+  EXPECT_EQ(skel->getNumDofs(), 9u);
+
+  for (auto i = 0; i < 10; ++i) {
+    world->step();
+  }
+
+  EXPECT_TRUE(skel->getPositions().allFinite());
+  EXPECT_TRUE(skel->getVelocities().allFinite());
+}
+
+//==============================================================================
+TEST(MjcfParserTest, SwimmerMixedJointStack)
+{
+  const auto uri = "dart://sample/mjcf/openai/swimmer.xml";
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  ASSERT_EQ(world->getNumSkeletons(), 2);
+
+  auto skel = world->getSkeleton("torso");
+  ASSERT_NE(skel, nullptr);
+
+  // 3 real bodies (torso, mid, back) + 2 dummies for torso's stack.
+  EXPECT_EQ(skel->getNumBodyNodes(), 5u);
+  EXPECT_EQ(countStackedJointDummyBodies(skel), 2u);
+  EXPECT_EQ(skel->getNumDofs(), 5u);
+
+  for (auto i = 0; i < 10; ++i) {
+    world->step();
+  }
+
+  EXPECT_TRUE(skel->getPositions().allFinite());
+  EXPECT_TRUE(skel->getVelocities().allFinite());
 }

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -33,6 +33,7 @@
 #include "TestHelpers.hpp"
 #include "dart/collision/native/NativeCollisionDetector.hpp"
 #include "dart/dart.hpp"
+#include "dart/utils/mjcf/detail/GeomCollisionFilter.hpp"
 #include "dart/utils/mjcf/detail/MujocoModel.hpp"
 #include "dart/utils/mjcf/detail/Types.hpp"
 #include "dart/utils/mjcf/detail/Utils.hpp"
@@ -804,4 +805,43 @@ TEST(MjcfParserTest, UnnamedRootBodyWithUnnamedJointStack)
 
   EXPECT_TRUE(stacked->getPositions().allFinite());
   EXPECT_TRUE(stacked->getVelocities().allFinite());
+}
+
+//==============================================================================
+TEST(MjcfParserTest, GeomFilterPreservesDeactivationSnapshots)
+{
+  auto world = utils::MjcfParser::readWorld(
+      "dart://sample/mjcf/test/deactivation_filter.xml");
+  ASSERT_NE(world, nullptr);
+
+  auto box = world->getSkeleton("box");
+  ASSERT_NE(box, nullptr);
+  ASSERT_TRUE(box->isMobile());
+
+  // Establish a stable contact before forcing the already-settled fixture
+  // into the resting state. This isolates snapshot preservation from the
+  // separate sleep-candidate dwell policy.
+  for (std::size_t i = 0u; i < 10u; ++i)
+    world->step();
+  box->setVelocities(Eigen::VectorXd::Zero(box->getNumDofs()));
+  box->setResting(true);
+  ASSERT_TRUE(box->isResting());
+
+  const Eigen::VectorXd frozenPositions = box->getPositions();
+  for (std::size_t i = 0u; i < 100u; ++i) {
+    world->step();
+    ASSERT_TRUE(box->isResting()) << "MJCF box spuriously woke at step " << i;
+    EXPECT_TRUE(box->getPositions().isApprox(frozenPositions, 1e-12));
+  }
+
+  auto* geomFilter = dynamic_cast<GeomCollisionFilter*>(
+      world->getConstraintSolver()->getCollisionOption().collisionFilter.get());
+  ASSERT_NE(geomFilter, nullptr);
+  auto* boxShape = box->getBodyNode(0u)->getShapeNode(0u);
+  ASSERT_NE(boxShape, nullptr);
+  geomFilter->setGeomBitmasks(boxShape, 0, 0);
+
+  world->step();
+  EXPECT_FALSE(box->isResting())
+      << "collision-filter revision change did not invalidate the snapshot";
 }

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -311,6 +311,213 @@ TEST(MjcfParserTest, Striker)
   ASSERT_NE(goalSkel, nullptr);
 
   EXPECT_TRUE(world->hasSkeleton(options.mGeomSkeletonNamePrefix + "table"));
+
+  // striker.xml's <default> sets contype="0" conaffinity="0" on <geom>, so
+  // every geom that doesn't override these (e.g. the arm's decorative
+  // shoulder geoms) must be visual-only: no CollisionAspect at all. This is
+  // what keeps the density=1e6 "coaster" marker cylinder (nested under the
+  // "goal" body, resting inside the table) from ever generating a contact.
+  auto shoulderPanLink = strikerSkel->getBodyNode("r_shoulder_pan_link");
+  ASSERT_NE(shoulderPanLink, nullptr);
+  ASSERT_GT(shoulderPanLink->getNumShapeNodes(), 0u);
+  EXPECT_FALSE(shoulderPanLink->getShapeNode(0)->has<dynamics::CollisionAspect>());
+
+  auto goalRootBody = goalSkel->getRootBodyNode();
+  ASSERT_NE(goalRootBody, nullptr);
+  ASSERT_GT(goalRootBody->getNumShapeNodes(), 0u);
+  EXPECT_FALSE(goalRootBody->getShapeNode(0)->has<dynamics::CollisionAspect>());
+
+  auto coasterBody = goalSkel->getBodyNode("coaster");
+  ASSERT_NE(coasterBody, nullptr);
+  ASSERT_GT(coasterBody->getNumShapeNodes(), 0u);
+  EXPECT_FALSE(coasterBody->getShapeNode(0)->has<dynamics::CollisionAspect>());
+
+  // Geoms that explicitly re-enable collision (contype="1" conaffinity="1")
+  // must still get a CollisionAspect: the table and the arm-tip geoms.
+  auto tableSkel = world->getSkeleton(options.mGeomSkeletonNamePrefix + "table");
+  ASSERT_NE(tableSkel, nullptr);
+  ASSERT_GT(tableSkel->getNumBodyNodes(), 0u);
+  ASSERT_GT(tableSkel->getBodyNode(0)->getNumShapeNodes(), 0u);
+  auto tableShapeNode = tableSkel->getBodyNode(0)->getShapeNode(0);
+  EXPECT_TRUE(tableShapeNode->has<dynamics::CollisionAspect>());
+  // The table geom doesn't override friction, so it inherits the <default>
+  // class's friction=".0 .0 .0".
+  ASSERT_TRUE(tableShapeNode->has<dynamics::DynamicsAspect>());
+  EXPECT_DOUBLE_EQ(
+      tableShapeNode->getDynamicsAspect()->getFrictionCoeff(), 0.0);
+
+  auto tipsArmBody = strikerSkel->getBodyNode("tips_arm");
+  ASSERT_NE(tipsArmBody, nullptr);
+  ASSERT_GT(tipsArmBody->getNumShapeNodes(), 0u);
+  EXPECT_TRUE(tipsArmBody->getShapeNode(0)->has<dynamics::CollisionAspect>());
+
+  auto wristRollBody = strikerSkel->getBodyNode("r_wrist_roll_link");
+  ASSERT_NE(wristRollBody, nullptr);
+  ASSERT_GT(wristRollBody->getNumShapeNodes(), 0u);
+  EXPECT_TRUE(wristRollBody->getShapeNode(0)->has<dynamics::CollisionAspect>());
+
+  // Before the contype/conaffinity fix, the coaster marker (density 1e6)
+  // would be given a CollisionAspect and collide with the table, producing a
+  // ~1e6 mass-ratio contact that MuJoCo never generates and that makes the
+  // Dantzig primary solver fail every step. With the fix, contype==0 &&
+  // conaffinity==0 geoms (the coaster and the goal-root marker) carry no
+  // CollisionAspect at all, so no contact can ever involve them. Note the
+  // goal's thin side walls are contype=0 conaffinity=1 and DO legitimately
+  // collide with the table and the ball under MuJoCo's pair rule
+  // ((ctA & caB) || (ctB & caA)); asserting zero goal contacts would
+  // contradict the model's own semantics.
+  world->getConstraintSolver()->setCollisionDetector(
+      collision::NativeCollisionDetector::create());
+
+  for (auto i = 0; i < 50; ++i) {
+    world->step();
+
+    const auto& result
+        = world->getConstraintSolver()->getLastCollisionResult();
+    for (auto j = 0u; j < result.getNumContacts(); ++j) {
+      const auto& contact = result.getContact(j);
+      const auto bn1 = contact.getBodyNodePtr1();
+      const auto bn2 = contact.getBodyNodePtr2();
+      const bool involvesCoaster = (bn1 && bn1.get() == coasterBody)
+                                   || (bn2 && bn2.get() == coasterBody);
+      EXPECT_FALSE(involvesCoaster)
+          << "Contact involving the aspect-less coaster marker at step " << i
+          << ", contact index " << j;
+    }
+  }
+
+  // The arm must stay well-behaved. The free ball is deliberately not
+  // asserted: with faithful masks and friction the model exposes ball
+  // contacts against the goal's 1 mm frictionless walls, a thin-geometry
+  // hard-contact stress case (MuJoCo absorbs it with margin/soft contacts)
+  // that is an engine-robustness item, not a parser-fidelity one.
+  EXPECT_TRUE(strikerSkel->getPositions().allFinite());
+  EXPECT_TRUE(strikerSkel->getVelocities().allFinite());
+}
+
+//==============================================================================
+TEST(MjcfParserTest, GeomFriction)
+{
+  // striker.xml's <default> sets friction=".0 .0 .0", and the "table" geom
+  // (contype="1" conaffinity="1", no friction override) inherits it.
+  {
+    auto world = utils::MjcfParser::readWorld(
+        "dart://sample/mjcf/openai/striker.xml");
+    ASSERT_NE(world, nullptr);
+
+    const auto options = utils::MjcfParser::Options();
+    auto tableSkel
+        = world->getSkeleton(options.mGeomSkeletonNamePrefix + "table");
+    ASSERT_NE(tableSkel, nullptr);
+    ASSERT_GT(tableSkel->getBodyNode(0)->getNumShapeNodes(), 0u);
+    auto tableShapeNode = tableSkel->getBodyNode(0)->getShapeNode(0);
+    ASSERT_TRUE(tableShapeNode->has<dynamics::DynamicsAspect>());
+    EXPECT_DOUBLE_EQ(
+        tableShapeNode->getDynamicsAspect()->getFrictionCoeff(), 0.0);
+  }
+
+  // thrower.xml's <default> sets friction=".8 .1 .1", and the (unnamed) floor
+  // geom (contype="1" conaffinity="1", no friction override) inherits it.
+  {
+    auto world = utils::MjcfParser::readWorld(
+        "dart://sample/mjcf/openai/thrower.xml");
+    ASSERT_NE(world, nullptr);
+
+    const auto options = utils::MjcfParser::Options();
+    auto floorSkel = world->getSkeleton(options.mGeomSkeletonNamePrefix + "");
+    ASSERT_NE(floorSkel, nullptr);
+    ASSERT_GT(floorSkel->getBodyNode(0)->getNumShapeNodes(), 0u);
+    auto floorShapeNode = floorSkel->getBodyNode(0)->getShapeNode(0);
+    ASSERT_TRUE(floorShapeNode->has<dynamics::DynamicsAspect>());
+    EXPECT_DOUBLE_EQ(
+        floorShapeNode->getDynamicsAspect()->getFrictionCoeff(), 0.8);
+  }
+
+  // walker2d.xml demonstrates both inheritance and override within the same
+  // file: the "floor" geom doesn't set friction and inherits the <default>
+  // class's friction=".7 .1 .1", while "torso_geom" explicitly overrides it
+  // to 0.9.
+  {
+    auto world = utils::MjcfParser::readWorld(
+        "dart://sample/mjcf/openai/walker2d.xml");
+    ASSERT_NE(world, nullptr);
+
+    auto torsoSkel = world->getSkeleton("torso");
+    ASSERT_NE(torsoSkel, nullptr);
+
+    // "floor" is a root <geom>, which lives in its own kinematic Skeleton
+    // rather than under "torso".
+    const auto options = utils::MjcfParser::Options();
+    auto floorSkel
+        = world->getSkeleton(options.mGeomSkeletonNamePrefix + "floor");
+    ASSERT_NE(floorSkel, nullptr);
+    ASSERT_GT(floorSkel->getBodyNode(0)->getNumShapeNodes(), 0u);
+    auto floorShapeNode = floorSkel->getBodyNode(0)->getShapeNode(0);
+    ASSERT_TRUE(floorShapeNode->has<dynamics::DynamicsAspect>());
+    EXPECT_DOUBLE_EQ(
+        floorShapeNode->getDynamicsAspect()->getFrictionCoeff(), 0.7);
+
+    auto torsoBody = torsoSkel->getBodyNode("torso");
+    ASSERT_NE(torsoBody, nullptr);
+    ASSERT_GT(torsoBody->getNumShapeNodes(), 0u);
+    auto torsoShapeNode = torsoBody->getShapeNode(0);
+    ASSERT_TRUE(torsoShapeNode->has<dynamics::DynamicsAspect>());
+    EXPECT_DOUBLE_EQ(
+        torsoShapeNode->getDynamicsAspect()->getFrictionCoeff(), 0.9);
+  }
+}
+
+//==============================================================================
+TEST(MjcfParserTest, ContypeConaffinityPairRule)
+{
+  // A minimal scene with three mutually-overlapping static spheres exercising
+  // MuJoCo's contype/conaffinity pair rule in isolation:
+  //   collides(A, B) := (contype_A & conaffinity_B) || (contype_B & conaffinity_A)
+  // bodyA: contype=1 conaffinity=0
+  // bodyB: contype=0 conaffinity=1
+  // bodyC: contype=1 conaffinity=0 (same masks as bodyA)
+  // A vs B -> (1 & 1) || (0 & 0) = 1 -> collide
+  // A vs C -> (1 & 0) || (1 & 0) = 0 -> do not collide
+  const auto uri = "dart://sample/mjcf/test/contype_conaffinity.xml";
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  auto skelA = world->getSkeleton("bodyA");
+  auto skelB = world->getSkeleton("bodyB");
+  auto skelC = world->getSkeleton("bodyC");
+  ASSERT_NE(skelA, nullptr);
+  ASSERT_NE(skelB, nullptr);
+  ASSERT_NE(skelC, nullptr);
+
+  world->getConstraintSolver()->setCollisionDetector(
+      collision::NativeCollisionDetector::create());
+
+  world->step();
+
+  const auto& result = world->getConstraintSolver()->getLastCollisionResult();
+
+  auto hasContactBetween = [&](const dynamics::SkeletonPtr& s1,
+                                const dynamics::SkeletonPtr& s2) {
+    for (auto i = 0u; i < result.getNumContacts(); ++i) {
+      const auto& contact = result.getContact(i);
+      const auto bn1 = contact.getBodyNodePtr1();
+      const auto bn2 = contact.getBodyNodePtr2();
+      if (!bn1 || !bn2)
+        continue;
+
+      const bool matches
+          = (bn1->getSkeleton().get() == s1.get()
+             && bn2->getSkeleton().get() == s2.get())
+            || (bn1->getSkeleton().get() == s2.get()
+                && bn2->getSkeleton().get() == s1.get());
+      if (matches)
+        return true;
+    }
+    return false;
+  };
+
+  EXPECT_TRUE(hasContactBetween(skelA, skelB));
+  EXPECT_FALSE(hasContactBetween(skelA, skelC));
 }
 
 //==============================================================================

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -845,3 +845,31 @@ TEST(MjcfParserTest, GeomFilterPreservesDeactivationSnapshots)
   EXPECT_FALSE(box->isResting())
       << "collision-filter revision change did not invalidate the snapshot";
 }
+
+//==============================================================================
+TEST(MjcfParserTest, StackedJointPreservesLogicalBodyAdjacency)
+{
+  auto world = utils::MjcfParser::readWorld(
+      "dart://sample/mjcf/test/stacked_joint_adjacency.xml");
+  ASSERT_NE(world, nullptr);
+
+  auto skeleton = world->getSkeleton("parent");
+  ASSERT_NE(skeleton, nullptr);
+  skeleton->enableSelfCollisionCheck();
+
+  auto collisionGroup = world->getConstraintSolver()
+                            ->getCollisionDetector()
+                            ->createCollisionGroup(skeleton.get());
+  ASSERT_EQ(collisionGroup->getNumShapeFrames(), 2u);
+  collision::CollisionOption option;
+  option.collisionFilter
+      = world->getConstraintSolver()->getCollisionOption().collisionFilter;
+  collision::CollisionResult result;
+
+  EXPECT_FALSE(collisionGroup->collide(option, &result));
+
+  skeleton->enableAdjacentBodyCheck();
+  result.clear();
+  EXPECT_TRUE(collisionGroup->collide(option, &result));
+  EXPECT_GT(result.getNumContacts(), 0u);
+}

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -557,3 +557,43 @@ TEST(MjcfParserTest, SwimmerMixedJointStack)
   EXPECT_TRUE(skel->getPositions().allFinite());
   EXPECT_TRUE(skel->getVelocities().allFinite());
 }
+
+//==============================================================================
+TEST(MjcfParserTest, UnnamedRootBodyWithUnnamedJointStack)
+{
+  // Regression: a root <body> without a name whose joints are also unnamed
+  // used to crash in the stacked-joint chain path (nullptr parent BodyNode in
+  // the unnamed-joint name fallback), and unnamed root bodies must keep
+  // inheriting a generated BodyNode name instead of a synthetic
+  // "__mjcf_dof" link name or the World's generic default.
+  const auto uri = "dart://sample/mjcf/test/unnamed_root_joint_stack.xml";
+
+  auto world = utils::MjcfParser::readWorld(uri);
+  ASSERT_NE(world, nullptr);
+
+  dynamics::SkeletonPtr stacked = nullptr;
+  for (std::size_t i = 0u; i < world->getNumSkeletons(); ++i) {
+    auto skel = world->getSkeleton(i);
+    if (skel->getNumDofs() == 2u) {
+      stacked = skel;
+      break;
+    }
+  }
+  ASSERT_NE(stacked, nullptr);
+
+  // Two chained revolute joints: one synthetic intermediate link plus the
+  // real body.
+  EXPECT_EQ(stacked->getNumBodyNodes(), 2u);
+  EXPECT_NE(stacked->getRootJoint(), nullptr);
+
+  // The skeleton name must come from the real (non-synthetic) BodyNode.
+  EXPECT_EQ(stacked->getName().find("__mjcf_dof"), std::string::npos);
+  EXPECT_FALSE(stacked->getName().empty());
+
+  for (auto i = 0; i < 10; ++i) {
+    world->step();
+  }
+
+  EXPECT_TRUE(stacked->getPositions().allFinite());
+  EXPECT_TRUE(stacked->getVelocities().allFinite());
+}

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -39,6 +39,7 @@
 #include "dart/utils/mjcf/detail/Utils.hpp"
 #include "dart/utils/utils.hpp"
 
+#include <Eigen/Eigenvalues>
 #include <gtest/gtest.h>
 
 #include <iostream>
@@ -579,6 +580,28 @@ std::size_t countStackedJointDummyBodies(const dynamics::SkeletonPtr& skel)
 }
 
 //==============================================================================
+// A stacked joint needs inertialess carrier links to preserve the MJCF body's
+// mass and spatial inertia exactly. Individual zero-inertia BodyNodes trigger
+// DART's conservative local-link warning, but the relevant dynamics invariant
+// is that descendant body inertia makes the generalized mass matrix positive
+// definite and forward dynamics finite.
+void expectStackedJointDynamicsWellPosed(const dynamics::SkeletonPtr& skeleton)
+{
+  ASSERT_NE(skeleton, nullptr);
+  const Eigen::MatrixXd massMatrix = skeleton->getMassMatrix();
+  ASSERT_TRUE(massMatrix.allFinite());
+
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(massMatrix);
+  ASSERT_EQ(eigensolver.info(), Eigen::Success);
+  EXPECT_GT(eigensolver.eigenvalues().minCoeff(), 1e-10);
+
+  skeleton->setForces(Eigen::VectorXd::LinSpaced(
+      skeleton->getNumDofs(), 0.01, 0.01 * skeleton->getNumDofs()));
+  skeleton->computeForwardDynamics();
+  EXPECT_TRUE(skeleton->getAccelerations().allFinite());
+}
+
+//==============================================================================
 TEST(MjcfParserTest, HumanoidStackedHingeJoints)
 {
   // The humanoid model has several bodies with 2 or 3 stacked hinge joints
@@ -624,6 +647,8 @@ TEST(MjcfParserTest, HumanoidStackedHingeJoints)
   EXPECT_EQ(
       humanoidSkel->getRootJoint()->getType(),
       dynamics::FreeJoint::getStaticType());
+
+  expectStackedJointDynamicsWellPosed(humanoidSkel);
 
   world->getConstraintSolver()->setCollisionDetector(
       collision::NativeCollisionDetector::create());
@@ -759,6 +784,8 @@ TEST(MjcfParserTest, SwimmerMixedJointStack)
   EXPECT_EQ(countStackedJointDummyBodies(skel), 2u);
   EXPECT_EQ(skel->getNumDofs(), 5u);
 
+  expectStackedJointDynamicsWellPosed(skel);
+
   for (auto i = 0; i < 10; ++i) {
     world->step();
   }
@@ -798,6 +825,8 @@ TEST(MjcfParserTest, UnnamedRootBodyWithUnnamedJointStack)
   // The skeleton name must come from the real (non-synthetic) BodyNode.
   EXPECT_EQ(stacked->getName().find("__mjcf_dof"), std::string::npos);
   EXPECT_FALSE(stacked->getName().empty());
+
+  expectStackedJointDynamicsWellPosed(stacked);
 
   for (auto i = 0; i < 10; ++i) {
     world->step();

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -320,7 +320,8 @@ TEST(MjcfParserTest, Striker)
   auto shoulderPanLink = strikerSkel->getBodyNode("r_shoulder_pan_link");
   ASSERT_NE(shoulderPanLink, nullptr);
   ASSERT_GT(shoulderPanLink->getNumShapeNodes(), 0u);
-  EXPECT_FALSE(shoulderPanLink->getShapeNode(0)->has<dynamics::CollisionAspect>());
+  EXPECT_FALSE(
+      shoulderPanLink->getShapeNode(0)->has<dynamics::CollisionAspect>());
 
   auto goalRootBody = goalSkel->getRootBodyNode();
   ASSERT_NE(goalRootBody, nullptr);
@@ -334,7 +335,8 @@ TEST(MjcfParserTest, Striker)
 
   // Geoms that explicitly re-enable collision (contype="1" conaffinity="1")
   // must still get a CollisionAspect: the table and the arm-tip geoms.
-  auto tableSkel = world->getSkeleton(options.mGeomSkeletonNamePrefix + "table");
+  auto tableSkel
+      = world->getSkeleton(options.mGeomSkeletonNamePrefix + "table");
   ASSERT_NE(tableSkel, nullptr);
   ASSERT_GT(tableSkel->getNumBodyNodes(), 0u);
   ASSERT_GT(tableSkel->getBodyNode(0)->getNumShapeNodes(), 0u);
@@ -372,8 +374,7 @@ TEST(MjcfParserTest, Striker)
   for (auto i = 0; i < 50; ++i) {
     world->step();
 
-    const auto& result
-        = world->getConstraintSolver()->getLastCollisionResult();
+    const auto& result = world->getConstraintSolver()->getLastCollisionResult();
     for (auto j = 0u; j < result.getNumContacts(); ++j) {
       const auto& contact = result.getContact(j);
       const auto bn1 = contact.getBodyNodePtr1();
@@ -401,8 +402,8 @@ TEST(MjcfParserTest, GeomFriction)
   // striker.xml's <default> sets friction=".0 .0 .0", and the "table" geom
   // (contype="1" conaffinity="1", no friction override) inherits it.
   {
-    auto world = utils::MjcfParser::readWorld(
-        "dart://sample/mjcf/openai/striker.xml");
+    auto world
+        = utils::MjcfParser::readWorld("dart://sample/mjcf/openai/striker.xml");
     ASSERT_NE(world, nullptr);
 
     const auto options = utils::MjcfParser::Options();
@@ -419,8 +420,8 @@ TEST(MjcfParserTest, GeomFriction)
   // thrower.xml's <default> sets friction=".8 .1 .1", and the (unnamed) floor
   // geom (contype="1" conaffinity="1", no friction override) inherits it.
   {
-    auto world = utils::MjcfParser::readWorld(
-        "dart://sample/mjcf/openai/thrower.xml");
+    auto world
+        = utils::MjcfParser::readWorld("dart://sample/mjcf/openai/thrower.xml");
     ASSERT_NE(world, nullptr);
 
     const auto options = utils::MjcfParser::Options();
@@ -472,7 +473,8 @@ TEST(MjcfParserTest, ContypeConaffinityPairRule)
 {
   // A minimal scene with three mutually-overlapping static spheres exercising
   // MuJoCo's contype/conaffinity pair rule in isolation:
-  //   collides(A, B) := (contype_A & conaffinity_B) || (contype_B & conaffinity_A)
+  //   collides(A, B) := (contype_A & conaffinity_B) || (contype_B &
+  //   conaffinity_A)
   // bodyA: contype=1 conaffinity=0
   // bodyB: contype=0 conaffinity=1
   // bodyC: contype=1 conaffinity=0 (same masks as bodyA)
@@ -496,25 +498,24 @@ TEST(MjcfParserTest, ContypeConaffinityPairRule)
 
   const auto& result = world->getConstraintSolver()->getLastCollisionResult();
 
-  auto hasContactBetween = [&](const dynamics::SkeletonPtr& s1,
-                                const dynamics::SkeletonPtr& s2) {
-    for (auto i = 0u; i < result.getNumContacts(); ++i) {
-      const auto& contact = result.getContact(i);
-      const auto bn1 = contact.getBodyNodePtr1();
-      const auto bn2 = contact.getBodyNodePtr2();
-      if (!bn1 || !bn2)
-        continue;
+  auto hasContactBetween
+      = [&](const dynamics::SkeletonPtr& s1, const dynamics::SkeletonPtr& s2) {
+          for (auto i = 0u; i < result.getNumContacts(); ++i) {
+            const auto& contact = result.getContact(i);
+            const auto bn1 = contact.getBodyNodePtr1();
+            const auto bn2 = contact.getBodyNodePtr2();
+            if (!bn1 || !bn2)
+              continue;
 
-      const bool matches
-          = (bn1->getSkeleton().get() == s1.get()
-             && bn2->getSkeleton().get() == s2.get())
-            || (bn1->getSkeleton().get() == s2.get()
-                && bn2->getSkeleton().get() == s1.get());
-      if (matches)
-        return true;
-    }
-    return false;
-  };
+            const bool matches = (bn1->getSkeleton().get() == s1.get()
+                                  && bn2->getSkeleton().get() == s2.get())
+                                 || (bn1->getSkeleton().get() == s2.get()
+                                     && bn2->getSkeleton().get() == s1.get());
+            if (matches)
+              return true;
+          }
+          return false;
+        };
 
   EXPECT_TRUE(hasContactBetween(skelA, skelB));
   EXPECT_FALSE(hasContactBetween(skelA, skelC));

--- a/tests/integration/test_MjcfParser.cpp
+++ b/tests/integration/test_MjcfParser.cpp
@@ -847,6 +847,47 @@ TEST(MjcfParserTest, GeomFilterPreservesDeactivationSnapshots)
 }
 
 //==============================================================================
+TEST(MjcfParserTest, GeomFilterDoesNotRetainRemovedSkeletons)
+{
+  auto world = utils::MjcfParser::readWorld(
+      "dart://sample/mjcf/test/contype_conaffinity.xml");
+  ASSERT_NE(world, nullptr);
+  ASSERT_GT(world->getNumSkeletons(), 0u);
+
+  auto collisionFilter
+      = world->getConstraintSolver()->getCollisionOption().collisionFilter;
+  ASSERT_NE(collisionFilter, nullptr);
+
+  std::vector<dynamics::WeakSkeletonPtr> removedSkeletons;
+  while (world->getNumSkeletons() > 0u) {
+    auto skeleton = world->getSkeleton(0u);
+    removedSkeletons.emplace_back(skeleton);
+    world->removeSkeleton(skeleton);
+  }
+
+  for (const auto& skeleton : removedSkeletons)
+    EXPECT_TRUE(skeleton.expired());
+
+  const auto addOverlappingBox = [&world](const std::string& name) {
+    auto skeleton = dynamics::Skeleton::create(name);
+    auto pair = skeleton->createJointAndBodyNodePair<dynamics::WeldJoint>();
+    pair.second->createShapeNodeWith<dynamics::CollisionAspect>(
+        std::make_shared<dynamics::BoxShape>(Eigen::Vector3d::Ones()));
+    world->addSkeleton(skeleton);
+    return skeleton;
+  };
+
+  const auto box1 = addOverlappingBox("replacement_1");
+  const auto box2 = addOverlappingBox("replacement_2");
+  auto collisionGroup = world->getConstraintSolver()
+                            ->getCollisionDetector()
+                            ->createCollisionGroup(box1.get(), box2.get());
+  collision::CollisionOption option;
+  option.collisionFilter = collisionFilter;
+  EXPECT_TRUE(collisionGroup->collide(option));
+}
+
+//==============================================================================
 TEST(MjcfParserTest, StackedJointPreservesLogicalBodyAdjacency)
 {
   auto world = utils::MjcfParser::readWorld(


### PR DESCRIPTION
## Summary

One cohesive MJCF parser-fidelity PR (per the fewer-PRs direction), in three commits plus follow-ups:

### 1. Stacked hinge/slide joint compositions
MJCF bodies listing multiple `<joint>` elements beyond the existing special cases failed with *unsupported joint composition*, rejecting `humanoid.xml`, `humanoidstandup.xml`, `walker2d.xml`, `hopper.xml`, `half_cheetah.xml`, `swimmer.xml`. Remaining hinge/slide stacks are now translated into chains of single-DOF joints through massless intermediate BodyNodes; per the MuJoCo XML reference each DART joint factor `T_CBJ · Q(q) · T_CBJ⁻¹` is exactly MuJoCo's local-frame screw about the undisplaced anchor, so the chained product reproduces MuJoCo's composition for arbitrary q. Existing compositions match first and stay byte-identical.

### 2. Parser hardening (review follow-ups + a fixture-exposed crash)
- Unnamed joints on root bodies no longer dereference a null parent BodyNode.
- Unnamed root bodies keep inheriting a generated BodyNode name (skipping synthetic `__mjcf_dof` links).
- **Release builds segfaulted on any MJCF file without a `<default>` element** (`Defaults::getRootDefault()` returned null; the `DART_ASSERT` compiles out). It now falls back to MuJoCo's built-in attribute defaults.

### 3. contype/conaffinity collision filtering + geom friction
`contype`/`conaffinity` and `friction` were parsed (with correct defaults and `<default>` inheritance) but never consumed:
- Geoms with `contype==0 && conaffinity==0` get visual-only ShapeNodes (no collision aspect) — e.g. striker's goal-root marker and its density-1e6 coaster cylinder, whose spurious table contact previously produced a ~1e6 mass-ratio LCP that made the Dantzig primary solver fail (and fall back to PGS) **every step**.
- The full MuJoCo pair rule `(ctA & caB) || (ctB & caA)` is enforced by a new `detail::GeomCollisionFilter` that subclasses `BodyNodeCollisionFilter` — deliberately, because `ConstraintSolver::updateConstraints` `dynamic_cast`s the installed filter to `BodyNodeCollisionFilter` for the resting-contact optimization; a generic composite would silently defeat it. Base filtering (self-collision/adjacency/resting pairs) is applied first; unregistered ShapeFrames are unaffected.
- MJCF geom sliding friction is applied to the ShapeNode dynamics aspect (striker's `<default>` sets friction 0).

## Validation
- `test_MjcfParser`: **20/20** (10 pre-existing unchanged; 6 stacked-joint tests incl. humanoid topology + 100 steps finite with the native detector; unnamed-root regression; extended Striker collision-aspect/coaster-contact assertions; GeomFriction incl. `<default>` inheritance; ContypeConaffinityPairRule on a minimal asymmetric-mask fixture; custom-filter deactivation snapshot preservation and mutation invalidation).
- `pixi run lint` and `pixi run test-all` passed on head `7c8b0018932` after merging current `release-6.20`.
- `pixi run -e gazebo test-gz` passed on the same head (gz-physics and gz-sim compatibility gates).

## Notes
- With faithful masks/friction, striker's free ball now legitimately contacts the goal's 1 mm frictionless walls and can go non-finite under hard contacts (MuJoCo absorbs this with margin/soft contacts) — an engine-robustness item tracked in the WS-G lane, deliberately not asserted here.
- Zero-mass intermediate BodyNodes emit DART's generic zero-mass `dtwarn` on load (diagnostic-only; sims verified finite).
- `main` is not dual-PR-applicable: its `dart/io/mjcf` does not convert MJCF to skeletons at all.
- Filter lifetime note: bitmasks are keyed by ShapeFrame pointer; parser-created worlds are the intended scope (dynamically replacing ShapeNodes after parse would need re-registration).
