### PR TITLE
Refresh perf/dep-min dev-task docs with the 2026-07-10 evidence cycle

### DIFF
--- a/docs/dev_tasks/dart6_dependency_minimization/03-native-collision-port-scoping.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/03-native-collision-port-scoping.md
@@ -109,7 +109,7 @@ the incumbent for each capability.
 ## The target (DART 6.20) - `dart/collision/`
 
 - Clean factory interface: `CollisionDetector` (virtuals: `collide×2`, `distance×2`, `raycast`, `createCollisionGroup`, `createCollisionObject`, `refreshCollisionObject`, `getType`, `cloneWithoutCollisionObjects`), `CollisionGroup`, `CollisionObject`, `CollisionResult`, `Contact`, `CollisionOption`.
-- Detectors: **`dart`** (basic, narrowphase-only, no broadphase/distance/raycast, limited shapes), **`fcl`** (full; **hardcoded default** created in *both* `ConstraintSolver` constructors via `FCLCollisionDetector::create()` - `dart/constraint/ConstraintSolver.cpp:322` & `:342`; core), `ode`, `bullet`.
+- Detectors: **`dart`** (basic, narrowphase-only, no broadphase/distance/raycast, limited shapes), **`fcl`** (full; **hardcoded default** created in *both* `ConstraintSolver` constructors via `FCLCollisionDetector::create()` - `dart/constraint/ConstraintSolver.cpp:416` & `:433`; core), `ode`, `bullet`.
 - FCL coupling to break: default detector, `VoxelGridShape`/octree (only FCL, via `fcl::OcTree`), distance queries (**FCL-only** - Bullet/ODE/DART `distance()` are warn-and-return stubs).
 - Capability incumbents (verified in-tree, for parity targeting): **distance -> FCL only** (`::fcl::distance`; others stub), **raycast -> Bullet only** (only `BulletCollisionDetector` overrides `raycast()`; FCL/ODE/DART fall back to the base "not supported"), **VoxelGrid/octree -> FCL only**.
 
@@ -127,10 +127,10 @@ The port is **not a copy**:
 | gz requirement | Evidence | Native-port obligation |
 | --- | --- | --- |
 | `find_package(DART COMPONENTS collision-bullet collision-ode utils utils-urdf)` | `.deps/gz-physics/CMakeLists.txt` | Keep `collision-bullet` + `collision-ode` **components resolvable** (real or facade). |
-| Subclasses `BulletCollisionDetector` / `OdeCollisionDetector` (`GzBulletCollisionDetector`/`GzOdeCollisionDetector` add `SetCollisionPairMaxContacts`) | `dartsim/src/GzCollisionDetector.*` | Those detector classes must stay **subclassable** with the same interface (facade-over-native is OK only if it preserves it). |
+| Subclasses `OdeCollisionDetector` **only** (`GzOdeCollisionDetector` adds `SetCollisionPairMaxContacts`; there is no `GzBulletCollisionDetector` — Bullet is used via plain `create()`) | `dartsim/src/GzOdeCollisionDetector.{hh,cc}` | `OdeCollisionDetector` must stay **subclassable** with overridable `collide()` (facade-over-native is OK only if it preserves that); Bullet/FCL only need `create()` + name resolution. |
 | `SetWorldCollisionDetector("bullet"/"ode"/"fcl"/"dart")` | `dartsim/src/WorldFeatures.cc` | All four names must keep resolving. |
 | `world->getLastCollisionResult().getContacts()`; `Contact{point,normal,penetrationDepth,force,collisionObject1/2}` | `dartsim/src/SimulationFeatures.cc` | Native `Contact` must populate the same fields with equivalent semantics. |
-| Per-pair contact capping | `GzCollisionDetector::LimitCollisionPairMaxContacts` | Native must honor `CollisionOption.maxNumContactsPerPair`. |
+| Per-pair contact capping | `GzOdeCollisionDetector::LimitCollisionPairMaxContacts` | Native must honor `CollisionOption.maxNumContactsPerPair`. |
 | CI gate | `scripts/run_gz_physics_task.sh` (ctest + plugin-links-DART check) | `pixi run -e gazebo test-gz` must stay green on every phase. |
 
 ## Feature-parity matrix (native must match the default detector)
@@ -220,7 +220,7 @@ Success means **both**:
    components. This phase must prove gz subclassing still works, not just
    `find_package`.
 6. **Default flip.** Flip native in *both* `ConstraintSolver` constructors
-   (`ConstraintSolver.cpp:322` & `:342`) and confirm runtime
+   (`ConstraintSolver.cpp:416` & `:433`) and confirm runtime
    `setCollisionDetector` remains unaffected. Require the full A/B packet,
    `pixi run test-all`, and `pixi run -e gazebo test-gz` before merge.
 7. **FCL decoupling.** Only after the default flip is green, drop FCL from the

--- a/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
@@ -16,9 +16,9 @@ DART 6.22.0, while preserving the downstream gz-physics/gz-sim contract.
 
 **The native engine merges INTO the `dart` detector: `dart/collision/native/`
 folds into `dart/collision/dart/`, and `NativeCollisionDetector` merges into
-`DARTCollisionDetector`, replacing its legacy narrowphase-only
-implementation. The single built-in backend is the `dart` detector, canonical
-factory key `"dart"`. The keys `"fcl"`, `"bullet"`, `"ode"` remain resolvable
+`DARTCollisionDetector`, replacing its legacy collision implementation. The
+single built-in backend is the `dart` detector, canonical factory key `"dart"`.
+The keys `"fcl"`, `"bullet"`, `"ode"` remain resolvable
 and, from 6.22, create dart-backed facade implementations.**
 
 Maintainer direction (2026-07-10): "NativeDetector must merged into
@@ -32,11 +32,13 @@ Mechanics, and why this is clean now:
   All in-tree users are updated in the same PR (`contact_benchmark
   --collision native`, dashboard detector index 4, native unit tests, the
   comparison harness's `--detector native`, the dartpy binding).
-- The legacy `DARTCollisionDetector` narrowphase (six primitive pairs, no
-  broadphase, `distance()` stub, no raycast) is a strict subset of the engine
-  replacing it, so the `"dart"` key only gains capability. `dart`-detector
-  guard rows re-baseline with the consolidation PR's A/B evidence
-  (pre-release change, allowed with recorded old/new rows).
+- The incumbent `DARTCollisionDetector` has six primitive narrowphase pairs,
+  an in-detector AABB sweep broadphase (including plane pruning and parallel
+  scratch paths), a `distance()` stub, and no raycast. The consolidated engine
+  must preserve or deliberately replace and re-baseline that existing
+  broadphase behavior while extending the `"dart"` key's shape and query
+  capabilities. `dart`-detector guard rows re-baseline with the consolidation
+  PR's A/B evidence (pre-release change, allowed with recorded old/new rows).
 - gz-physics keeps working: `SetWorldCollisionDetector("dart")` returns the
   consolidated engine; the other names keep resolving; gz's own default
   remains its `GzOdeCollisionDetector` subclass until 6.22

--- a/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
@@ -52,7 +52,11 @@ Mechanics, and why this is clean now:
 
 **6.22 removes the external fcl/bullet/ode dependencies; the detector classes
 and CMake components survive as compatibility facades over the consolidated
-`dart` detector.** The source-verified gz obligations and how facades satisfy them:
+`dart` detector.** Dependency removal is gated on migrating the installed public
+detector headers and API types so they no longer include or expose FCL, Bullet,
+or ODE headers. Header-only downstream compile checks and component smoke tests
+must pass without those packages installed. The source-verified gz obligations
+and how facades satisfy them:
 
 | gz obligation (evidence) | facade answer |
 | --- | --- |

--- a/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
@@ -101,10 +101,11 @@ must pass against facades before 6.22 ships.
 ## Timeline
 
 - **6.20 (now, phases 4-6 of the port plan):** close the remaining native
-  performance gaps (broadphase landed; S3 narrowphase delta, small-scene
-  overhead, and the S6 dense-pile resting profile remain), then flip only the
-  DEFAULT detector (both ctors + WorldConfig/SkelParser surface). All legacy
-  detectors stay real and selectable; no deprecations on the LTS branch.
+  performance gaps (broadphase landed; S3 narrowphase delta and small-scene
+  overhead remain; the S6 dense-pile row was resolved by the documented
+  acceptance re-scope), then flip only the DEFAULT detector (both ctors +
+  WorldConfig/SkelParser surface). All legacy detectors stay real and
+  selectable; no deprecations on the LTS branch.
 - **6.21:** deprecation attributes with migration messages on
   FCL/Bullet/ODE `create()`/ctors; CHANGELOG + migration guide;
   CMake configure-time notices. Everything still functional.

--- a/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
@@ -107,8 +107,8 @@ must pass against facades before 6.22 ships.
 ## Timeline
 
 - **6.20 (now, phases 4-6 of the port plan):** close the remaining native
-  performance gaps (#3368 carries the branch-local broadphase work and must
-  merge before it is a base-branch precondition; S3 narrowphase delta and
+  performance gaps (#3368's AABB-tree broadphase is merged base-branch
+  evidence; S3 narrowphase delta and
   small-scene overhead remain; the S6 dense-pile row was resolved by the
   documented acceptance re-scope), then flip only the DEFAULT detector (both ctors +
   WorldConfig/SkelParser surface). All legacy detectors stay real and

--- a/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
@@ -1,0 +1,116 @@
+# Phase 5 — backend consolidation, facades, and the 6.21/6.22 deprecation plan
+
+> Decision doc (v2, 2026-07-10). Evidence: source-verified gz usage surface
+> (`.deps/gz-physics/dartsim/src/`), the phase-0 acceptance envelope
+> ([05-phase0-baseline-packet.md](05-phase0-baseline-packet.md)), and the
+> 2026-07-10 current-head audit (`/tmp/audit_head_20260710T011207Z`).
+> Maintainer ratification points are listed at the end.
+
+## Goal restated
+
+Consolidate DART's built-in collision detection into one backend; deprecate
+the FCL, Bullet, and ODE collision backends in DART 6.21.0 and remove them in
+DART 6.22.0, while preserving the downstream gz-physics/gz-sim contract.
+
+## Decision 1 — canonical backend and naming
+
+**The native engine (`dart::collision::native`, class
+`NativeCollisionDetector`) is the single built-in backend; canonical factory
+key `"native"`. The legacy keys `"dart"`, `"fcl"`, `"bullet"`, `"ode"` remain
+permanently resolvable and, from 6.22, create native-backed implementations.**
+
+Rationale:
+
+- During the 6.20/6.21 transition `"dart"` still names the legacy limited
+  `DARTCollisionDetector`; documenting `"dart"` as canonical would be
+  ambiguous exactly when users migrate. `"native"` is unambiguous across the
+  whole window and already shipped as the opt-in key in 6.20.
+- The legacy `dart` detector is a strict subset of native (six primitive
+  pairs, narrowphase-only, `distance()` stub, no raycast, no broadphase), so
+  aliasing `"dart"` to native at 6.22 loses nothing.
+- gz-physics keeps working: all four names keep resolving
+  (`WorldFeatures.cc:47-70`), and gz's actual default is its own
+  `GzOdeCollisionDetector` subclass (`EntityManagementFeatures.cc:728`), so
+  DART's default flip does not change gz behavior by itself.
+- Phase 6 adds `CollisionDetectorType::Native` (World enum) and the dartpy
+  `NATIVE` enum value; the dartpy `NativeCollisionDetector` class binding
+  already landed with the comparison harness PR.
+
+## Decision 2 — facades over native, not component removal
+
+**6.22 removes the external fcl/bullet/ode dependencies; the detector classes
+and CMake components survive as compatibility facades over the native
+engine.** The source-verified gz obligations and how facades satisfy them:
+
+| gz obligation (evidence) | facade answer |
+| --- | --- |
+| `find_package(DART COMPONENTS collision-bullet collision-ode ...)` (`gz-physics/CMakeLists.txt:74-84`) | components remain, containing facade libs with no external dep |
+| `GzOdeCollisionDetector : public OdeCollisionDetector`, overrides `collide()x2`, adds per-pair capping (`GzOdeCollisionDetector.hh:26-69`) | `OdeCollisionDetector` stays a real subclassable class whose `collide()` delegates to native and honors `CollisionOption.maxNumContactsPerPair` |
+| keys "fcl"/"bullet"/"ode"/"dart" resolve via `create()` (`WorldFeatures.cc:47-70`) | facade factories keep all four registrations |
+| `getLastCollisionResult()` Contact fields {point, normal, penetrationDepth, force, collisionObject1/2} (`SimulationFeatures.cc:213-256`) | native populates the same DART 6 `Contact` (proven by adapter parity tests) |
+| raycast (Bullet incumbent, `SimulationFeatures.cc:176-185`) | native raycast merged (#3355) |
+| distance (FCL incumbent) | native distance merged (#3343/#3352) |
+| VoxelGrid/octree (FCL incumbent) | native compound voxel support merged (#3358) |
+
+Notes: gz subclasses **only** `OdeCollisionDetector` (there is no
+`GzBulletCollisionDetector`; the doc-03 matrix row overstated this). Bullet
+and FCL only need `create()` + name resolution + `getType()`.
+
+Behavior disclosure: facades emit native contact profiles (counts/normals may
+differ from real FCL/Bullet/ODE). That is the documented semantic of the 6.22
+removal; 6.21's deprecation cycle is the migration window, and the gz gate
+must pass against facades before 6.22 ships.
+
+## Mechanics facts that shape the implementation
+
+- The two FCL-hardcoded ConstraintSolver ctors are at
+  `dart/constraint/ConstraintSolver.cpp:416` and `:433` (doc 03's 322/342 was
+  stale). The phase-6 flip surface also includes `WorldConfig` (`World.hpp:103`
+  defaults to Fcl) and `SkelParser`'s FCL helpers
+  (`dart/utils/SkelParser.cpp:718-731`). 23 files reference
+  `FCLCollisionDetector` outside `dart/collision/fcl/` (5 core, 2 dartpy,
+  ~16 tests/examples).
+- Component asymmetry: `collision/fcl`, `collision/dart`, `collision/native`
+  compile **into core libdart** (`dart_add_core_headers/sources`);
+  `collision-bullet`/`collision-ode` are separate exported components. So the
+  6.22 bullet/ode drop is component-level, while the FCL drop is core surgery:
+  `target_link_libraries(dart PUBLIC ... fcl ...)` (`dart/CMakeLists.txt:117`),
+  `DART_PKG_EXTERNAL_DEPS` (`CMakeLists.txt:103` -> `dart.pc` Requires), and
+  `dart_check_required_package(fcl)` (`cmake/DARTFindDependencies.cmake:21-22`).
+- `DART_DEPRECATED(version)` ignores its argument and carries no message
+  (`dart/common/Deprecated.hpp:44-53`). 6.21 deprecations should use
+  `[[deprecated("...use the native collision detector...")]]` (or a new
+  `DART_DEPRECATED_MESSAGE`) on `create()`/constructors — NOT on the classes
+  gz subclasses; warning-cleanliness of `GzOdeCollisionDetector` under
+  -Werror must be prototyped before 6.21 ships.
+- SOVERSION is `MAJOR.MINOR` (`cmake/DARTMacros.cmake:94`): every minor gets
+  a new SONAME, so converting classes to facades in 6.21/6.22 is
+  ABI-permissible; the constraint is source/API compatibility plus the gz
+  gate.
+
+## Timeline
+
+- **6.20 (now, phases 4-6 of the port plan):** close the remaining native
+  performance gaps (broadphase landed; S3 narrowphase delta, small-scene
+  overhead, and the S6 dense-pile resting profile remain), then flip only the
+  DEFAULT detector (both ctors + WorldConfig/SkelParser surface). All legacy
+  detectors stay real and selectable; no deprecations on the LTS branch.
+- **6.21:** deprecation attributes with migration messages on
+  FCL/Bullet/ODE/legacy-dart `create()`/ctors; CHANGELOG + migration guide;
+  CMake configure-time notices. Everything still functional.
+- **6.22:** drop external fcl/bullet/ode from the required surface; classes
+  become facades-over-native; `"dart"` key resolves to the native engine;
+  legacy `DARTCollisionDetector` narrowphase retired; FCL decoupled from core
+  (`phase 7`), bullet/ode components rebuilt as facade components; package/
+  export smoke tests.
+
+## Maintainer ratification points
+
+1. Facade-over-native for `OdeCollisionDetector` vs coordinating a gz-physics
+   change that drops the `GzOdeCollisionDetector` subclass first (facade is
+   the recommended default; both keep the gz gate green in 6.22).
+2. Canonical name `"native"` (recommended) vs `"dart"` — both keys resolve to
+   the same engine from 6.22 either way; this only decides documentation and
+   the eventual class naming.
+3. Whether 6.21 should also deprecate the legacy `DARTCollisionDetector`
+   engine explicitly (recommended: yes, same cycle).

--- a/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
@@ -103,9 +103,10 @@ must pass against facades before 6.22 ships.
 ## Timeline
 
 - **6.20 (now, phases 4-6 of the port plan):** close the remaining native
-  performance gaps (broadphase landed; S3 narrowphase delta and small-scene
-  overhead remain; the S6 dense-pile row was resolved by the documented
-  acceptance re-scope), then flip only the DEFAULT detector (both ctors +
+  performance gaps (#3368 carries the branch-local broadphase work and must
+  merge before it is a base-branch precondition; S3 narrowphase delta and
+  small-scene overhead remain; the S6 dense-pile row was resolved by the
+  documented acceptance re-scope), then flip only the DEFAULT detector (both ctors +
   WorldConfig/SkelParser surface). All legacy detectors stay real and
   selectable; no deprecations on the LTS branch.
 - **6.21:** deprecation attributes with migration messages on

--- a/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/08-phase5-facade-decision.md
@@ -12,40 +12,50 @@ Consolidate DART's built-in collision detection into one backend; deprecate
 the FCL, Bullet, and ODE collision backends in DART 6.21.0 and remove them in
 DART 6.22.0, while preserving the downstream gz-physics/gz-sim contract.
 
-## Decision 1 — canonical backend and naming
+## Decision 1 — canonical backend and naming (maintainer-directed, 2026-07-10)
 
-**The native engine (`dart::collision::native`, class
-`NativeCollisionDetector`) is the single built-in backend; canonical factory
-key `"native"`. The legacy keys `"dart"`, `"fcl"`, `"bullet"`, `"ode"` remain
-permanently resolvable and, from 6.22, create native-backed implementations.**
+**The native engine merges INTO the `dart` detector: `dart/collision/native/`
+folds into `dart/collision/dart/`, and `NativeCollisionDetector` merges into
+`DARTCollisionDetector`, replacing its legacy narrowphase-only
+implementation. The single built-in backend is the `dart` detector, canonical
+factory key `"dart"`. The keys `"fcl"`, `"bullet"`, `"ode"` remain resolvable
+and, from 6.22, create dart-backed facade implementations.**
 
-Rationale:
+Maintainer direction (2026-07-10): "NativeDetector must merged into
+DartDetector (so native/ into dart/ as well)."
 
-- During the 6.20/6.21 transition `"dart"` still names the legacy limited
-  `DARTCollisionDetector`; documenting `"dart"` as canonical would be
-  ambiguous exactly when users migrate. `"native"` is unambiguous across the
-  whole window and already shipped as the opt-in key in 6.20.
-- The legacy `dart` detector is a strict subset of native (six primitive
-  pairs, narrowphase-only, `distance()` stub, no raycast, no broadphase), so
-  aliasing `"dart"` to native at 6.22 loses nothing.
-- gz-physics keeps working: all four names keep resolving
-  (`WorldFeatures.cc:47-70`), and gz's actual default is its own
-  `GzOdeCollisionDetector` subclass (`EntityManagementFeatures.cc:728`), so
-  DART's default flip does not change gz behavior by itself.
-- Phase 6 adds `CollisionDetectorType::Native` (World enum) and the dartpy
-  `NATIVE` enum value; the dartpy `NativeCollisionDetector` class binding
-  already landed with the comparison harness PR.
+Mechanics, and why this is clean now:
 
-## Decision 2 — facades over native, not component removal
+- 6.20.0 is unreleased, so the interim `"native"` factory key, the
+  `NativeCollisionDetector` class name, and its dartpy binding have never
+  shipped; the consolidation PR renames/folds them with no deprecation cycle.
+  All in-tree users are updated in the same PR (`contact_benchmark
+  --collision native`, dashboard detector index 4, native unit tests, the
+  comparison harness's `--detector native`, the dartpy binding).
+- The legacy `DARTCollisionDetector` narrowphase (six primitive pairs, no
+  broadphase, `distance()` stub, no raycast) is a strict subset of the engine
+  replacing it, so the `"dart"` key only gains capability. `dart`-detector
+  guard rows re-baseline with the consolidation PR's A/B evidence
+  (pre-release change, allowed with recorded old/new rows).
+- gz-physics keeps working: `SetWorldCollisionDetector("dart")` returns the
+  consolidated engine; the other names keep resolving; gz's own default
+  remains its `GzOdeCollisionDetector` subclass until 6.22
+  (`EntityManagementFeatures.cc:728`).
+- No new enum value is needed: `CollisionDetectorType::Dart` and the dartpy
+  `DARTCollisionDetector` binding now denote the consolidated engine, and the
+  phase-6 flip simply changes the default from Fcl to Dart across the flip
+  surface (`ConstraintSolver.cpp:416`/`:433`, `WorldConfig`, `SkelParser`).
+
+## Decision 2 — facades over the dart detector, not component removal
 
 **6.22 removes the external fcl/bullet/ode dependencies; the detector classes
-and CMake components survive as compatibility facades over the native
-engine.** The source-verified gz obligations and how facades satisfy them:
+and CMake components survive as compatibility facades over the consolidated
+`dart` detector.** The source-verified gz obligations and how facades satisfy them:
 
 | gz obligation (evidence) | facade answer |
 | --- | --- |
 | `find_package(DART COMPONENTS collision-bullet collision-ode ...)` (`gz-physics/CMakeLists.txt:74-84`) | components remain, containing facade libs with no external dep |
-| `GzOdeCollisionDetector : public OdeCollisionDetector`, overrides `collide()x2`, adds per-pair capping (`GzOdeCollisionDetector.hh:26-69`) | `OdeCollisionDetector` stays a real subclassable class whose `collide()` delegates to native and honors `CollisionOption.maxNumContactsPerPair` |
+| `GzOdeCollisionDetector : public OdeCollisionDetector`, overrides `collide()x2`, adds per-pair capping (`GzOdeCollisionDetector.hh:26-69`) | `OdeCollisionDetector` stays a real subclassable class whose `collide()` delegates to the dart engine and honors `CollisionOption.maxNumContactsPerPair` |
 | keys "fcl"/"bullet"/"ode"/"dart" resolve via `create()` (`WorldFeatures.cc:47-70`) | facade factories keep all four registrations |
 | `getLastCollisionResult()` Contact fields {point, normal, penetrationDepth, force, collisionObject1/2} (`SimulationFeatures.cc:213-256`) | native populates the same DART 6 `Contact` (proven by adapter parity tests) |
 | raycast (Bullet incumbent, `SimulationFeatures.cc:176-185`) | native raycast merged (#3355) |
@@ -56,7 +66,7 @@ Notes: gz subclasses **only** `OdeCollisionDetector` (there is no
 `GzBulletCollisionDetector`; the doc-03 matrix row overstated this). Bullet
 and FCL only need `create()` + name resolution + `getType()`.
 
-Behavior disclosure: facades emit native contact profiles (counts/normals may
+Behavior disclosure: facades emit the dart engine's contact profiles (counts/normals may
 differ from real FCL/Bullet/ODE). That is the documented semantic of the 6.22
 removal; 6.21's deprecation cycle is the migration window, and the gz gate
 must pass against facades before 6.22 ships.
@@ -79,7 +89,7 @@ must pass against facades before 6.22 ships.
   `dart_check_required_package(fcl)` (`cmake/DARTFindDependencies.cmake:21-22`).
 - `DART_DEPRECATED(version)` ignores its argument and carries no message
   (`dart/common/Deprecated.hpp:44-53`). 6.21 deprecations should use
-  `[[deprecated("...use the native collision detector...")]]` (or a new
+  `[[deprecated("...use the dart collision detector...")]]` (or a new
   `DART_DEPRECATED_MESSAGE`) on `create()`/constructors — NOT on the classes
   gz subclasses; warning-cleanliness of `GzOdeCollisionDetector` under
   -Werror must be prototyped before 6.21 ships.
@@ -96,21 +106,20 @@ must pass against facades before 6.22 ships.
   DEFAULT detector (both ctors + WorldConfig/SkelParser surface). All legacy
   detectors stay real and selectable; no deprecations on the LTS branch.
 - **6.21:** deprecation attributes with migration messages on
-  FCL/Bullet/ODE/legacy-dart `create()`/ctors; CHANGELOG + migration guide;
+  FCL/Bullet/ODE `create()`/ctors; CHANGELOG + migration guide;
   CMake configure-time notices. Everything still functional.
 - **6.22:** drop external fcl/bullet/ode from the required surface; classes
-  become facades-over-native; `"dart"` key resolves to the native engine;
-  legacy `DARTCollisionDetector` narrowphase retired; FCL decoupled from core
+  become facades over the dart detector; FCL decoupled from core
   (`phase 7`), bullet/ode components rebuilt as facade components; package/
   export smoke tests.
 
 ## Maintainer ratification points
 
-1. Facade-over-native for `OdeCollisionDetector` vs coordinating a gz-physics
+1. Facade-over-dart for `OdeCollisionDetector` vs coordinating a gz-physics
    change that drops the `GzOdeCollisionDetector` subclass first (facade is
    the recommended default; both keep the gz gate green in 6.22).
-2. Canonical name `"native"` (recommended) vs `"dart"` — both keys resolve to
-   the same engine from 6.22 either way; this only decides documentation and
-   the eventual class naming.
-3. Whether 6.21 should also deprecate the legacy `DARTCollisionDetector`
-   engine explicitly (recommended: yes, same cycle).
+2. ~~Canonical name~~ RESOLVED by maintainer direction 2026-07-10: canonical
+   `"dart"`, with `dart/collision/native/` merged into `dart/collision/dart/`
+   and `NativeCollisionDetector` merged into `DARTCollisionDetector`.
+3. (retired) The legacy `DARTCollisionDetector` engine question is subsumed
+   by the consolidation: its narrowphase is replaced in 6.20, not deprecated.

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -27,7 +27,7 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 | 1 | Native math core (Aabb/Gjk/Mpr/BoxBox/SphereSphere/shapes/Span shim) internal-only | ✅ merged (#3281) |
 | 2 | DART 6 detector adapter over the native core (bridge, sliced P1–P9 + P10 coverage) | ✅ complete (#3350) |
 | 3 | Capability parity (distance→FCL, raycast→Bullet, CCD, manifolds, voxel) | ✅ complete (#3360) |
-| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — #3364 merged; AABB-tree broadphase PR #3368 open (bit-identical guards, S3 −65%); remaining: S3 narrowphase delta and small-scene overhead; S6 resolved by documented acceptance re-scope (see RESUME) |
+| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — #3364 and AABB-tree broadphase #3368 merged (bit-identical guards, S3 −65%); remaining: S3 narrowphase delta and small-scene overhead; S6 resolved by documented acceptance re-scope (see RESUME) |
 | 5 | Bullet/ODE/FCL facade decision (must keep gz subclassing) | 🔄 **active** — decision doc drafted with maintainer direction; ODE facade-vs-coordinated-gz change remains to ratify |
 | 6 | Default flip in both `ConstraintSolver` ctors (point of no return) | ⬜ not started |
 | 7 | FCL decoupling from core (the dependency win) + retire this task folder | ⬜ not started |

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -27,7 +27,7 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 | 1 | Native math core (Aabb/Gjk/Mpr/BoxBox/SphereSphere/shapes/Span shim) internal-only | ✅ merged (#3281) |
 | 2 | DART 6 detector adapter over the native core (bridge, sliced P1–P9 + P10 coverage) | ✅ complete (#3350) |
 | 3 | Capability parity (distance→FCL, raycast→Bullet, CCD, manifolds, voxel) | ✅ complete (#3360) |
-| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — first solver-facing manifold optimization merged (#3364); see §4 |
+| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — #3364 merged; AABB-tree broadphase PR #3368 open (bit-identical guards, S3 −65%); remaining: S3 narrowphase delta, small-scene overhead, S6 resting profile (see RESUME) |
 | 5 | Bullet/ODE/FCL facade decision (must keep gz subclassing) | ⬜ not started |
 | 6 | Default flip in both `ConstraintSolver` ctors (point of no return) | ⬜ not started |
 | 7 | FCL decoupling from core (the dependency win) + retire this task folder | ⬜ not started |

--- a/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/HANDOFF.md
@@ -27,8 +27,8 @@ default detector until the phase-6 flip**, and every phase is gz-gated.
 | 1 | Native math core (Aabb/Gjk/Mpr/BoxBox/SphereSphere/shapes/Span shim) internal-only | ✅ merged (#3281) |
 | 2 | DART 6 detector adapter over the native core (bridge, sliced P1–P9 + P10 coverage) | ✅ complete (#3350) |
 | 3 | Capability parity (distance→FCL, raycast→Bullet, CCD, manifolds, voxel) | ✅ complete (#3360) |
-| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — #3364 merged; AABB-tree broadphase PR #3368 open (bit-identical guards, S3 −65%); remaining: S3 narrowphase delta, small-scene overhead, S6 resting profile (see RESUME) |
-| 5 | Bullet/ODE/FCL facade decision (must keep gz subclassing) | ⬜ not started |
+| 4 | Evidence-driven performance optimization (broadphase, SIMD, manifold reuse) | 🔄 **active** — #3364 merged; AABB-tree broadphase PR #3368 open (bit-identical guards, S3 −65%); remaining: S3 narrowphase delta and small-scene overhead; S6 resolved by documented acceptance re-scope (see RESUME) |
+| 5 | Bullet/ODE/FCL facade decision (must keep gz subclassing) | 🔄 **active** — decision doc drafted with maintainer direction; ODE facade-vs-coordinated-gz change remains to ratify |
 | 6 | Default flip in both `ConstraintSolver` ctors (point of no return) | ⬜ not started |
 | 7 | FCL decoupling from core (the dependency win) + retire this task folder | ⬜ not started |
 

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -78,11 +78,42 @@ scope-diff-guarded.
 - **D6** (solver-facing native manifold cap with performance evidence):
   **#3364** — **merged**.
 
-**Next: Phase 4 closeout / remaining measured optimization.** PR #3364 landed
-the first native performance optimization: cap solver-facing native manifolds at
-three contacts while honoring stricter per-pair caps. This targets the measured
-solver row overhead from native's fourth contact on contact-rich scenes and
-keeps the native detector opt-in.
+**Phase 4 continues (2026-07-10 refresh).** After #3364, the AABB-tree
+broadphase PR (#3368, `feature/native-aabb-tree-broadphase`) replaced the
+O(n^2) BruteForce pair loop with DART 7's dynamic AABB tree while keeping all
+eight native guard rows bit-identical (fat-AABB cull + tight-AABB filter +
+sorted pair order): S2 settled-3k 0.0809 -> 0.0340 ms/step (now ties the
+`dart` detector), S3 active-3k 34.63 -> 12.28 ms/step, S4 generated-900
+0.125 -> 0.072, GB 120/4/1 1404 -> 1232 ms; gz gate green on the branch.
+Artifacts: `/tmp/audit_head_20260710T011207Z` (parent full matrix incl.
+native rows) and `/tmp/aabbtree_ab_20260710T022954Z` (branch A/B).
+
+Remaining measured Phase 4 gaps against the phase-6 envelope (native >=
+fastest incumbent per row):
+
+1. S3 active-3k: native 12.28 vs dart 9.14 ms/step (16-thread) — remaining
+   delta is narrowphase/manifold-cache side; profile on a quiet host first.
+2. Small scenes: native ~1.21 vs dart 1.06 ms/step on S1-60; ~40% slower
+   than dart on a small MJCF arm-scene bisect. Native small-scene collide
+   overhead packet.
+3. S6 dense-pile resting profile: native 0/71 resting vs dart 71/71 — the
+   pile physically jitters (max smoothed linear speed 0.24 m/s at 20k
+   steps); NOT a sleep-gating bug. A solver-facing manifold cap 3 -> 4 A/B
+   was decisively REJECTED (penetration 0.0046 -> 0.158 m, S1-120 +102%;
+   `/tmp/cap4_ab_20260710T014124Z`). Root cause is contact-quality/solver
+   interaction; next probe is a shape-type bisect of the pile (box-only vs
+   cylinder-only) under native vs dart.
+
+**Phase 5 decision draft exists:**
+[08-phase5-facade-decision.md](08-phase5-facade-decision.md) — canonical key
+`native`; 6.21 deprecates FCL/Bullet/ODE via messaged attributes on
+create()/ctors; 6.22 removes the external deps with facades-over-native
+(only `OdeCollisionDetector` needs subclassability for gz). Maintainer
+ratification points are listed in that doc. Note doc 03's ConstraintSolver
+line numbers were stale: the FCL ctor sites are `ConstraintSolver.cpp:416`
+and `:433`.
+
+Historical context for #3364 (superseded rows above):
 
 Measured on `origin/release-6.20` parent `43e419638986` vs #3364:
 

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -96,13 +96,34 @@ fastest incumbent per row):
 2. Small scenes: native ~1.21 vs dart 1.06 ms/step on S1-60; ~40% slower
    than dart on a small MJCF arm-scene bisect. Native small-scene collide
    overhead packet.
-3. S6 dense-pile resting profile: native 0/71 resting vs dart 71/71 — the
-   pile physically jitters (max smoothed linear speed 0.24 m/s at 20k
-   steps); NOT a sleep-gating bug. A solver-facing manifold cap 3 -> 4 A/B
-   was decisively REJECTED (penetration 0.0046 -> 0.158 m, S1-120 +102%;
-   `/tmp/cap4_ab_20260710T014124Z`). Root cause is contact-quality/solver
-   interaction; next probe is a shape-type bisect of the pile (box-only vs
-   cylinder-only) under native vs dart.
+3. S6 dense-pile resting profile: RESOLVED as a documented re-scope
+   (2026-07-11, maintainer-authorized best-path with self-run A/B). Five
+   approaches were falsified with evidence: naive cap-4 (creep 0.158 m,
+   S1-120 +102%), an ERV dead-zone inside the resting band (reintroduced
+   #3209 creep: the 0.1 ERV push is simultaneously the anti-creep mechanism
+   and the jitter pump), split impulse as shipped (untuned; pen 0.182),
+   all cached-state toggles (warm-start/friction-basis/refresh-threshold:
+   zero effect; the Dantzig fallback fires ~1/89k solves so impulse seeds
+   are inert), and quad-area 4th point + cap 4 (fixed the naive-cap-4
+   degeneracy and produced the only transient rest ever observed — 5/71 at
+   20k steps — but 40k-horizon re-wakes to 0/71). Meanwhile the REAL
+   acceptance surfaces all rest BETTER under native than legacy dart:
+   S2 gz 3k 3003/3003, S4 900/900 (dart: 600/900), S5 90/90 (dart: 60/90);
+   legacy dart itself fails the S6 fixture on 1/5 seeds, and rolling-shape
+   piles never rest under ANY detector (physically correct without rolling
+   resistance). The consolidated-detector S6 acceptance row becomes:
+   bounded max_penetration within the dense-island band (anti-creep, the
+   actual #3209 finding: 0.005 at 40k steps vs 0.36 unbounded pre-D7) +
+   finite + documented non-resting attributable to rolling dynamics. A
+   rolling-resistance contact parameter (condim>=4 analog; D7-style
+   adaptive defaults) graduates to a designed 6.21 feature. Salvage: the
+   quad-area 4th-point criterion fix for the manifold cache is
+   independently correct (the volume criterion degenerates on coplanar
+   face manifolds) and ships separately with its own hash A/B (cap stays
+   3); probe branch exp/quadcap4-manifold; artifacts
+   ~/dart-bench-artifacts/ (note: earlier /tmp artifact paths in this file
+   were lost to a host reboot; the numbers are preserved here and in the
+   PR bodies).
 
 **Phase 5 decision (maintainer-directed 2026-07-10):**
 [08-phase5-facade-decision.md](08-phase5-facade-decision.md) — the native

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -125,7 +125,7 @@ fastest incumbent per row):
    were lost to a host reboot; the numbers are preserved here and in the
    PR bodies).
 
-**Phase 5 decision (maintainer-directed 2026-07-10):**
+**Phase 5 decision is active (maintainer-directed 2026-07-10):**
 [08-phase5-facade-decision.md](08-phase5-facade-decision.md) — the native
 engine merges INTO the dart detector (`dart/collision/native/` folds into
 `dart/collision/dart/`, `NativeCollisionDetector` merges into

--- a/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
+++ b/docs/dev_tasks/dart6_dependency_minimization/RESUME.md
@@ -104,14 +104,20 @@ fastest incumbent per row):
    interaction; next probe is a shape-type bisect of the pile (box-only vs
    cylinder-only) under native vs dart.
 
-**Phase 5 decision draft exists:**
-[08-phase5-facade-decision.md](08-phase5-facade-decision.md) — canonical key
-`native`; 6.21 deprecates FCL/Bullet/ODE via messaged attributes on
-create()/ctors; 6.22 removes the external deps with facades-over-native
-(only `OdeCollisionDetector` needs subclassability for gz). Maintainer
-ratification points are listed in that doc. Note doc 03's ConstraintSolver
-line numbers were stale: the FCL ctor sites are `ConstraintSolver.cpp:416`
-and `:433`.
+**Phase 5 decision (maintainer-directed 2026-07-10):**
+[08-phase5-facade-decision.md](08-phase5-facade-decision.md) — the native
+engine merges INTO the dart detector (`dart/collision/native/` folds into
+`dart/collision/dart/`, `NativeCollisionDetector` merges into
+`DARTCollisionDetector`, canonical key `"dart"`; the interim `"native"` key
+never shipped and is folded in the consolidation PR). 6.21 deprecates
+FCL/Bullet/ODE via messaged attributes on create()/ctors; 6.22 removes the
+external deps with facades over the dart detector (only
+`OdeCollisionDetector` needs subclassability for gz). Remaining ratification
+point: facade-vs-coordinated-gz-change for ODE. Note doc 03's
+ConstraintSolver line numbers were stale: the FCL ctor sites are
+`ConstraintSolver.cpp:416` and `:433`. The maintainer also set a total PR
+budget for the whole effort (prefer fewer, larger cohesive PRs; ~10-20 total
+across both dev tasks).
 
 Historical context for #3364 (superseded rows above):
 

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -17,11 +17,10 @@ criteria 1-3 MET on the merged head). The maintainer broadened criterion 4 to
 cross-engine evidence vs MuJoCo across DART's major workloads; lane **WS-G**
 (08-mujoco-comparison-lane.md) owns that work. #3366 (dartpy getDofs ownership
 bugfix) and #3367 (MuJoCo comparison harness + mujoco env + dartpy native
-binding) have merged. Open PRs from the 2026-07-10 cycle: #3368 (native
-AABB-tree broadphase, dep-min lane) and #3369 (MJCF stacked hinge/slide joint
-support). In-flight packets: MJCF contype/conaffinity+friction fidelity and
-native small-scene overhead (WP-SS family); the S6 native resting-profile row
-is resolved by the dep-min lane's documented acceptance re-scope.
+binding), #3368 (native AABB-tree broadphase), and #3369 (MJCF stacked joints
+and collision fidelity) have merged. The native small-scene overhead WP-SS
+family remains in flight; the S6 native resting-profile row is resolved by the
+dep-min lane's documented acceptance re-scope.
 
 ## Lane status
 
@@ -32,7 +31,7 @@ is resolved by the dep-min lane's documented acceptance re-scope.
 | WS-C dynamics batching | 04-dynamics-batching-lane.md | PG.30–PG.33 | gated (PG.30 #3310; PG.31 #3341; PG.32 delivered by #3297/#3307; PG.33 gated) |
 | WS-D SIMD enablement | 05-simd-enablement-lane.md | PG.40–PG.42 | active (PG.40 folded into PG.42; PG.41 waits for PG.10 seam evidence) |
 | WS-E infra/evidence | 06-infra-evidence-lane.md | PG.01–PG.04 | open (PG.01 done; PG.02 #3327; PG.03 #3337; PG.04 blocked D4) |
-| WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phases 0–3 complete (native adapter + capability parity); phase 4 active after #3364, with AABB-tree broadphase in open PR #3368 |
+| WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phases 0–3 complete (native adapter + capability parity); phase 4 active after #3364, with AABB-tree broadphase merged in #3368 |
 
 ## Packet board
 
@@ -70,8 +69,8 @@ against the packet's acceptance evidence.
 
 - WS-F consumes WS-D kernels in its phase 4. Phases 0–3 are complete, including
   the DART 6 native detector adapter and capability parity; phase 4 is active
-  after #3364. Open PR #3368 carries the branch-local AABB-tree broadphase and
-  must merge before that result is treated as base-branch evidence.
+  after #3364, and #3368's AABB-tree broadphase is now merged base-branch
+  evidence.
 - WS-B investment is re-reviewed when WS-F reaches phase 5 (facade
   decision) — see D5 in the README.
 - WS-A WP-PG.12 and WS-C WP-PG.30 share the single-free-body

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -16,9 +16,9 @@ Current handoff (2026-07-10): the completion audit ran (see RESUME.md —
 criteria 1-3 MET on the merged head). The maintainer broadened criterion 4 to
 cross-engine evidence vs MuJoCo across DART's major workloads; lane **WS-G**
 (08-mujoco-comparison-lane.md) owns that work. #3366 (dartpy getDofs ownership
-bugfix) has merged. Open PRs from the 2026-07-10 cycle: #3367 (MuJoCo
-comparison harness + mujoco env + dartpy native binding), #3368 (native
-AABB-tree broadphase, dep-min lane), and #3369 (MJCF stacked hinge/slide joint
+bugfix) and #3367 (MuJoCo comparison harness + mujoco env + dartpy native
+binding) have merged. Open PRs from the 2026-07-10 cycle: #3368 (native
+AABB-tree broadphase, dep-min lane) and #3369 (MJCF stacked hinge/slide joint
 support). In-flight packets: MJCF contype/conaffinity+friction fidelity and
 native small-scene overhead (WP-SS family); the S6 native resting-profile row
 is resolved by the dep-min lane's documented acceptance re-scope.

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -12,11 +12,16 @@ Related open queue at last refresh: none blocking (enablers merged:
 #3270 was closed by maintainer direction and its D1/D2 evidence now rides
 with the first real SIMD-kernel PR.
 
-Current handoff (2026-07-09): no packet is claimed after #3361. The next
-session should run the current-head completion/evidence audit in RESUME.md
-before writing more code. If the audit finds a real remaining bottleneck, claim
-the smallest matching packet; otherwise prepare the closeout/promote-docs path
-for issue #3056 rather than creating more small PRs.
+Current handoff (2026-07-10): the completion audit ran (see RESUME.md —
+criteria 1-3 MET on the merged head). The maintainer broadened criterion 4 to
+cross-engine evidence vs MuJoCo across DART's major workloads; lane **WS-G**
+(08-mujoco-comparison-lane.md) owns that work. Open PRs from the 2026-07-10
+cycle: #3366 (dartpy getDofs ownership bugfix), #3367 (MuJoCo comparison
+harness + mujoco env + dartpy native binding), #3368 (native AABB-tree
+broadphase, dep-min lane), #3369 (MJCF stacked hinge/slide joint support).
+In-flight packets: MJCF contype/conaffinity+friction fidelity; native
+small-scene overhead (WP-SS family) and the S6 native resting-profile
+investigation are evidence-gated in the dep-min lane.
 
 ## Lane status
 

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -15,13 +15,13 @@ with the first real SIMD-kernel PR.
 Current handoff (2026-07-10): the completion audit ran (see RESUME.md —
 criteria 1-3 MET on the merged head). The maintainer broadened criterion 4 to
 cross-engine evidence vs MuJoCo across DART's major workloads; lane **WS-G**
-(08-mujoco-comparison-lane.md) owns that work. Open PRs from the 2026-07-10
-cycle: #3366 (dartpy getDofs ownership bugfix), #3367 (MuJoCo comparison
-harness + mujoco env + dartpy native binding), #3368 (native AABB-tree
-broadphase, dep-min lane), #3369 (MJCF stacked hinge/slide joint support).
-In-flight packets: MJCF contype/conaffinity+friction fidelity; native
-small-scene overhead (WP-SS family) and the S6 native resting-profile
-investigation are evidence-gated in the dep-min lane.
+(08-mujoco-comparison-lane.md) owns that work. #3366 (dartpy getDofs ownership
+bugfix) has merged. Open PRs from the 2026-07-10 cycle: #3367 (MuJoCo
+comparison harness + mujoco env + dartpy native binding), #3368 (native
+AABB-tree broadphase, dep-min lane), and #3369 (MJCF stacked hinge/slide joint
+support). In-flight packets: MJCF contype/conaffinity+friction fidelity and
+native small-scene overhead (WP-SS family); the S6 native resting-profile row
+is resolved by the dep-min lane's documented acceptance re-scope.
 
 ## Lane status
 

--- a/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
+++ b/docs/dev_tasks/dart6_performance_generalization/07-orchestration-dashboard.md
@@ -32,7 +32,7 @@ is resolved by the dep-min lane's documented acceptance re-scope.
 | WS-C dynamics batching | 04-dynamics-batching-lane.md | PG.30–PG.33 | gated (PG.30 #3310; PG.31 #3341; PG.32 delivered by #3297/#3307; PG.33 gated) |
 | WS-D SIMD enablement | 05-simd-enablement-lane.md | PG.40–PG.42 | active (PG.40 folded into PG.42; PG.41 waits for PG.10 seam evidence) |
 | WS-E infra/evidence | 06-infra-evidence-lane.md | PG.01–PG.04 | open (PG.01 done; PG.02 #3327; PG.03 #3337; PG.04 blocked D4) |
-| WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phase 1 internal math core merged (#3281); no DART 6 detector adapter or phase-4 broadphase SIMD yet |
+| WS-F native collision port | ../dart6_dependency_minimization/03-native-collision-port-scoping.md | phases 0–7 | external owner; phases 0–3 complete (native adapter + capability parity); phase 4 active after #3364, with AABB-tree broadphase in open PR #3368 |
 
 ## Packet board
 
@@ -68,9 +68,10 @@ against the packet's acceptance evidence.
 
 ## Cross-lane coordination notes
 
-- WS-F consumes WS-D kernels in its phase 4; WS-D's WP-PG.42 checked live
-  phase status before claiming. As of #3281, WS-F has internal native
-  collision math only, with no DART 6 detector adapter or broadphase SIMD.
+- WS-F consumes WS-D kernels in its phase 4. Phases 0–3 are complete, including
+  the DART 6 native detector adapter and capability parity; phase 4 is active
+  after #3364. Open PR #3368 carries the branch-local AABB-tree broadphase and
+  must merge before that result is treated as base-branch evidence.
 - WS-B investment is re-reviewed when WS-F reaches phase 5 (facade
   decision) — see D5 in the README.
 - WS-A WP-PG.12 and WS-C WP-PG.30 share the single-free-body

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -18,7 +18,9 @@ engines, warmup excluded, median-of-reps, finite/contact telemetry,
 FFI-overhead calibration row, MuJoCo integrator normalized to Euler with
 model-default sensitivity row, 1.1x win/noise band).
 
-Reproduce:
+Reproduce (the harness and the `mujoco` pixi environment land with #3367;
+until that merges, run from the `feature/mujoco-comparison-harness` branch —
+and the humanoid rows additionally need #3369's MJCF stacked-joint support):
 
 ```sh
 pixi run build-py-dev && pixi install -e mujoco

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -26,7 +26,7 @@ collision-fidelity work needed by the affected rows):
 pixi run build-py-dev && pixi install -e mujoco
 PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
   pixi run python scripts/mujoco_comparison/run_comparison.py \
-  --reps 5 --detector native \
+  --reps 5 --detector native --dart-sleep off \
   --scene ARM-REACHER --scene ARM-PUSHER \
   --scene HUM-FALL --scene HUM-ACTIVE \
   --scene PILE-120 --scene PILE-900 --scene DYN-STIR-120 \
@@ -35,7 +35,8 @@ PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
 ```
 
 The explicit scene list is required: the runner's default set still omits the
-two HUM rows. Do not accept the cross-engine matrix unless both HUM rows run;
+two HUM rows. `--dart-sleep off` makes every active comparison independent of
+deactivation. Do not accept the cross-engine matrix unless both HUM rows run;
 a parser or runtime failure remains a blocked row rather than evidence.
 
 ## Standings (2026-07-10 prototype rows; quiet-host full matrix pending)

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -34,7 +34,6 @@ PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
 
 | Class | Scene | DART (native det) | MuJoCo | Verdict |
 | --- | --- | ---: | ---: | --- |
-| Locomotion | ant | 0.0306 ms/step | 0.0398 | **DART +30%** |
 | Arms | reacher | 0.0200 | 0.0086 | MJ 2.3x (µs-scale) |
 | Arms | pusher | 0.0373 | 0.0065 | MJ 5.7x |
 | Arms | striker/thrower | — | — | INVALID until contype fidelity lands |
@@ -42,6 +41,11 @@ PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
 | Many objects | PILE-120 active | 1.55 ms/step | 0.57 | MJ ~2.7x |
 | Dynamic | DYN-STIR-120 | 1.82 | 0.61 | MJ ~3.0x |
 | Sleeping | settled 3k | 0.034 ms/step (deactivation) | ~2 (no sleeping exists) | **DART ~60x** (to be formalized) |
+
+The prototype ant row is deferred: the merged orchestrator does not register
+an ant scenario, and no exact direct-runner command, artifact, and engine SHAs
+were retained for the earlier measurement. Do not treat that result as accepted
+evidence; restore a locomotion row only with reproducible provenance.
 
 ## Gap analysis -> packets
 

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -1,0 +1,77 @@
+# WS-G — MuJoCo cross-engine comparison lane (generalized performance)
+
+> Owner doc for the maintainer-directed generalization goal: DART must
+> outperform MuJoCo across its major workloads — robot arms/manipulators,
+> humanoids, many-object scenes, sleeping-body cases, and highly dynamic
+> non-sleeping cases — with full collision + constraint pipelines exercised
+> (no sleep-shortcut wins on the dynamic classes).
+
+## Harness
+
+`scripts/mujoco_comparison/` (landed in #3367): split-process runners
+(`dart_runner.py` in the default env against the dartpy dev build;
+`mujoco_runner.py` in the lean `mujoco` pixi env pinning conda-forge
+`mujoco-python`), one seeded SceneSpec emitting both a dartpy world and MJCF,
+fairness contract in its README (same timestep, single-threaded, identical
+seeded per-joint sinusoidal torques applied directly to joints on both
+engines, warmup excluded, median-of-reps, finite/contact telemetry,
+FFI-overhead calibration row, MuJoCo integrator normalized to Euler with
+model-default sensitivity row, 1.1x win/noise band).
+
+Reproduce:
+
+```sh
+pixi run build-py-dev && pixi install -e mujoco
+PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
+  pixi run python scripts/mujoco_comparison/run_comparison.py \
+  --reps 5 --detector native \
+  --mujoco-python $PWD/.pixi/envs/mujoco/bin/python --out-dir /tmp/mj_cmp
+```
+
+## Standings (2026-07-10 prototype rows; quiet-host full matrix pending)
+
+| Class | Scene | DART (native det) | MuJoCo | Verdict |
+| --- | --- | ---: | ---: | --- |
+| Locomotion | ant | 0.0306 ms/step | 0.0398 | **DART +30%** |
+| Arms | reacher | 0.0200 | 0.0086 | MJ 2.3x (µs-scale) |
+| Arms | pusher | 0.0373 | 0.0065 | MJ 5.7x |
+| Arms | striker/thrower | — | — | INVALID until contype fidelity lands |
+| Humanoid | humanoid.xml | parse fails | 0.113 | blocked on stacked-joint parser |
+| Many objects | PILE-120 active | 1.55 ms/step | 0.57 | MJ ~2.7x |
+| Dynamic | DYN-STIR-120 | 1.82 | 0.61 | MJ ~3.0x |
+| Sleeping | settled 3k | 0.034 ms/step (deactivation) | ~2 (no sleeping exists) | **DART ~60x** (to be formalized) |
+
+## Gap analysis -> packets
+
+1. **MJCF stacked-joint compositions** (humanoid/walker2d/hopper/half_cheetah/
+   swimmer fail to load; MjcfParser.cpp:386): chain-of-1-DOF-joints design;
+   packet delegated (in flight).
+2. **MJCF collision/friction fidelity**: contype/conaffinity ignored (DART
+   collides marker geoms MuJoCo excludes — striker's density-1e6 cylinder
+   makes Dantzig fail every step and forces the PGS fallback + double
+   constructLcpTerms); per-geom friction ignored. Blocks fair arm rows.
+3. **Small-scene per-step overhead** (arms class): pusher profile shows
+   ~11.35 µs per tiny LCP group (constructLcpTerms ~5 µs/call),
+   updateConstraints self ~11.8 µs, integration ~12 µs, vs MuJoCo's whole
+   step at 6.5 µs. Packet family WP-SS.1 (small-LCP construct/solve fast
+   path), WP-SS.2 (native small-scene collide overhead; also the S1-60
+   parity gap), WP-SS.3 (integration overhead for small skeletons). Cut
+   after fidelity packets land (do not optimize against invalid scenes).
+4. **Active-pile gap (~2.7x)**: post-AabbTree (#3368) the many-object
+   broadphase is fixed; remaining active-pile cost is solver-side (Dantzig
+   per-island + contact allocation churn). Re-baseline after #3368 +
+   fidelity, then decide packets (matrix-free option rows are diagnostic
+   only, default-off per D3).
+5. **dartpy getDofs ownership bug** (#3366): fixed; harness torque-drive
+   depends on it.
+
+## Rules
+
+- Wins on ARM/HUM-ACTIVE/PILE(active)/DYN classes must show zero sleeping
+  bodies in DART (deactivation disabled on DYN rows; asserted).
+- SLEEP class is the only row where deactivation is the measured feature.
+- Detector rows: native is the headline once phase 6 flips; until then
+  report native explicitly (FCL default mangles capsules -> MJCF rows under
+  the default detector are invalid).
+- Every claimed row needs: exact command, SHAs, versions, governor, median
+  of >=5 reps, finite + contact telemetry both engines.

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -8,7 +8,7 @@
 
 ## Harness
 
-`scripts/mujoco_comparison/` (landed in #3367): split-process runners
+`scripts/mujoco_comparison/` (proposed in open PR #3367): split-process runners
 (`dart_runner.py` in the default env against the dartpy dev build;
 `mujoco_runner.py` in the lean `mujoco` pixi env pinning conda-forge
 `mujoco-python`), one seeded SceneSpec emitting both a dartpy world and MJCF,
@@ -18,7 +18,7 @@ engines, warmup excluded, median-of-reps, finite/contact telemetry,
 FFI-overhead calibration row, MuJoCo integrator normalized to Euler with
 model-default sensitivity row, 1.1x win/noise band).
 
-Reproduce (the harness and the `mujoco` pixi environment land with #3367;
+Reproduce (the harness and the `mujoco` pixi environment are in open PR #3367;
 until that merges, run from the `feature/mujoco-comparison-harness` branch —
 and the humanoid rows additionally need #3369's MJCF stacked-joint support):
 

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -8,7 +8,7 @@
 
 ## Harness
 
-`scripts/mujoco_comparison/` (proposed in open PR #3367): split-process runners
+`scripts/mujoco_comparison/` (merged in #3367): split-process runners
 (`dart_runner.py` in the default env against the dartpy dev build;
 `mujoco_runner.py` in the lean `mujoco` pixi env pinning conda-forge
 `mujoco-python`), one seeded SceneSpec emitting both a dartpy world and MJCF,
@@ -18,9 +18,9 @@ engines, warmup excluded, median-of-reps, finite/contact telemetry,
 FFI-overhead calibration row, MuJoCo integrator normalized to Euler with
 model-default sensitivity row, 1.1x win/noise band).
 
-Reproduce (the harness and the `mujoco` pixi environment are in open PR #3367;
-until that merges, run from the `feature/mujoco-comparison-harness` branch —
-and the humanoid rows additionally need #3369's MJCF stacked-joint support):
+Reproduce from current `release-6.20` (the harness and the `mujoco` pixi
+environment merged in #3367; the humanoid rows additionally need open PR
+#3369's MJCF stacked-joint support):
 
 ```sh
 pixi run build-py-dev && pixi install -e mujoco

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -73,8 +73,8 @@ PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
 - Wins on ARM/HUM-ACTIVE/PILE(active)/DYN classes must show zero sleeping
   bodies in DART (deactivation disabled on DYN rows; asserted).
 - SLEEP class is the only row where deactivation is the measured feature.
-- Detector rows: native is the headline once phase 6 flips; until then
-  report native explicitly (FCL default mangles capsules -> MJCF rows under
-  the default detector are invalid).
+- Detector rows: `dart` is the headline after the phase-6 consolidation and
+  default flip; reserve `native` for explicit pre-consolidation runs (FCL
+  default mangles capsules -> MJCF rows under the default detector are invalid).
 - Every claimed row needs: exact command, SHAs, versions, governor, median
   of >=5 reps, finite + contact telemetry both engines.

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -19,8 +19,8 @@ FFI-overhead calibration row, MuJoCo integrator normalized to Euler with
 model-default sensitivity row, 1.1x win/noise band).
 
 Reproduce from current `release-6.20` (the harness and the `mujoco` pixi
-environment merged in #3367; the humanoid rows additionally need open PR
-#3369's MJCF stacked-joint support):
+environment merged in #3367; #3369 merged the MJCF stacked-joint support and
+collision-fidelity work needed by the affected rows):
 
 ```sh
 pixi run build-py-dev && pixi install -e mujoco
@@ -49,13 +49,9 @@ evidence; restore a locomotion row only with reproducible provenance.
 
 ## Gap analysis -> packets
 
-1. **MJCF stacked-joint compositions** (humanoid/walker2d/hopper/half_cheetah/
-   swimmer fail to load; MjcfParser.cpp:386): chain-of-1-DOF-joints design;
-   packet delegated (in flight).
-2. **MJCF collision/friction fidelity**: contype/conaffinity ignored (DART
-   collides marker geoms MuJoCo excludes — striker's density-1e6 cylinder
-   makes Dantzig fail every step and forces the PGS fallback + double
-   constructLcpTerms); per-geom friction ignored. Blocks fair arm rows.
+1. **MJCF stacked-joint and collision fidelity**: #3369 merged stacked
+   hinge/slide support, contype/conaffinity filtering, and per-geom friction.
+   Re-run the affected rows on the merged base before accepting standings.
 3. **Small-scene per-step overhead** (arms class): pusher profile shows
    ~11.35 µs per tiny LCP group (constructLcpTerms ~5 µs/call),
    updateConstraints self ~11.8 µs, integration ~12 µs, vs MuJoCo's whole
@@ -63,11 +59,10 @@ evidence; restore a locomotion row only with reproducible provenance.
    path), WP-SS.2 (native small-scene collide overhead; also the S1-60
    parity gap), WP-SS.3 (integration overhead for small skeletons). Cut
    after fidelity packets land (do not optimize against invalid scenes).
-4. **Active-pile gap (~2.7x)**: on open PR #3368's branch, the AABB-tree
-   removes the many-object broadphase bottleneck and leaves solver-side cost
-   (Dantzig per-island + contact allocation churn). This conclusion is
-   branch-local until #3368 merges; re-baseline on the merged base with the
-   fidelity fixes before deciding packets (matrix-free option rows are
+4. **Active-pile gap (~2.7x)**: #3368's merged AABB-tree removes the
+   many-object broadphase bottleneck and leaves solver-side cost (Dantzig
+   per-island + contact allocation churn). Re-baseline on the merged base
+   with the fidelity fixes before deciding packets (matrix-free option rows are
    diagnostic only, default-off per D3).
 5. **dartpy getDofs ownership bug** (#3366): fixed; harness torque-drive
    depends on it.

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -27,8 +27,16 @@ pixi run build-py-dev && pixi install -e mujoco
 PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
   pixi run python scripts/mujoco_comparison/run_comparison.py \
   --reps 5 --detector native \
+  --scene ARM-REACHER --scene ARM-PUSHER \
+  --scene HUM-FALL --scene HUM-ACTIVE \
+  --scene PILE-120 --scene PILE-900 --scene DYN-STIR-120 \
+  --scene FFI-OVERHEAD \
   --mujoco-python $PWD/.pixi/envs/mujoco/bin/python --out-dir /tmp/mj_cmp
 ```
+
+The explicit scene list is required: the runner's default set still omits the
+two HUM rows. Do not accept the cross-engine matrix unless both HUM rows run;
+a parser or runtime failure remains a blocked row rather than evidence.
 
 ## Standings (2026-07-10 prototype rows; quiet-host full matrix pending)
 
@@ -36,8 +44,8 @@ PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
 | --- | --- | ---: | ---: | --- |
 | Arms | reacher | 0.0200 | 0.0086 | MJ 2.3x (µs-scale) |
 | Arms | pusher | 0.0373 | 0.0065 | MJ 5.7x |
-| Arms | striker/thrower | — | — | INVALID until contype fidelity lands |
-| Humanoid | humanoid.xml | parse fails | 0.113 | blocked on stacked-joint parser |
+| Arms | striker/thrower | — | — | scenario registration + merged-base rerun pending |
+| Humanoid | humanoid.xml | — | — | merged-base HUM-FALL/HUM-ACTIVE rerun pending |
 | Many objects | PILE-120 active | 1.55 ms/step | 0.57 | MJ ~2.7x |
 | Dynamic | DYN-STIR-120 | 1.82 | 0.61 | MJ ~3.0x |
 | Sleeping | settled 3k | 0.034 ms/step (deactivation) | ~2 (no sleeping exists) | **DART ~60x** (to be formalized) |

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -74,8 +74,10 @@ evidence; restore a locomotion row only with reproducible provenance.
 
 ## Rules
 
-- Wins on ARM/HUM-ACTIVE/PILE(active)/DYN classes must show zero sleeping
-  bodies in DART (deactivation disabled on DYN rows; asserted).
+- Wins on ARM/HUM-ACTIVE/PILE(active)/DYN classes are accepted only when DART
+  deactivation is disabled for the row, or when a bound resting-state API
+  reports and the harness asserts zero sleeping bodies. A missing/unknown
+  sleeping-body count is not evidence of zero sleeping bodies.
 - SLEEP class is the only row where deactivation is the measured feature.
 - Detector rows: `dart` is the headline after the phase-6 consolidation and
   default flip; reserve `native` for explicit pre-consolidation runs (FCL

--- a/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
+++ b/docs/dev_tasks/dart6_performance_generalization/08-mujoco-comparison-lane.md
@@ -59,11 +59,12 @@ PYTHONPATH=$PWD/build/default/cpp/Release/python/dartpy \
    path), WP-SS.2 (native small-scene collide overhead; also the S1-60
    parity gap), WP-SS.3 (integration overhead for small skeletons). Cut
    after fidelity packets land (do not optimize against invalid scenes).
-4. **Active-pile gap (~2.7x)**: post-AabbTree (#3368) the many-object
-   broadphase is fixed; remaining active-pile cost is solver-side (Dantzig
-   per-island + contact allocation churn). Re-baseline after #3368 +
-   fidelity, then decide packets (matrix-free option rows are diagnostic
-   only, default-off per D3).
+4. **Active-pile gap (~2.7x)**: on open PR #3368's branch, the AABB-tree
+   removes the many-object broadphase bottleneck and leaves solver-side cost
+   (Dantzig per-island + contact allocation churn). This conclusion is
+   branch-local until #3368 merges; re-baseline on the merged base with the
+   fidelity fixes before deciding packets (matrix-free option rows are
+   diagnostic only, default-off per D3).
 5. **dartpy getDofs ownership bug** (#3366): fixed; harness torque-drive
    depends on it.
 

--- a/docs/dev_tasks/dart6_performance_generalization/README.md
+++ b/docs/dev_tasks/dart6_performance_generalization/README.md
@@ -74,6 +74,7 @@ explicit, is the **active** regime and why scenes stay active:
 | WS-D | SIMD enablement | [05-simd-enablement-lane.md](05-simd-enablement-lane.md) | PG.40–PG.42 | Make merged `dart/simd` (#3229) earn its keep at proven seams; FP/ISA contracts first |
 | WS-E | Infra + evidence | [06-infra-evidence-lane.md](06-infra-evidence-lane.md) | PG.01–PG.04 | Durable baselines, profiling doc, benchmark matrix extensions, executor tooling |
 | WS-F | Native collision port | [../dart6_dependency_minimization/03-native-collision-port-scoping.md](../dart6_dependency_minimization/03-native-collision-port-scoping.md) | phases 0–7 | **External owner** — 8-phase port plan (#3234). Tracked here for sequencing only; do not duplicate its packets |
+| WS-G | MuJoCo cross-engine comparison | [08-mujoco-comparison-lane.md](08-mujoco-comparison-lane.md) | harness + gap packets | Maintainer-directed generalization bar: DART must outperform MuJoCo across arms, humanoids, many-object, sleeping, and highly dynamic workloads (full pipelines; no sleep-shortcut wins on dynamic classes) |
 
 Status across lanes lives in
 [07-orchestration-dashboard.md](07-orchestration-dashboard.md).

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -33,8 +33,8 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
   (heap corruption, SIGSEGV at teardown); #3368 (dep-min lane) removes the
   native detector's O(n^2) broadphase with bit-identical guards.
 
-Open PRs from this cycle: #3366, #3367, #3368, #3369 — all awaiting review/
-merge; docs refresh is this PR.
+#3366 has merged. Open PRs from this cycle: #3367, #3368, and #3369 — all
+awaiting review/merge; docs refresh is this PR.
 
 A fresh session should start from current `origin/release-6.20` (the audited
 head above or later; re-fetch — the maintainer merges frequently), read this

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -24,9 +24,11 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
 - Criterion 4 (general evidence): the maintainer broadened the bar to
   cross-engine evidence vs MuJoCo across DART's major workloads. New lane
   **WS-G**: [08-mujoco-comparison-lane.md](08-mujoco-comparison-lane.md).
-  Harness + mujoco pixi env + dartpy native binding: PR #3367. First
-  standings: DART+native already beats MuJoCo on ant (+30%); gaps and root
-  causes recorded in the lane doc with packets (MJCF stacked joints PR
+  Harness + mujoco pixi env + dartpy native binding: PR #3367. The earlier
+  prototype ant result is deferred because its exact command, artifact, and
+  engine SHAs were not retained; do not count it as accepted cross-engine
+  evidence. Reproducible standings, gaps, and root causes are recorded in the
+  lane doc with packets (MJCF stacked joints PR
   #3369; MJCF contype/conaffinity+friction fidelity packet in flight;
   WP-SS small-scene-overhead family evidence-gated on fidelity).
 - Side products: #3366 fixes a dartpy `getDofs`/`getChainDofs` ownership bug

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -33,7 +33,7 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
   (heap corruption, SIGSEGV at teardown); #3368 (dep-min lane) removes the
   native detector's O(n^2) broadphase with bit-identical guards.
 
-#3366 has merged. Open PRs from this cycle: #3367, #3368, and #3369 — all
+#3366 and #3367 have merged. Open PRs from this cycle: #3368 and #3369 — both
 awaiting review/merge; docs refresh is this PR.
 
 A fresh session should start from current `origin/release-6.20` (the audited

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -9,7 +9,32 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
 
 ## Next packets
 
-**Current claimed packet: none. Stop and audit before writing more code.**
+**2026-07-10: the current-head completion audit RAN** (release-6.20 @
+`db255a08e8e`; artifacts `/tmp/audit_head_20260710T011207Z`):
+
+- Criterion 1 (S1 primary fixture 3x): **MET** — 120/dart/1 RTF 0.126447
+  (3.51x the 0.036 round-2 baseline), avg step 7.908 ms, hash
+  `0x123ee9779bccacfb`.
+- Criterion 2 (S6 pile-sleep): **MET** — 71/71 resting, max_pen 0, hash
+  `0xec80f734df6d5e74` (exact #3353 accepted value), RTF 0.21.
+- Criterion 3 (no regressions): all S2/S3 guard hashes bit-identical across
+  dart/fcl/bullet/ode; S4/S5 fcl match the recorded drift values; S4/S5
+  bullet re-baselined by merged #3355's analytic PlaneShape path (new values
+  in the audit dir are the current guards).
+- Criterion 4 (general evidence): the maintainer broadened the bar to
+  cross-engine evidence vs MuJoCo across DART's major workloads. New lane
+  **WS-G**: [08-mujoco-comparison-lane.md](08-mujoco-comparison-lane.md).
+  Harness + mujoco pixi env + dartpy native binding: PR #3367. First
+  standings: DART+native already beats MuJoCo on ant (+30%); gaps and root
+  causes recorded in the lane doc with packets (MJCF stacked joints PR
+  #3369; MJCF contype/conaffinity+friction fidelity packet in flight;
+  WP-SS small-scene-overhead family evidence-gated on fidelity).
+- Side products: #3366 fixes a dartpy `getDofs`/`getChainDofs` ownership bug
+  (heap corruption, SIGSEGV at teardown); #3368 (dep-min lane) removes the
+  native detector's O(n^2) broadphase with bit-identical guards.
+
+Open PRs from this cycle: #3366, #3367, #3368, #3369 — all awaiting review/
+merge; docs refresh is this PR.
 
 Current `release-6.20` head is #3361 merge commit `91c158fc3e5`
 (`WP-PG.14: add opt-in matrix-free contact LCP`). A fresh session should start

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -28,20 +28,20 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
   prototype ant result is deferred because its exact command, artifact, and
   engine SHAs were not retained; do not count it as accepted cross-engine
   evidence. Reproducible standings, gaps, and root causes are recorded in the
-  lane doc with packets (MJCF stacked joints PR
-  #3369; MJCF contype/conaffinity+friction fidelity packet in flight;
-  WP-SS small-scene-overhead family evidence-gated on fidelity).
+  lane doc with packets. #3369 merged the MJCF stacked-joint and collision
+  fidelity work; the WP-SS small-scene-overhead family remains.
 - Side products: #3366 fixes a dartpy `getDofs`/`getChainDofs` ownership bug
   (heap corruption, SIGSEGV at teardown); #3368 (dep-min lane) removes the
   native detector's O(n^2) broadphase with bit-identical guards.
 
-#3366 and #3367 have merged. Open PRs from this cycle: #3368 and #3369 — both
-awaiting review/merge; docs refresh is this PR.
+#3366, #3367, #3368, and #3369 have merged; docs refresh is this PR. Re-baseline
+the WS-G and native Phase 4 rows on the current merged base before cutting the
+next evidence-driven packet.
 
 A fresh session should start from current `origin/release-6.20` (the audited
 head above or later; re-fetch — the maintainer merges frequently), read this
-README plus the lane docs, and continue from the WS-G lane + the open-PR
-queue above rather than redoing the completed audit. The maintainer's
+README plus the lane docs, and continue from the WS-G lane on the merged base
+rather than redoing the completed audit. The maintainer's
 north-star requirement is broader than "latest packet merged": finish issue
 #3056 on DART 6.20 with cross-engine evidence (WS-G) showing the result is
 general, and respect the 2026-07-10 maintainer directives — the native

--- a/docs/dev_tasks/dart6_performance_generalization/RESUME.md
+++ b/docs/dev_tasks/dart6_performance_generalization/RESUME.md
@@ -36,13 +36,16 @@ packet that overlaps the `origin/perf/dart6-*` experiment branches.
 Open PRs from this cycle: #3366, #3367, #3368, #3369 — all awaiting review/
 merge; docs refresh is this PR.
 
-Current `release-6.20` head is #3361 merge commit `91c158fc3e5`
-(`WP-PG.14: add opt-in matrix-free contact LCP`). A fresh session should start
-from that head, re-read this README plus the lane docs, and do a current-base
-completion/evidence audit before claiming any new packet. The maintainer's
-north-star requirement is still broader than "latest packet merged": finish
-issue #3056 on DART 6.20 with enough tests, benchmarks, and GUI/headless
-evidence to show the result is general and not overfit to one fixture.
+A fresh session should start from current `origin/release-6.20` (the audited
+head above or later; re-fetch — the maintainer merges frequently), read this
+README plus the lane docs, and continue from the WS-G lane + the open-PR
+queue above rather than redoing the completed audit. The maintainer's
+north-star requirement is broader than "latest packet merged": finish issue
+#3056 on DART 6.20 with cross-engine evidence (WS-G) showing the result is
+general, and respect the 2026-07-10 maintainer directives — the native
+engine merges INTO the dart detector (see the dep-min Phase 5 decision doc)
+and the whole remaining effort should land in few, large, cohesive PRs
+(total budget across both dev tasks roughly 10-20).
 
 Do not open a small follow-up PR merely because a packet exists. Prefer one
 consolidated evidence/closeout branch unless the audit identifies a real
@@ -63,10 +66,11 @@ original fuller artifact remains
 `/tmp/wp_pg14_matrix_free_ab_20260709T040443Z` with S3 active-3k option-on
 fallback preserving hash `0xcf0ba6eaa97be038`.
 
-Recommended next session plan:
+Recommended next session plan (items 1-2 are DONE for the 2026-07-10 cycle;
+kept for the method):
 
-1. Verify live state: `git fetch origin release-6.20`, confirm head contains
-   #3361, inspect open PRs/issues, and avoid touching dirty sibling worktrees
+1. Verify live state: `git fetch origin release-6.20`, inspect open
+   PRs/issues, and avoid touching dirty sibling worktrees
    such as `/home/js/dev/dartsim/dart/task_3-fix-simd`.
 2. Run a current-head acceptance audit against the README north-star gate:
    tests, benchmark matrix, GUI/headless artifacts, decision status, and

--- a/python/tests/unit/test_mujoco_comparison.py
+++ b/python/tests/unit/test_mujoco_comparison.py
@@ -1,3 +1,5 @@
+import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -5,6 +7,17 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 RUNNER = ROOT / "scripts" / "mujoco_comparison" / "run_comparison.py"
+
+
+def _load_runner_module():
+    script_dir = str(RUNNER.parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+    spec = importlib.util.spec_from_file_location("mujoco_run_comparison", RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_dart_sleep_override_disables_deactivation_for_selected_rows(tmp_path):
@@ -35,3 +48,29 @@ def test_dart_sleep_override_disables_deactivation_for_selected_rows(tmp_path):
     assert len(dart_commands) == 2
     assert all("--sleep off" in command for command in dart_commands)
     assert all("--sleep on" not in command for command in dart_commands)
+
+
+def test_sleep_override_is_serialized_and_rendered_for_blocked_rows(tmp_path):
+    runner = _load_runner_module()
+    summary = {
+        "detector_override": "native",
+        "dart_sleep_override": "off",
+        "scenes": {
+            "HUM-ACTIVE": {
+                "category": "mjcf",
+                "dart": None,
+                "mujoco": None,
+                "verdict": "blocked: dart runner failed",
+            }
+        },
+        "sensitivity": {},
+    }
+
+    serialized = json.loads(json.dumps(summary))
+    assert serialized["dart_sleep_override"] == "off"
+
+    runner._write_markdown(tmp_path, summary)
+    markdown = (tmp_path / "results.md").read_text(encoding="utf-8")
+    assert "DART detector override: `native`" in markdown
+    assert "DART sleep override: `off` for every selected scenario" in markdown
+    assert "blocked: dart runner failed" in markdown

--- a/python/tests/unit/test_mujoco_comparison.py
+++ b/python/tests/unit/test_mujoco_comparison.py
@@ -1,0 +1,37 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+RUNNER = ROOT / "scripts" / "mujoco_comparison" / "run_comparison.py"
+
+
+def test_dart_sleep_override_disables_deactivation_for_selected_rows(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "--scene",
+            "ARM-REACHER",
+            "--scene",
+            "HUM-ACTIVE",
+            "--reps",
+            "1",
+            "--dart-sleep",
+            "off",
+            "--out-dir",
+            str(tmp_path),
+            "--dry-run",
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+    dart_commands = [
+        line for line in result.stdout.splitlines() if "dart_runner.py" in line
+    ]
+    assert len(dart_commands) == 2
+    assert all("--sleep off" in command for command in dart_commands)
+    assert all("--sleep on" not in command for command in dart_commands)

--- a/scripts/mujoco_comparison/run_comparison.py
+++ b/scripts/mujoco_comparison/run_comparison.py
@@ -408,7 +408,23 @@ def _verdict(dart_steps_per_s: float, mujoco_steps_per_s: float) -> str:
 
 
 def _write_markdown(out_dir: Path, summary: dict) -> None:
-    lines = ["# DART vs MuJoCo Comparison", ""]
+    detector_override = summary.get("detector_override")
+    dart_sleep_override = summary.get("dart_sleep_override")
+    lines = [
+        "# DART vs MuJoCo Comparison",
+        "",
+        "## Run provenance",
+        "",
+        "- DART detector override: "
+        + (f"`{detector_override}`" if detector_override else "scenario defaults"),
+        "- DART sleep override: "
+        + (
+            f"`{dart_sleep_override}` for every selected scenario"
+            if dart_sleep_override
+            else "scenario defaults"
+        ),
+        "",
+    ]
     lines += [
         "| Scene | DART steps/s | MuJoCo steps/s | Ratio (DART/MuJoCo) | Verdict | Finite (D/M) |",
         "| --- | ---: | ---: | ---: | --- | --- |",
@@ -600,6 +616,7 @@ def main(argv: list[str]) -> int:
         "reps": args.reps,
         "seed": args.seed,
         "detector_override": args.detector,
+        "dart_sleep_override": args.dart_sleep,
         "scenes": scenes_summary,
         "sensitivity": sensitivity,
         "raw_rows": {

--- a/scripts/mujoco_comparison/run_comparison.py
+++ b/scripts/mujoco_comparison/run_comparison.py
@@ -196,6 +196,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Override every scenario's --detector for dart_runner.py.",
     )
     parser.add_argument(
+        "--dart-sleep",
+        choices=("on", "off"),
+        default=None,
+        help="Override every scenario's --sleep setting for dart_runner.py.",
+    )
+    parser.add_argument(
         "--seed", type=int, default=0, help="Seed for all generated scenes."
     )
     parser.add_argument(
@@ -240,8 +246,10 @@ def _dart_command(
     out_path: Path,
     config: str,
     detector_override: Optional[str],
+    sleep_override: Optional[str],
 ) -> list[str]:
     detector = detector_override or scenario.detector
+    sleep = sleep_override or scenario.sleep
     cmd = [
         python_exe,
         str(DART_RUNNER),
@@ -256,7 +264,7 @@ def _dart_command(
         "--detector",
         detector,
         "--sleep",
-        scenario.sleep,
+        sleep,
         "--scene-id",
         scenario.scene_id,
         "--config",
@@ -500,6 +508,7 @@ def main(argv: list[str]) -> int:
                     dart_out,
                     config="headline",
                     detector_override=args.detector,
+                    sleep_override=args.dart_sleep,
                 )
                 if not _run(dart_cmd, args.dry_run):
                     blocked[scenario.scene_id] = "dart runner failed"


### PR DESCRIPTION
## Summary

Docs-only refresh of both active dev-task project homes with this cycle's evidence and decisions, so a zero-context session can resume without chat memory.

**Performance generalization (`docs/dev_tasks/dart6_performance_generalization/`):**
- Records the current-head completion audit (release-6.20 @ `db255a08e8e`): criterion 1 (S1 primary fixture 3×) **met** at 3.51× with matching hash; criterion 2 (S6 pile-sleep) **met** at 71/71 resting with the #3353 accepted hash; criterion 3 (no regressions) verified with all legacy guard hashes bit-identical (S4/S5 bullet re-baselined by merged #3355's analytic plane path).
- Opens lane **WS-G** (`08-mujoco-comparison-lane.md`): the maintainer-directed cross-engine bar (outperform MuJoCo across arms, humanoids, many-object, sleeping, highly dynamic; full pipelines, no sleep-shortcut wins), the harness fairness contract, first standings (DART+native beats MuJoCo on ant), and the gap→packet mapping.
- Logs the cycle's PRs: #3366 (dartpy getDofs ownership bugfix), #3367 (harness + mujoco env + native binding), #3368 (native AABB-tree broadphase), #3369 (MJCF stacked joints).

**Dependency minimization (`docs/dev_tasks/dart6_dependency_minimization/`):**
- Phase 4 status: #3368 evidence (bit-identical guards; S2 −58%, S3 −65%, S4 −42%) plus the three remaining measured gaps (S3 narrowphase delta vs dart, small-scene overhead, S6 native resting profile — including the decisively rejected manifold cap-4 A/B).
- Adds `08-phase5-facade-decision.md`: canonical `native` key, 6.21 messaged deprecations on create()/ctors, 6.22 external-dependency removal with facades-over-native, the source-verified gz obligation table (only `OdeCollisionDetector` is subclassed), SOVERSION/mechanics facts, and the maintainer ratification points.
- Corrects stale facts in the scoping doc: ConstraintSolver FCL ctor sites are `:416`/`:433` (was 322/342), and the gz compatibility matrix row overstated Bullet subclassing (no `GzBulletCollisionDetector` exists).

## Validation

Docs-only; `pixi run lint` + `pixi run check-lint` clean.