### PR TITLE
Format AI infrastructure scripts with black (release-6.20 CI)

### DIFF
--- a/scripts/check_ai_infrastructure.py
+++ b/scripts/check_ai_infrastructure.py
@@ -297,9 +297,7 @@ def check_branch_profile(
         root / "docs" / "onboarding" / "architecture.md",
     )
     marker_content = "\n".join(
-        owner.read_text(encoding="utf-8")
-        for owner in marker_owners
-        if owner.is_file()
+        owner.read_text(encoding="utf-8") for owner in marker_owners if owner.is_file()
     )
     for marker in string_lists["required_markers"]:
         if marker not in marker_content:
@@ -494,9 +492,7 @@ def check_hooks(root: Path, errors: list[str]) -> None:
                 f"{path.relative_to(root)}: must invoke the staged agent hook profile"
             )
     launcher = root / ".claude" / "hooks" / "pre-commit-guard.ps1"
-    launcher_text = (
-        launcher.read_text(encoding="utf-8") if launcher.exists() else ""
-    )
+    launcher_text = launcher.read_text(encoding="utf-8") if launcher.exists() else ""
     for marker in WINDOWS_LAUNCHER_MARKERS:
         if marker not in launcher_text:
             errors.append(
@@ -663,9 +659,9 @@ def check_instruction_budget(root: Path, errors: list[str]) -> None:
 
 
 def check_release_guidance(root: Path, errors: list[str]) -> None:
-    python_skill = (
-        root / ".claude" / "skills" / "dart-python" / "SKILL.md"
-    ).read_text(encoding="utf-8")
+    python_skill = (root / ".claude" / "skills" / "dart-python" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
     python_frontmatter = python_skill.split("---", 2)[1]
     if "nanobind" in python_frontmatter or "pybind11" not in python_skill:
         errors.append("dart-python: DART 6.20 metadata must name pybind11")
@@ -680,9 +676,9 @@ def check_release_guidance(root: Path, errors: list[str]) -> None:
         if not (root / ".github" / "workflows" / workflow).is_file():
             errors.append(f"dart-ci: nonexistent workflow `{workflow}`")
 
-    release_fix = (
-        root / ".claude" / "commands" / "dart-release-ci-fix.md"
-    ).read_text(encoding="utf-8")
+    release_fix = (root / ".claude" / "commands" / "dart-release-ci-fix.md").read_text(
+        encoding="utf-8"
+    )
     if "release-6.20" not in release_fix or "release-6.19" in release_fix:
         errors.append("dart-release-ci-fix: release default must be release-6.20")
 
@@ -840,7 +836,7 @@ def check_ci_wiring(root: Path, errors: list[str]) -> None:
         'pixi run python -c "import sys; print(sys.executable)"',
         "$launcher",
         "$hookCommand",
-            "& (Join-Path (git rev-parse --show-toplevel)",
+        "& (Join-Path (git rev-parse --show-toplevel)",
         '$ErrorActionPreference = "Continue"',
         '"git status"',
         "DART_HOOK_DRY_RUN",
@@ -1245,9 +1241,9 @@ def exercise_scenarios(
                         f"dart-verify-sim source is missing contract marker {marker!r}"
                     )
             try:
-                new_task_text = (
-                    root / ".claude/commands/dart-new-task.md"
-                ).read_text(encoding="utf-8")
+                new_task_text = (root / ".claude/commands/dart-new-task.md").read_text(
+                    encoding="utf-8"
+                )
             except OSError:
                 new_task_text = ""
             for marker in (
@@ -1276,9 +1272,7 @@ def exercise_scenarios(
                 ".claude/commands/dart-ultrawork.md": (
                     "routes through `dart-verify-sim`",
                 ),
-                ".claude/commands/dart-resume.md": (
-                    "route through `dart-verify-sim`",
-                ),
+                ".claude/commands/dart-resume.md": ("route through `dart-verify-sim`",),
                 ".claude/commands/dart-pr.md": ("use `dart-verify-sim`",),
                 ".claude/commands/dart-manage-pr.md": ("Visual verification",),
                 ".claude/commands/dart-review-pr.md": (

--- a/tests/test_ai_infrastructure.py
+++ b/tests/test_ai_infrastructure.py
@@ -283,7 +283,9 @@ def test_simulation_consumer_routes_are_required(monkeypatch, relative, marker):
 
     errors = infra.exercise_scenarios(ROOT, emit=False)
 
-    assert any(relative in error and "simulation route marker" in error for error in errors)
+    assert any(
+        relative in error and "simulation route marker" in error for error in errors
+    )
 
 
 def test_boolean_schema_versions_are_rejected():
@@ -495,9 +497,7 @@ def test_agent_hook_path_routing_is_bounded():
     assert hook.is_ai_infrastructure_path("docs/onboarding/testing.md")
     assert hook.is_ai_infrastructure_path(".codex/agents/dart_scout.toml")
     assert hook.is_ai_infrastructure_path(".github/workflows/ci_macos.yml")
-    assert hook.is_ai_infrastructure_path(
-        "python/tests/unit/gui/test_agent_capture.py"
-    )
+    assert hook.is_ai_infrastructure_path("python/tests/unit/gui/test_agent_capture.py")
     assert hook.is_ai_infrastructure_path(
         "python/tests/unit/gui/test_agent_debug_overlay.py"
     )
@@ -774,9 +774,9 @@ def test_ci_wiring_requires_native_windows_hook_smoke(tmp_path):
         "--width 320 --height 240\n"
         "--out /tmp/dart-agent-visual-smoke --prefix smoke\n"
         "pixi run image-verdict\n"
-            "/tmp/dart-agent-visual-smoke/smoke_auto0.png\n"
-            "xvfb-run\n"
-            "pixi run test-agent-debug-overlay\n"
+        "/tmp/dart-agent-visual-smoke/smoke_auto0.png\n"
+        "xvfb-run\n"
+        "pixi run test-agent-debug-overlay\n"
     )
     (workflows / "ci_windows.yml").write_text(
         "Native Windows hook smoke\n"
@@ -833,12 +833,12 @@ def test_ci_wiring_requires_visual_verification_smoke(tmp_path, marker):
             "- name: Agent visual verification smoke"
         )
         assert separator
-        mutated = before + separator + visual_and_after.replace(
-            marker, "missing-visual-marker", 1
+        mutated = (
+            before
+            + separator
+            + visual_and_after.replace(marker, "missing-visual-marker", 1)
         )
-    (workflows / "ci_ubuntu.yml").write_text(
-        mutated
-    )
+    (workflows / "ci_ubuntu.yml").write_text(mutated)
     (workflows / "ci_windows.yml").write_text(
         (ROOT / ".github/workflows/ci_windows.yml").read_text()
     )
@@ -858,9 +858,7 @@ def test_ci_wiring_requires_visual_verification_smoke(tmp_path, marker):
         ("soft-fail", "must not use continue-on-error"),
     ),
 )
-def test_visual_smoke_cannot_be_skipped_or_soft_failed(
-    tmp_path, mutation, expected
-):
+def test_visual_smoke_cannot_be_skipped_or_soft_failed(tmp_path, mutation, expected):
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
     ubuntu = (ROOT / ".github/workflows/ci_ubuntu.yml").read_text()
@@ -902,9 +900,7 @@ def test_visual_smoke_cannot_be_skipped_or_soft_failed(
         "assert after_clear == base",
     ),
 )
-def test_ci_wiring_requires_non_skippable_overlay_pixel_assertions(
-    tmp_path, marker
-):
+def test_ci_wiring_requires_non_skippable_overlay_pixel_assertions(tmp_path, marker):
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
     (workflows / "ci_ubuntu.yml").write_text(
@@ -1053,14 +1049,14 @@ def test_ci_wiring_requires_factory_capture_and_visual_task(
             ".claude/hooks/pre-commit-guard.ps1",
             "$global:LASTEXITCODE = $null",
         ),
-            (
-                ".claude/hooks/pre-commit-guard.ps1",
-                "$payload = [Console]::In.ReadToEnd()",
-            ),
-            (
-                ".claude/hooks/pre-commit-guard.ps1",
-                "$pipelineInput = @($input | ForEach-Object { $_ })",
-            ),
+        (
+            ".claude/hooks/pre-commit-guard.ps1",
+            "$payload = [Console]::In.ReadToEnd()",
+        ),
+        (
+            ".claude/hooks/pre-commit-guard.ps1",
+            "$pipelineInput = @($input | ForEach-Object { $_ })",
+        ),
         (
             ".claude/hooks/pre-commit-guard.ps1",
             "$pipelineInput.Count -gt 0",


### PR DESCRIPTION
## Summary

- Reformat two AI-infrastructure Python files with `black` so the release-6.20 "Check format" job passes.

## Motivation / Problem

- The `Publish dartpy` → `Check format` job on `release-6.20` fails at `black --check --diff .`:
  `2 files would be reformatted`. The drift was introduced by #3385, which
  landed `scripts/check_ai_infrastructure.py` and `tests/test_ai_infrastructure.py`
  without running `pixi run lint`. Failing run:
  https://github.com/dartsim/dart/actions/runs/29232345566/job/86759153036

## Changes / Key Changes

- `black`-format `scripts/check_ai_infrastructure.py` (line rewraps, drop over-indented list item).
- `black`-format `tests/test_ai_infrastructure.py` (line rewraps, drop over-indented tuple entries).
- Formatting-only; no logic or behavior change.

## Testing

- `uvx black@25.12.0 --check .` — clean for all in-scope tracked files (matches the
  release-6.20 `black >=25.1,<26` pin and the exact CI resolver version; the local
  pixi env carries main's black 26.x, so `uvx` was used to match CI).
- `uvx isort@6.1.0 --profile black --check` on both files — clean.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Fixes formatting drift from #3385. Release-scoped: the affected files differ on
  `main`, which is already format-clean, so no matching `main` PR is required.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [ ] CHANGELOG.md updated if required (N/A — formatting-only CI fix)
- [ ] Add unit tests for new functionality (N/A)
- [ ] Document new methods and classes (N/A)
- [ ] Add Python bindings (dartpy) if applicable (N/A)
