### PR TITLE
Fix Clang parsing of AABB tree exception tests

### DIFF
--- a/tests/unit/collision/native/test_aabb_tree.cpp
+++ b/tests/unit/collision/native/test_aabb_tree.cpp
@@ -402,10 +402,10 @@ TEST(AabbTreeBroadPhase, RejectsInvalidFatAabbMargins)
 {
   EXPECT_THROW(AabbTreeBroadPhase(-0.1), std::invalid_argument);
   EXPECT_THROW(
-      AabbTreeBroadPhase(std::numeric_limits<double>::infinity()),
+      (void)AabbTreeBroadPhase{std::numeric_limits<double>::infinity()},
       std::invalid_argument);
   EXPECT_THROW(
-      AabbTreeBroadPhase(std::numeric_limits<double>::quiet_NaN()),
+      (void)AabbTreeBroadPhase{std::numeric_limits<double>::quiet_NaN()},
       std::invalid_argument);
 
   AabbTreeBroadPhase bp(0.25);


### PR DESCRIPTION
## Summary

- make the non-finite AABB tree constructor checks unambiguously expression statements
- restore Clang and arm64 compilation of the tests merged in #3368

## Motivation / Problem

The current `release-6.20` branch fails Clang compilation because GoogleTest expands the two constructor-form `EXPECT_THROW` statements in a context where Clang parses them as prohibited function declarations.

## Changes / Key Changes

- use braced construction cast to `void` for the infinity and NaN constructor checks
- keep the existing exception assertions and production behavior unchanged

## Testing

- `pixi run lint`
- `pixi run test-all` (105 Python tests; 152 C++ tests)
- `pixi run -e gazebo test-gz` (199 gz-physics tests, 4 performance tests, and gz-sim integration)

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3368

---

#### Checklist

- [x] Milestone set (DART 6.20)
- [x] CHANGELOG.md not required for a test-compilation-only fix
- [x] Existing unit tests cover the behavior
- [x] Documentation not applicable
- [x] Python bindings not applicable
