### PR TITLE
Fix release dartpy formatting gate

### DIFF
--- a/scripts/mujoco_comparison/gen_scenes.py
+++ b/scripts/mujoco_comparison/gen_scenes.py
@@ -125,7 +125,11 @@ def _ffi_overhead_layout(seed: int) -> common.GeneratedLayout:
     scenes.
     """
     box = common.BoxBody(
-        name="box0000", half_extent=0.1, mass=1.0, friction=0.8, position=(0.0, 0.0, 1.0)
+        name="box0000",
+        half_extent=0.1,
+        mass=1.0,
+        friction=0.8,
+        position=(0.0, 0.0, 1.0),
     )
     spec = common.GeneratedSceneSpec(
         scene_id="ffi-overhead",

--- a/scripts/mujoco_comparison/mujoco_runner.py
+++ b/scripts/mujoco_comparison/mujoco_runner.py
@@ -132,7 +132,9 @@ def _mocap_id_for_body(model: "mujoco.MjModel", name: str) -> int | None:
     return mocap_id if mocap_id >= 0 else None
 
 
-def _drive_joint_dof_addrs(model: "mujoco.MjModel", joint_names: list[str]) -> dict[str, int]:
+def _drive_joint_dof_addrs(
+    model: "mujoco.MjModel", joint_names: list[str]
+) -> dict[str, int]:
     """Map joint name -> its (first, and assumed only) DOF address.
 
     Every joint the harness drives (reacher/pusher/humanoid actuator
@@ -187,7 +189,9 @@ def main(argv: list[str]) -> int:
                 file=sys.stderr,
             )
 
-    stirrer_mocap_id = _mocap_id_for_body(model, "stirrer") if stirrer is not None else None
+    stirrer_mocap_id = (
+        _mocap_id_for_body(model, "stirrer") if stirrer is not None else None
+    )
 
     def apply_drive(t: float) -> None:
         if not drive_addrs:

--- a/scripts/mujoco_comparison/run_comparison.py
+++ b/scripts/mujoco_comparison/run_comparison.py
@@ -223,8 +223,7 @@ def _selected_scenarios(ids: list[str]) -> list[Scenario]:
         return [
             scenario
             for scenario in all_scenarios
-            if scenario.scene_id in DEFAULT_SCENE_IDS
-            or scenario is OVERHEAD_SCENARIO
+            if scenario.scene_id in DEFAULT_SCENE_IDS or scenario is OVERHEAD_SCENARIO
         ]
     wanted = {i.upper() for i in ids}
     selected = [s for s in all_scenarios if s.scene_id.upper() in wanted]
@@ -336,7 +335,9 @@ def _run(cmd: list[str], dry_run: bool) -> bool:
     return True
 
 
-def _generate_scene_files(scenario: Scenario, seed: int, work_dir: Path) -> tuple[Path, Path]:
+def _generate_scene_files(
+    scenario: Scenario, seed: int, work_dir: Path
+) -> tuple[Path, Path]:
     """Return (dart_scene_path, mujoco_scene_path) for a scenario.
 
     For "mjcf" scenarios both engines read the same file directly. For
@@ -431,7 +432,10 @@ def _write_markdown(out_dir: Path, summary: dict) -> None:
 
     if summary.get("sensitivity"):
         lines += ["", "## MuJoCo Model-Default-Integrator Sensitivity", ""]
-        lines += ["| Scene | Euler steps/s | Model-default steps/s |", "| --- | ---: | ---: |"]
+        lines += [
+            "| Scene | Euler steps/s | Model-default steps/s |",
+            "| --- | ---: | ---: |",
+        ]
         for scene_id, entry in summary["sensitivity"].items():
             lines.append(
                 f"| `{scene_id}` | {entry['euler_steps_per_s']:.1f} | "
@@ -475,12 +479,16 @@ def main(argv: list[str]) -> int:
     with tempfile.TemporaryDirectory(prefix="mujoco_comparison_") as tmp:
         work_dir = Path(tmp)
         for scenario in scenarios:
-            dart_scene, mujoco_scene = _generate_scene_files(scenario, args.seed, work_dir)
+            dart_scene, mujoco_scene = _generate_scene_files(
+                scenario, args.seed, work_dir
+            )
             raw_rows[scenario.scene_id] = {"dart": [], "mujoco": []}
 
             scenario_blocked = False
             for rep in range(args.reps):
-                dart_out = args.out_dir / "raw" / f"{scenario.scene_id}-dart-rep{rep}.json"
+                dart_out = (
+                    args.out_dir / "raw" / f"{scenario.scene_id}-dart-rep{rep}.json"
+                )
                 mujoco_out = (
                     args.out_dir / "raw" / f"{scenario.scene_id}-mujoco-rep{rep}.json"
                 )
@@ -526,7 +534,11 @@ def main(argv: list[str]) -> int:
                 and not args.skip_sensitivity
                 and not args.dry_run
             ):
-                sens_out = args.out_dir / "raw" / f"{scenario.scene_id}-mujoco-sensitivity.json"
+                sens_out = (
+                    args.out_dir
+                    / "raw"
+                    / f"{scenario.scene_id}-mujoco-sensitivity.json"
+                )
                 sens_cmd = _mujoco_command(
                     args.mujoco_python,
                     mujoco_scene,


### PR DESCRIPTION
## Summary

- Restore the `release-6.20` dartpy publishing format gate by applying the repository's Black formatting to the newly merged MuJoCo comparison scripts.

## Motivation / Problem

- The `Publish dartpy` workflow failed on release head `dfe5c795a78c653d026a6c7b3f8ec37a4e9c4238` because `black --check --diff` reported three unformatted Python files.

## Changes / Key Changes

- Format `gen_scenes.py`, `mujoco_runner.py`, and `run_comparison.py` with Black.
- Preserve behavior; this PR contains formatting-only changes.

## Testing

- `pixi run lint`
- `pixi run test-all` (105 Python tests and the full 151-test CTest suite passed)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes the formatting failure in workflow run https://github.com/dartsim/dart/actions/runs/29162639613/job/86570216388

---

#### Checklist

- [x] Milestone set (`DART 6.20.0`)
- [x] CHANGELOG.md not required: formatting-only CI repair
- [x] Unit tests are not required for formatting-only changes
- [x] No new methods or classes to document
- [x] No Python binding API changes
