### PR TITLE
Skip MSVC whole-program optimization in Windows CI test build

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: windows-2025-vs2026
     env:
       CMAKE_GENERATOR: Visual Studio 18 2026
-      # Whole-program optimization (/GL + link-time /LTCG) cannot be cached by
-      # sccache and makes the MSVC Release build run for hours, overrunning the
-      # job timeout. Disable it for the CI C++/dartpy test build; the published
-      # wheels (publish_dartpy.yml) keep it on and are still tested there.
+      # Whole-program optimization (/GL) runs an expensive link-time /LTCG
+      # codegen pass that makes the MSVC Release build run for hours, overrunning
+      # the job timeout. Disable it for the CI C++/dartpy test build; the
+      # published wheels (publish_dartpy.yml) keep it on and are still tested.
       DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION: "ON"
     # Keep the job bounded, but allow large native-collision PRs enough time
     # for MSVC Release test linking on hosted runners. Release-branch Windows

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -35,6 +35,11 @@ jobs:
     runs-on: windows-2025-vs2026
     env:
       CMAKE_GENERATOR: Visual Studio 18 2026
+      # Whole-program optimization (/GL + link-time /LTCG) cannot be cached by
+      # sccache and makes the MSVC Release build run for hours, overrunning the
+      # job timeout. Disable it for the CI C++/dartpy test build; the published
+      # wheels (publish_dartpy.yml) keep it on and are still tested there.
+      DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION: "ON"
     # Keep the job bounded, but allow large native-collision PRs enough time
     # for MSVC Release test linking on hosted runners. Release-branch Windows
     # builds can exceed three hours on cold hosted runners after the DART 6.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@
 
   * Disable MSVC whole-program optimization (`/GL` plus link-time `/LTCG`) in the
     Windows CI C++/dartpy test build so the MSVC Release build stays under the
-    job timeout. `/GL` cannot be cached by `sccache`, so it forced a multi-hour
+    job timeout. `/GL`'s link-time `/LTCG` codegen pass forced a multi-hour
     rebuild every run and intermittently overran the 300-minute limit; the
     published wheels keep whole-program optimization and are still tested. Add
     the `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION` CMake option (also honored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
     across Pixi, CI, and source builds.
     ([#3348](https://github.com/dartsim/dart/pull/3348))
 
+  * Disable MSVC whole-program optimization (`/GL` plus link-time `/LTCG`) in the
+    Windows CI C++/dartpy test build so the MSVC Release build stays under the
+    job timeout. `/GL` cannot be cached by `sccache`, so it forced a multi-hour
+    rebuild every run and intermittently overran the 300-minute limit; the
+    published wheels keep whole-program optimization and are still tested. Add
+    the `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION` CMake option (also honored
+    through the environment) to control it.
+
   * Keep Pixi DartPy and GUI demo configuration warning-free on CMake 4.3 by
     using the Pixi `pybind11` package with modern Python discovery, updating
     the FetchContent fallback to the same pybind11 release, and resolving GLVND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,29 @@ if(MSVC)
     "Force /MD (Release DLL runtime) for all configurations to match pre-built packages"
     ON
   )
+  # Whole-program optimization (/GL + link-time /LTCG) roughly triples the MSVC
+  # Release build time and cannot be cached by sccache. Keep it ON by default so
+  # shipped wheels stay optimized, but let the CI C++ test build disable it to
+  # stay under the Windows job timeout (the wheel jobs still exercise an
+  # optimized build).
+  dart_option(
+    DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
+    "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds"
+    OFF
+  )
+  # Honor the environment so CI can toggle this for every cmake configure in the
+  # job (the C++ and dartpy builds use different pixi config tasks) without
+  # editing each task. An explicit -D on the command line still applies when the
+  # environment variable is unset.
+  if(DEFINED ENV{DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION})
+    set(
+      DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
+      "$ENV{DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION}"
+      CACHE BOOL
+      "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds"
+      FORCE
+    )
+  endif()
   dart_configure_msvc_runtime_library()
 else()
   dart_option(BUILD_SHARED_LIBS "Build shared libraries" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,11 +125,11 @@ if(MSVC)
     "Force /MD (Release DLL runtime) for all configurations to match pre-built packages"
     ON
   )
-  # Whole-program optimization (/GL + link-time /LTCG) roughly triples the MSVC
-  # Release build time and cannot be cached by sccache. Keep it ON by default so
-  # shipped wheels stay optimized, but let the CI C++ test build disable it to
-  # stay under the Windows job timeout (the wheel jobs still exercise an
-  # optimized build).
+  # Whole-program optimization (/GL) defers code generation to a link-time /LTCG
+  # pass that optimizes across every translation unit at once, which roughly
+  # triples the MSVC Release build time. Keep it ON by default so shipped wheels
+  # stay optimized, but let the CI C++ test build disable it to stay under the
+  # Windows job timeout (the wheel jobs still exercise an optimized build).
   #
   # Seed the cache from the environment BEFORE dart_option() so CI can toggle it
   # for every cmake configure in the job without editing each pixi config task.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,15 +130,13 @@ if(MSVC)
   # shipped wheels stay optimized, but let the CI C++ test build disable it to
   # stay under the Windows job timeout (the wheel jobs still exercise an
   # optimized build).
-  dart_option(
-    DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
-    "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds"
-    OFF
-  )
-  # Honor the environment so CI can toggle this for every cmake configure in the
-  # job (the C++ and dartpy builds use different pixi config tasks) without
-  # editing each task. An explicit -D on the command line still applies when the
-  # environment variable is unset.
+  #
+  # Seed the cache from the environment BEFORE dart_option() so CI can toggle it
+  # for every cmake configure in the job without editing each pixi config task.
+  # dart_option() also sets a normal (non-cache) variable of the same name, which
+  # would shadow a cache value forced after it and leave the first configure on
+  # the default; seeding first makes dart_option() normalize the intended value.
+  # An explicit -D still applies when the environment variable is unset.
   if(DEFINED ENV{DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION})
     set(
       DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
@@ -148,6 +146,11 @@ if(MSVC)
       FORCE
     )
   endif()
+  dart_option(
+    DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
+    "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds"
+    OFF
+  )
   dart_configure_msvc_runtime_library()
 else()
   dart_option(BUILD_SHARED_LIBS "Build shared libraries" ON)

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -459,7 +459,7 @@ function(dart_configure_msvc_toolchain)
       $<$<COMPILE_LANGUAGE:CXX>:/W1>
       $<$<COMPILE_LANGUAGE:CXX>:/Zi>
       $<$<COMPILE_LANGUAGE:CXX>:/Gy>
-      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/GL>
+      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>,$<NOT:$<BOOL:${DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION}>>>:/GL>
     )
     add_link_options($<$<CONFIG:Release>:/INCREMENTAL:NO>)
   endif()

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -223,7 +223,9 @@ if(spdlog_FOUND)
   add_component_dependency_packages(${PROJECT_NAME} dart spdlog)
 endif()
 
-if(MSVC)
+if(MSVC AND NOT DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION)
+  # /LTCG pairs with the /GL whole-program objects; skip it when whole-program
+  # optimization is disabled so no uncached link-time codegen remains.
   set_target_properties(dart PROPERTIES STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
 endif()
 

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -225,7 +225,7 @@ endif()
 
 if(MSVC AND NOT DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION)
   # /LTCG pairs with the /GL whole-program objects; skip it when whole-program
-  # optimization is disabled so no uncached link-time codegen remains.
+  # optimization is disabled so no link-time codegen pass remains.
   set_target_properties(dart PROPERTIES STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
 endif()
 


### PR DESCRIPTION
## Summary

- Stop building the Windows CI C++/dartpy **test** build with MSVC whole-program
  optimization (`/GL` + link-time `/LTCG`) so the MSVC Release build stays under
  the job timeout.

## Motivation / Problem

- The `CI Windows` → `Release` job on `release-6.20` intermittently **times out**
  at its `timeout-minutes: 300` limit. On the latest commit the MSVC build alone
  ran ~4 h 58 m (continuous, no hang) and `ctest` was cancelled after only
  44 / 149 tests. Even the last *successful* run (Jul 13) took **259 min** —
  ~40 min under the ceiling.
- Root cause: DART compiles Windows Release with `/GL` (whole-program
  optimization), which triggers link-time `/LTCG`. **`sccache` cannot cache
  `/GL`/LTCG compilation**, so every Windows build is effectively a full cold
  whole-program rebuild that sits right at the 5-hour limit and randomly crosses
  it. This is unrelated to any recent source change (e.g. the pixi lockfile
  update changed no toolchain).

## Changes / Key Changes

- Add CMake option `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION` (default `OFF`,
  MSVC-only) that drops `/GL` from the Release compile options. It is also
  honored from the environment so a single job-level variable toggles every
  cmake configure in the job (the C++ and dartpy builds use different pixi
  config tasks).
- Set `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION: "ON"` for the `CI Windows`
  test job only.
- Published wheels (`publish_dartpy.yml`) do **not** set the flag, so they keep
  whole-program optimization and are still exercised by the `windows-cp3xx`
  wheel jobs (which run pytest). Test coverage of an optimized Windows build is
  preserved.

## Testing

- `gersemi --check`, `codespell`, `python scripts/check_ai_infrastructure.py`,
  and YAML load all pass locally.
- The change is MSVC-only (guarded by `if(MSVC)` / `$<CONFIG:Release>`), so the
  effective validation is the `CI Windows` job on this PR finishing under the
  timeout with `ctest` completing. Will monitor.

## Breaking Changes

- [x] None (default `OFF` preserves existing behavior; wheels unchanged).

## Related Issues / PRs (backports)

- Matching `main` PR opens alongside this one (same `/GL` timeout exposure).

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated (Build section)
- [ ] Add unit tests for new functionality (N/A — CI/build-config change)
- [ ] Document new methods and classes (N/A)
- [ ] Add Python bindings (dartpy) if applicable (N/A)
