### PR TITLE
Guard non-finite LCP solutions and format agent scripts (release-6.20 CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,15 @@
 
 * Dynamics
 
+  * Fix `BoxedLcpConstraintSolver` propagating non-finite constraint impulses:
+    a near-singular contact (e.g. a thin, hard, frictionless geometry) could
+    make the primary solver report success while emitting an *infinite* impulse
+    that slipped past the NaN-only sanity check and produced NaN body impulses
+    (`inf * 0` in the spatial Jacobian moment-arm rows). Both NaN and infinite
+    LCP solutions are now rejected so the secondary/fail-safe zeroing path runs,
+    guaranteeing finite impulses:
+    [#3384](https://github.com/dartsim/dart/pull/3384)
+
   * Add a default-off `BoxedLcpConstraintSolver` matrix-free contact solver
     option, plus dartpy bindings and `contact_benchmark` flags, for explicitly
     benchmarking large supported contact-only islands without changing the

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -1091,8 +1091,8 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
 
   // Treat a finite fallback solution as usable even if the solver reported
   // failure to avoid discarding potentially valid impulses. Note this uses the
-  // pre-scrub non-finite state (hadNonFinite), NOT a post-scrub recheck, so a failed
-  // fallback that wrote NaNs cannot be promoted to success by scrubbing.
+  // pre-scrub non-finite state (hadNonFinite), NOT a post-scrub recheck, so a
+  // failed fallback that wrote NaNs cannot be promoted to success by scrubbing.
   const bool finalSuccess
       = success || fallbackSuccess || (fallbackRan && !hadNonFinite);
 

--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -1053,17 +1053,22 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
         n, a, x, b, 0, lo, hi, fIndex, earlyTermination);
   }
 
-  const auto hasNaN = [](const double* values, std::size_t size) {
+  // A valid LCP solution must be finite. Reject NaN *and* infinite entries: a
+  // near-singular contact (e.g. a thin, hard, frictionless geometry) can make
+  // the primary solver emit an infinite impulse that is not NaN, and feeding
+  // that into the spatial Jacobian yields NaN body impulses (inf * 0 in the
+  // moment-arm rows). Treat both as failure so the fallback/scrub path runs.
+  const auto hasNonFinite = [](const double* values, std::size_t size) {
     for (std::size_t i = 0; i < size; ++i) {
-      if (std::isnan(values[i]))
+      if (!std::isfinite(values[i]))
         return true;
     }
     return false;
   };
 
-  // Sanity check. LCP solvers should not report success with nan values, but
-  // it could happen. So we set the success to false for nan values.
-  if (success && hasNaN(x, n))
+  // Sanity check. LCP solvers should not report success with non-finite
+  // values, but it could happen. So we set the success to false for them.
+  if (success && hasNonFinite(x, n))
     success = false;
 
   bool fallbackSuccess = false;
@@ -1079,35 +1084,35 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
     fallbackRan = true;
   }
 
-  // Capture the NaN state of the solution BEFORE any scrubbing so that
-  // usability is decided from the pre-scrub state. Scrubbing NaN entries must
-  // not be allowed to turn a failed solve into an apparently usable one.
-  const bool hadNaN = hasNaN(x, n);
+  // Capture the non-finite state of the solution BEFORE any scrubbing so that
+  // usability is decided from the pre-scrub state. Scrubbing entries must not
+  // be allowed to turn a failed solve into an apparently usable one.
+  const bool hadNonFinite = hasNonFinite(x, n);
 
   // Treat a finite fallback solution as usable even if the solver reported
   // failure to avoid discarding potentially valid impulses. Note this uses the
-  // pre-scrub NaN state (hadNaN), NOT a post-scrub recheck, so a failed
+  // pre-scrub non-finite state (hadNonFinite), NOT a post-scrub recheck, so a failed
   // fallback that wrote NaNs cannot be promoted to success by scrubbing.
   const bool finalSuccess
-      = success || fallbackSuccess || (fallbackRan && !hadNaN);
+      = success || fallbackSuccess || (fallbackRan && !hadNonFinite);
 
   if (finalSuccess) {
     // The solution will be used. If an otherwise-usable solution (e.g. a
-    // successful fallback) carries stray NaNs, scrub just those entries to 0
-    // so the remaining finite impulses can propagate.
-    if (hadNaN) {
+    // successful fallback) carries stray non-finite entries (NaN or infinite),
+    // scrub just those to 0 so the remaining finite impulses can propagate.
+    if (hadNonFinite) {
       for (std::size_t i = 0; i < n; ++i) {
-        if (std::isnan(x[i]))
+        if (!std::isfinite(x[i]))
           x[i] = 0.0;
       }
     }
   } else {
     // Fail safe: the solve genuinely failed (including a failed fallback that
-    // produced NaNs), so zero the ENTIRE solution rather than propagating
-    // partial finite impulses.
-    if (hadNaN) {
-      dterr << "[BoxedLcpConstraintSolver] The solution of LCP includes NAN "
-            << "values. We're setting it zero for "
+    // produced non-finite values), so zero the ENTIRE solution rather than
+    // propagating partial finite impulses.
+    if (hadNonFinite) {
+      dterr << "[BoxedLcpConstraintSolver] The solution of LCP includes "
+            << "non-finite (NaN or infinite) values. We're setting it zero for "
             << "safety. Consider using more robust solver such as PGS as a "
             << "secondary solver. If this happens even with PGS solver, please "
             << "report this as a bug.\n";
@@ -1254,15 +1259,15 @@ void BoxedLcpConstraintSolver::solvePositionConstrainedGroup(
       fIndex.data(),
       earlyTermination);
 
-  const auto hasNaN = [](const double* values, std::size_t size) {
+  const auto hasNonFinite = [](const double* values, std::size_t size) {
     for (std::size_t i = 0; i < size; ++i) {
-      if (std::isnan(values[i]))
+      if (!std::isfinite(values[i]))
         return true;
     }
     return false;
   };
 
-  if (success && hasNaN(x.data(), n))
+  if (success && hasNonFinite(x.data(), n))
     success = false;
 
   if (!success && mSecondaryBoxedLcpSolver) {
@@ -1279,9 +1284,10 @@ void BoxedLcpConstraintSolver::solvePositionConstrainedGroup(
         false);
   }
 
-  // If the solve failed or produced NaNs, skip the position correction for this
-  // group (leave positions unchanged) rather than apply garbage impulses.
-  if (!success || hasNaN(x.data(), n))
+  // If the solve failed or produced non-finite values (NaN or infinite), skip
+  // the position correction for this group (leave positions unchanged) rather
+  // than apply garbage impulses.
+  if (!success || hasNonFinite(x.data(), n))
     return;
 
   for (std::size_t i = 0; i < numConstraints; ++i) {

--- a/scripts/agent_capture.py
+++ b/scripts/agent_capture.py
@@ -87,13 +87,15 @@ def _make_box_on_ground(dart: Any) -> Any:
     world = dart.simulation.World()
     world.addSkeleton(
         _box_skeleton(
-            dart, "ground", (2.0, 2.0, 0.1), (0.0, 0.0, -0.05), static=True,
+            dart,
+            "ground",
+            (2.0, 2.0, 0.1),
+            (0.0, 0.0, -0.05),
+            static=True,
             color=(0.75, 0.75, 0.78),
         )
     )
-    world.addSkeleton(
-        _box_skeleton(dart, "box", (0.2, 0.2, 0.2), (0.0, 0.0, 0.35))
-    )
+    world.addSkeleton(_box_skeleton(dart, "box", (0.2, 0.2, 0.2), (0.0, 0.0, 0.35)))
     return world
 
 
@@ -101,7 +103,11 @@ def _make_box_stack(dart: Any) -> Any:
     world = dart.simulation.World()
     world.addSkeleton(
         _box_skeleton(
-            dart, "ground", (2.0, 2.0, 0.1), (0.0, 0.0, -0.05), static=True,
+            dart,
+            "ground",
+            (2.0, 2.0, 0.1),
+            (0.0, 0.0, -0.05),
+            static=True,
             color=(0.75, 0.75, 0.78),
         )
     )
@@ -122,7 +128,11 @@ def _make_two_body_contact(dart: Any) -> Any:
     world = dart.simulation.World()
     world.addSkeleton(
         _box_skeleton(
-            dart, "ground", (1.2, 1.2, 0.1), (0.0, 0.0, -0.05), static=True,
+            dart,
+            "ground",
+            (1.2, 1.2, 0.1),
+            (0.0, 0.0, -0.05),
+            static=True,
             color=(0.75, 0.75, 0.78),
         )
     )
@@ -159,9 +169,7 @@ def _camera_from_args(args: argparse.Namespace, world: Any) -> avq.AgentCamera:
     )
 
 
-def _sweep_camera(
-    camera: avq.AgentCamera, azimuth_offset: float
-) -> avq.AgentCamera:
+def _sweep_camera(camera: avq.AgentCamera, azimuth_offset: float) -> avq.AgentCamera:
     offset = np.asarray(camera.eye) - np.asarray(camera.center)
     distance_xy = math.hypot(offset[0], offset[1])
     azimuth = math.atan2(offset[1], offset[0]) + azimuth_offset
@@ -202,9 +210,7 @@ LABEL_VIEW_FRACTION = 0.05
 
 
 def _label_character_size(camera: avq.AgentCamera) -> float:
-    distance = float(
-        np.linalg.norm(np.asarray(camera.eye) - np.asarray(camera.center))
-    )
+    distance = float(np.linalg.norm(np.asarray(camera.eye) - np.asarray(camera.center)))
     half_fov = math.radians(camera.fovy_deg) * 0.5
     return LABEL_VIEW_FRACTION * 2.0 * distance * math.tan(half_fov)
 
@@ -240,9 +246,7 @@ def _capture_view(
         stats["skipped_contacts"] = (
             stats.get("skipped_contacts", 0) + scene.skipped_contacts
         )
-    ado.populate_overlay(
-        overlay, scene, character_size=_label_character_size(camera)
-    )
+    ado.populate_overlay(overlay, scene, character_size=_label_character_size(camera))
     try:
         return _shoot(viewer, camera, path, args)
     finally:
@@ -326,9 +330,7 @@ def run_capture(args: argparse.Namespace) -> dict[str, Any]:
         )
     world = _BUILTIN_SCENES[args.scene](dart)
 
-    tracker = (
-        ado.TrajectoryTracker(world) if "trajectories" in args.layers else None
-    )
+    tracker = ado.TrajectoryTracker(world) if "trajectories" in args.layers else None
     for _ in range(args.steps):
         world.step()
         if tracker is not None:
@@ -480,9 +482,7 @@ def run_capture(args: argparse.Namespace) -> dict[str, Any]:
                 if "contacts" in args.layers
                 else []
             )
-            camera = _sweep_camera(
-                base, sweep * frame / max(args.motion_frames - 1, 1)
-            )
+            camera = _sweep_camera(base, sweep * frame / max(args.motion_frames - 1, 1))
             motion_reports.append(
                 _assess_capture_view(world, camera, args, f"motion{frame}")
             )
@@ -605,13 +605,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--camera-azimuth", type=float, default=math.tau / 8.0)
     parser.add_argument("--camera-elevation", type=float, default=math.tau / 12.0)
     parser.add_argument("--camera-distance", type=float, default=None)
-    parser.add_argument(
-        "--camera-target", nargs=3, type=float, default=[0.0, 0.0, 0.0]
-    )
+    parser.add_argument("--camera-target", nargs=3, type=float, default=[0.0, 0.0, 0.0])
     parser.add_argument("--frame-margin", type=float, default=2.2)
-    parser.add_argument(
-        "--warmup-frames", type=int, default=DEFAULT_WARMUP_FRAMES
-    )
+    parser.add_argument("--warmup-frames", type=int, default=DEFAULT_WARMUP_FRAMES)
     parser.add_argument("--turntable", type=int, default=0)
     parser.add_argument("--motion-frames", type=int, default=0)
     parser.add_argument("--motion-substeps", type=int, default=8)

--- a/scripts/agent_view_quality.py
+++ b/scripts/agent_view_quality.py
@@ -618,8 +618,7 @@ def select_viewpoints(
             break
         azimuth = camera_azimuth(choice)
         if any(
-            _angular_distance(azimuth, camera_azimuth(other))
-            < min_azimuth_separation
+            _angular_distance(azimuth, camera_azimuth(other)) < min_azimuth_separation
             for other in selected
         ):
             continue

--- a/scripts/evidence_select.py
+++ b/scripts/evidence_select.py
@@ -125,7 +125,9 @@ def _find_exact_cover(
             total_bytes = sum(candidate["bytes"] for candidate in candidates)
             if total_bytes > max_total_bytes:
                 continue
-            covered = set().union(*(set(candidate["claims"]) for candidate in candidates))
+            covered = set().union(
+                *(set(candidate["claims"]) for candidate in candidates)
+            )
             if not claim_ids <= covered:
                 continue
             key = (
@@ -221,9 +223,7 @@ def select_evidence(
     # feasible exact cover (quality, bytes, then path break ties). The search is
     # explicitly bounded so large manifests retain the deterministic greedy
     # fallback instead of growing exponentially.
-    exact = _find_exact_cover(
-        ranked, set(claims), max_artifacts, max_total_bytes
-    )
+    exact = _find_exact_cover(ranked, set(claims), max_artifacts, max_total_bytes)
     if exact is not None:
         selected = []
         covered = set()
@@ -234,7 +234,8 @@ def select_evidence(
                 {
                     **candidate,
                     "rationale": (
-                        "covers claim(s) " + ", ".join(sorted(new_claims))
+                        "covers claim(s) "
+                        + ", ".join(sorted(new_claims))
                         + f"; quality={candidate['quality']:.3f}"
                     ),
                     "sha256": _sha256(candidate["path"]),


### PR DESCRIPTION
Fixes the three red `release-6.20` CI jobs on the current HEAD (#3374):
**coverage**, **Asserts enabled (no -DNDEBUG)**, and **Check format**.

## 1. Non-finite LCP solutions (coverage + Asserts enabled)

Both asserts-enabled builds aborted in `test_MjcfParser` (the `Striker`
subtest, whose stepping loop was added in #3369):

```
test_MjcfParser: dart/dynamics/BodyNode.cpp:2283:
  BodyNode::addConstraintImpulse(...): Assertion `!math::isNan(_constImp)' failed.
```

**Root cause (verified with a local diagnostic):** a near-singular contact —
striker.xml's thin, hard, frictionless 1 mm goal walls, effective mass ~0 along
the normal — makes the primary Dantzig solver report success while emitting an
*infinite* normal impulse (confirmed: every step logged `success=1 anyInf=1`
for a single-row `n=1` LCP). `BoxedLcpConstraintSolver` only rejected NaN
entries, so the infinite value propagated into the spatial contact Jacobian,
where `inf * 0` in the moment-arm rows produced NaN body impulses. Release
builds were unaffected only because `NDEBUG` compiled the assertion out while
the NaN silently corrupted the free ball's state.

**Fix:** treat both NaN and infinite solutions as non-finite failures at each
solve site (velocity and position phases). The primary result is rejected so
the secondary (PGS) fallback / fail-safe zeroing runs, and the scrub loop now
zeroes infinite as well as NaN entries — guaranteeing finite constraint
impulses.

## 2. black formatting (Check format)

`scripts/agent_capture.py`, `scripts/agent_view_quality.py`, and
`scripts/evidence_select.py` (added by #3374) were unformatted and failed the
`black --check` gate in the Publish dartpy "Check format" job. Reformatted with
the pinned `black`.

## Verification (local, asserts-enabled `BUILD_TYPE=None`)

- `test_MjcfParser`: **22/22 passed** (was aborting on `Striker`).
- `test_ConstraintSolver`, `test_ContactConstraint`: **passed** (no regression
  from the solver change).
- `black --check` clean on the three scripts.