### PR TITLE
Fix dartpy DOF binding return policies

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -36,8 +36,10 @@ jobs:
     env:
       CMAKE_GENERATOR: Visual Studio 18 2026
     # Keep the job bounded, but allow large native-collision PRs enough time
-    # for MSVC Release test linking on hosted runners.
-    timeout-minutes: 180
+    # for MSVC Release test linking on hosted runners. Release-branch Windows
+    # builds can exceed three hours on cold hosted runners after the DART 6.20
+    # native-collision test expansion.
+    timeout-minutes: 300
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,6 +491,11 @@
 
 * Python
 
+  * Fix dartpy DOF-list accessors so `Skeleton.getDofs()` and related chain
+    DOF helpers return wrappers for DART-owned `DegreeOfFreedom` objects
+    without transferring ownership or requiring movable/copyable DOF values:
+    [#3375](https://github.com/dartsim/dart/pull/3375)
+
   * Add dartpy bindings for inverse-kinematics gradient and analytical methods,
     including a Python analytical callback bridge that lets ssik-like solvers
     feed DART's native analytical and whole-body IK pipeline:

--- a/python/dartpy/dynamics/BodyNode.cpp
+++ b/python/dartpy/dynamics/BodyNode.cpp
@@ -968,9 +968,12 @@ void BodyNode(py::module& m)
           })
       .def(
           "getChainDofs",
-          +[](const dart::dynamics::BodyNode* self)
-              -> const std::vector<const dart::dynamics::DegreeOfFreedom*> {
-            return self->getChainDofs();
+          +[](dart::dynamics::BodyNode* self)
+              -> std::vector<dart::dynamics::DegreeOfFreedom*> {
+            std::vector<dart::dynamics::DegreeOfFreedom*> dofs;
+            for (const auto* dof : self->getChainDofs())
+              dofs.push_back(const_cast<dart::dynamics::DegreeOfFreedom*>(dof));
+            return dofs;
           },
           ::py::return_value_policy::reference_internal)
       .def(

--- a/python/dartpy/dynamics/JacobianNode.cpp
+++ b/python/dartpy/dynamics/JacobianNode.cpp
@@ -97,9 +97,12 @@ void JacobianNode(py::module& m)
           })
       .def(
           "getChainDofs",
-          +[](const dart::dynamics::JacobianNode* self)
-              -> const std::vector<const dart::dynamics::DegreeOfFreedom*> {
-            return self->getChainDofs();
+          +[](dart::dynamics::JacobianNode* self)
+              -> std::vector<dart::dynamics::DegreeOfFreedom*> {
+            std::vector<dart::dynamics::DegreeOfFreedom*> dofs;
+            for (const auto* dof : self->getChainDofs())
+              dofs.push_back(const_cast<dart::dynamics::DegreeOfFreedom*>(dof));
+            return dofs;
           },
           ::py::return_value_policy::reference_internal)
       .def(

--- a/python/dartpy/dynamics/ReferentialSkeleton.cpp
+++ b/python/dartpy/dynamics/ReferentialSkeleton.cpp
@@ -192,8 +192,8 @@ void ReferentialSkeleton(py::module& m)
           })
       .def(
           "getDofs",
-          +[](const dart::dynamics::ReferentialSkeleton* self)
-              -> std::vector<const dart::dynamics::DegreeOfFreedom*> {
+          +[](dart::dynamics::ReferentialSkeleton* self)
+              -> std::vector<dart::dynamics::DegreeOfFreedom*> {
             return self->getDofs();
           },
           ::py::return_value_policy::reference_internal)

--- a/python/dartpy/dynamics/Skeleton.cpp
+++ b/python/dartpy/dynamics/Skeleton.cpp
@@ -527,8 +527,8 @@ void Skeleton(py::module& m)
           ::py::arg("name"))
       .def(
           "getDofs",
-          +[](const dart::dynamics::Skeleton* self)
-              -> std::vector<const dart::dynamics::DegreeOfFreedom*> {
+          +[](dart::dynamics::Skeleton* self)
+              -> std::vector<dart::dynamics::DegreeOfFreedom*> {
             return self->getDofs();
           },
           ::py::return_value_policy::reference_internal)


### PR DESCRIPTION
## Summary

- Fix dartpy DOF-list bindings on `release-6.20` so `Skeleton.getDofs()`, `ReferentialSkeleton.getDofs()`, and the chain-DOF helpers return Python wrappers for existing DART-owned `DegreeOfFreedom` objects instead of asking pybind11 to move or own them.

## Motivation / Problem

- The `CI Linux / Asserts enabled (no -DNDEBUG)` job for `release-6.20` failed on commit `72ebe164e8c` in `python/tests/unit/dynamics/test_degree_of_freedom_ownership.py`.
- The failing bindings returned `const DegreeOfFreedom*` containers, which pybind11 3 rejected for the registered non-movable `DegreeOfFreedom` type with `return_value_policy = move`.

## Changes / Key Changes

- Bind `Skeleton.getDofs()` and `ReferentialSkeleton.getDofs()` through the mutable C++ overloads so dartpy exposes `DegreeOfFreedom*` wrappers under `reference_internal`.
- Adapt `BodyNode.getChainDofs()` and `JacobianNode.getChainDofs()` into Python-facing `std::vector<DegreeOfFreedom*>` values while keeping the underlying DOF ownership with DART.
- Add a `DART 6.20.0` changelog entry for the dartpy behavior fix.

## Before / After

| Surface | Before | After |
| --- | --- | --- |
| `Skeleton.getDofs()` in the no-`NDEBUG` dartpy build | Raised `RuntimeError: return_value_policy = move, but type dart::dynamics::DegreeOfFreedom is neither movable nor copyable!` | Returns usable wrappers for skeleton-owned DOFs |
| `getChainDofs()` bindings | Used const pointer vectors that do not match the registered Python DOF wrapper type | Returns Python-facing DOF pointer wrappers without transferring ownership |

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-py`
- `PYTHONPATH="$PWD/build/default/cpp/None/python/dartpy:$PWD/build/default/cpp/None/python" "$CONDA_PREFIX/bin/python3.14" -m pytest python/tests/unit/dynamics/test_degree_of_freedom_ownership.py -v`
- Direct smoke check against the no-`NDEBUG` dartpy build for `Skeleton.getDofs()` and `BodyNode.getChainDofs()`

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up fix for #3366 on `release-6.20`.
- CI job: https://github.com/dartsim/dart/actions/runs/29066055356/job/86411409804

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [x] Add Python bindings (dartpy) if applicable

Changelog decision:

- Mode: finalize
- Base evidence: `origin/release-6.20`
- Scope evidence: dartpy binding fix for public Python `DegreeOfFreedom` accessors
- Decision: entry required
- Target section: `DART 6.20.0 (Unreleased)` / Python
- Entry text: Fix dartpy DOF-list accessors so `Skeleton.getDofs()` and related chain DOF helpers return wrappers for DART-owned `DegreeOfFreedom` objects without transferring ownership or requiring movable/copyable DOF values.
- PR-body note: `CHANGELOG.md` updated in the PR branch
- Follow-up: none
