### PR TITLE
Fix heap-use-after-free in offscreen debug-font atlas build

### DIFF
--- a/dart/gui/offscreen.cpp
+++ b/dart/gui/offscreen.cpp
@@ -138,11 +138,22 @@ DebugFont buildDebugFont()
   font.baseSize = kDebugFontBaseSize;
   font.atlasWidth = width;
   font.atlasHeight = height;
-  font.lineHeight = baked->Ascent - baked->Descent;
   font.alpha.assign(
       pixels,
       pixels
           + static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
+
+  // GetTexDataAsAlpha8() runs the legacy Build() path, which rebuilds and
+  // compacts the dynamic atlas and reallocates the per-size ImFontBaked cache.
+  // That invalidates the `baked` pointer obtained before the build (the header
+  // warns LastBaked must never be cached across such calls), so re-acquire it
+  // now that the atlas is final before reading any metrics or glyphs from it.
+  baked = imFont->GetFontBaked(kDebugFontBaseSize);
+  if (baked == nullptr) {
+    return font;
+  }
+
+  font.lineHeight = baked->Ascent - baked->Descent;
 
   for (int code = 32; code < 127; ++code) {
     const ImFontGlyph* glyph = baked->FindGlyph(static_cast<ImWchar>(code));


### PR DESCRIPTION
## Problem

The `main` CI Linux **ASAN Tests** job is red on the current HEAD (#3371):
`UNIT_gui_DebugVisuals` fails with a heap-use-after-free at
`dart/gui/offscreen.cpp:141` in `buildDebugFont` (`buildDebugFont` was added by
#3371, so this is a regression from that PR).

```
==ERROR: AddressSanitizer: heap-use-after-free ... in buildDebugFont
SUMMARY: AddressSanitizer: heap-use-after-free dart/gui/offscreen.cpp:141 in buildDebugFont
```

## Root cause

`buildDebugFont()` cached the `ImFontBaked*` from `GetFontBaked()` and read its
`Ascent`/`Descent` and per-glyph metrics **after** calling
`ImFontAtlas::GetTexDataAsAlpha8()`. Under Dear ImGui 1.92's dynamic font
atlas, the legacy `GetTexDataAsAlpha8()`/`Build()` path rebuilds and compacts
the atlas and reallocates the per-size `ImFontBaked` cache, dangling the
earlier pointer. The imgui header explicitly warns that `LastBaked` must never
be cached and that `GetFontBaked()` should be re-called.

## Fix

Re-acquire the baked data via `GetFontBaked()` once the atlas is final (after
the texture is copied out), before reading any metrics or glyphs. Glyph UVs are
read post-build so they still match the packed atlas dimensions.

## Verification

Built `UNIT_gui_DebugVisuals` with `-DDART_ENABLE_ASAN=ON` and ran under
AddressSanitizer locally:

```
1/1 Test #164: UNIT_gui_DebugVisuals ............   Passed
100% tests passed out of 1
```

No heap-use-after-free.