### PR TITLE
Keep OpenSceneGraph optional when GUI OSG is disabled (DART 6.19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ dist/
 # pixi environments
 .pixi
 
+# AI tool local state
+.omx/
+
 # ImGui configuration
 imgui.ini
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## DART 6
 
+### [DART 6.19.4 (TBD)](https://github.com/dartsim/dart/milestone/103?closed=1)
+
+* Build
+
+  * Keep source builds configurable without OpenSceneGraph when
+    `DART_BUILD_GUI_OSG=OFF` by skipping the OSG-only dynamic-joint-constraints
+    example before it requests `osgText`:
+    [#3387](https://github.com/dartsim/dart/issues/3387)
+
 ### [DART 6.19.3 (2026-06-27)](https://github.com/dartsim/dart/milestone/101?closed=1)
 
 DART 6.19.3 is a patch release on the DART 6 LTS line. It hardens contact

--- a/examples/dynamic_joint_constraints/CMakeLists.txt
+++ b/examples/dynamic_joint_constraints/CMakeLists.txt
@@ -7,6 +7,10 @@ project(${example_name})
 set(required_components gui-osg)
 set(required_libraries dart dart-gui-osg)
 
+if(DART_IN_SOURCE_BUILD AND NOT TARGET dart-gui-osg)
+  return()
+endif()
+
 find_package(OpenSceneGraph 3.0.0 REQUIRED COMPONENTS osgText)
 set(osg_text_library ${OSGTEXT_LIBRARY})
 if(NOT osg_text_library)

--- a/pixi.toml
+++ b/pixi.toml
@@ -183,6 +183,7 @@ config-asan = { cmd = """
         -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer" \
         -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
         -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address" \
+        -DCMAKE_DISABLE_FIND_PACKAGE_OpenSceneGraph=TRUE \
         -DDART_BUILD_DARTPY=OFF \
         -DDART_BUILD_GUI_OSG=OFF \
         -DDART_BUILD_PROFILE=OFF \


### PR DESCRIPTION
## Summary

- Restore `DART_BUILD_GUI_OSG=OFF` builds without an OpenSceneGraph installation.
- Add a deterministic CI configuration gate that fails if OpenSceneGraph becomes required again.
- Record the DART 6.19.4 fix and ignore local `.omx/` runtime state.

## Motivation / Problem

- DART 6.19.3 configures the OSG-only `dynamic_joint_constraints` example far enough to run a required `find_package(OpenSceneGraph ...)`, even when the GUI OSG component is disabled. This makes OpenSceneGraph an accidental hard dependency and breaks consumers that intentionally build DART without it.

## Changes / Key Changes

- Return before the example's `osgText` lookup when an in-source build has no `dart-gui-osg` target.
- Make the ASan configuration explicitly disable discovery of OpenSceneGraph while `DART_BUILD_GUI_OSG=OFF`.
- Add the DART 6.19.4 changelog entry and the approved `.omx/` ignore rule.

## Testing

- Reproduced the original v6.19.3 configure failure with `DART_BUILD_GUI_OSG=OFF` and `CMAKE_DISABLE_FIND_PACKAGE_OpenSceneGraph=TRUE`.
- `pixi run lint`
- `pixi run config-asan`
- `pixi run test-asan` (444 build targets; 99/99 tests passed)
- OSG-enabled `dynamic_joint_constraints` target build and ELF dependency check
- `pixi run test-all` (full Release build; 99/99 C++ and 53/53 Python tests passed)
- `pixi run -e gazebo test-gz` (199/199 gz-physics tests, 4/4 performance tests, plugin linkage, and gz-sim integration passed)
- Two independent post-fix reviews with no substantive findings

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Related to #3387

---

#### Checklist

- [x] Milestone set (`DART 6.19.4` for `release-6.19`)
- [x] `CHANGELOG.md` updated
- [x] Regression coverage added through the forced no-OSG ASan configuration
- [x] Documentation changes are not applicable
- [x] Python bindings are not affected
