### PR TITLE
Packaging 6.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,27 @@
 
 ## DART 6
 
-### [DART 6.19.4 (TBD)](https://github.com/dartsim/dart/milestone/103?closed=1)
+### [DART 6.19.4 (2026-07-18)](https://github.com/dartsim/dart/milestone/103?closed=1)
+
+DART 6.19.4 is a focused patch release on the DART 6 LTS line. It restores
+source builds that disable the OpenSceneGraph GUI component and makes that
+optional-dependency contract deterministic in CI. The only additional
+maintenance change ignores local `.omx/` state.
 
 * Build
 
   * Keep source builds configurable without OpenSceneGraph when
     `DART_BUILD_GUI_OSG=OFF` by skipping the OSG-only dynamic-joint-constraints
-    example before it requests `osgText`:
+    example before it requests `osgText`. The ASan configuration now disables
+    OpenSceneGraph discovery so CI fails if this dependency becomes mandatory
+    again:
+    [#3391](https://github.com/dartsim/dart/pull/3391),
     [#3387](https://github.com/dartsim/dart/issues/3387)
+
+* Tooling and Docs
+
+  * Ignore local `.omx/` state so it is not accidentally committed:
+    [#3391](https://github.com/dartsim/dart/pull/3391)
 
 ### [DART 6.19.3 (2026-06-27)](https://github.com/dartsim/dart/milestone/101?closed=1)
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
        a Catkin workspace. Catkin is not required to build DART. For more
        information, see: http://ros.org/reps/rep-0136.html -->
   <name>dartsim</name>
-  <version>6.19.3</version>
+  <version>6.19.4</version>
   <description>
     DART (Dynamic Animation and Robotics Toolkit) is a collaborative,
     cross-platform, open source library created by the Georgia Tech Graphics

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "DART"
-version = "6.19.3"
+version = "6.19.4"
 description = "Dynamic Animation and Robotics Toolkit"
 authors = ["Jeongseok Lee <jslee02@gmail.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
## Summary

- Package DART 6.19.4 for the `release-6.19` maintenance line.
- Finalize the focused #3387 fix and approved `.omx/` maintenance for tagging.

## Motivation / Problem

- #3391 restores the optional-OpenSceneGraph build contract for
  `DART_BUILD_GUI_OSG=OFF` and adds deterministic regression coverage.
- The release branch needs 6.19.4 version metadata and finalized release notes
  before creating `v6.19.4`.

## Changes / Key Changes

- Bump `package.xml` from 6.19.3 to 6.19.4.
- Bump the `pixi.toml` workspace version from 6.19.3 to 6.19.4.
- Date and finalize the DART 6.19.4 changelog section, including #3391/#3387
  and the approved `.omx/` ignore-file maintenance.
- Make no source or behavior changes beyond the already-merged #3391.

## Testing

- `pixi run lint`
- `pixi run test-all`
- `pixi run -e gazebo test-gz`
- `git diff --check`
- Audited `v6.19.3..HEAD` to confirm the release contains only #3391 and
  6.19.4 packaging metadata.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- #3391
- #3387
- [DART 6.19.4 milestone](https://github.com/dartsim/dart/milestone/103)

---

#### Checklist

- [x] Milestone set (`DART 6.19.4`)
- [x] CHANGELOG.md updated if required
- [x] Add unit tests for new functionality (regression gate in #3391)
- [x] Document new methods and classes (not applicable)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
