### PR TITLE
Skip MSVC whole-program optimization in Windows CI test build

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -69,10 +69,10 @@ jobs:
       # Parallelize the ctest phase; the serial suite (incl. the ~350s long
       # pole) dominated the Windows job's ~90min wall-clock.
       CTEST_PARALLEL_LEVEL: 4
-      # Whole-program optimization (/GL + link-time /LTCG) cannot be cached by
-      # sccache and dominates the MSVC Release build time. Disable it for the CI
-      # C++/dartpy test build; the published wheels (publish_dartpy.yml) keep it
-      # on and are still tested there.
+      # Whole-program optimization (/GL) runs an expensive link-time /LTCG
+      # codegen pass that dominates the MSVC Release build time. Disable it for
+      # the CI C++/dartpy test build; the published wheels (publish_dartpy.yml)
+      # keep it on and are still tested there.
       DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION: "ON"
     # Fail fast on a regression instead of waiting for the ~6h default kill.
     # Sized generously for a first cold-sccache Ninja build.

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -69,6 +69,11 @@ jobs:
       # Parallelize the ctest phase; the serial suite (incl. the ~350s long
       # pole) dominated the Windows job's ~90min wall-clock.
       CTEST_PARALLEL_LEVEL: 4
+      # Whole-program optimization (/GL + link-time /LTCG) cannot be cached by
+      # sccache and dominates the MSVC Release build time. Disable it for the CI
+      # C++/dartpy test build; the published wheels (publish_dartpy.yml) keep it
+      # on and are still tested there.
+      DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION: "ON"
     # Fail fast on a regression instead of waiting for the ~6h default kill.
     # Sized generously for a first cold-sccache Ninja build.
     timeout-minutes: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,10 +490,11 @@ compatibility remains on the active DART 6 LTS branch._
   fixed at the cause with regression coverage, rather than silenced or patched
   around, plus a matching principle-audit item.
 - Skip MSVC whole-program optimization (`/GL` plus link-time `/LTCG`) in the
-  Windows CI C++/dartpy test build so the MSVC Release build stays fast and
-  `sccache`-cacheable; published wheels keep it and are still tested. Controlled
-  by the new `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION` CMake option, also
-  honored through the environment.
+  Windows CI C++/dartpy test build so the MSVC Release build avoids the expensive
+  link-time codegen pass that dominates its wall-clock; published wheels keep it
+  and are still tested. Controlled by the new
+  `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION` CMake option, also honored
+  through the environment.
 
 #### Tests, Benchmarks, and Quality Gates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,11 @@ compatibility remains on the active DART 6 LTS branch._
   regressions, numerical drift) are reproduced as the smallest failing case and
   fixed at the cause with regression coverage, rather than silenced or patched
   around, plus a matching principle-audit item.
+- Skip MSVC whole-program optimization (`/GL` plus link-time `/LTCG`) in the
+  Windows CI C++/dartpy test build so the MSVC Release build stays fast and
+  `sccache`-cacheable; published wheels keep it and are still tested. Controlled
+  by the new `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION` CMake option, also
+  honored through the environment.
 
 #### Tests, Benchmarks, and Quality Gates
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,27 @@ if(MSVC)
     "Force /MD (Release DLL runtime) for all configurations to match pre-built packages (conda-forge, vcpkg, etc.)" ON
     CATEGORY msvc
   )
+  # Whole-program optimization (/GL + link-time /LTCG) roughly triples the MSVC
+  # Release build time and cannot be cached by sccache. Keep it ON by default so
+  # shipped wheels stay optimized, but let the CI C++ test build disable it to
+  # keep the Windows job fast (the wheel jobs still exercise an optimized build).
+  dart_option(DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
+    "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds" OFF
+    CATEGORY msvc
+  )
+  # Honor the environment so CI can toggle this for every cmake configure in the
+  # job (the C++ and dartpy builds use different pixi config tasks) without
+  # editing each task. An explicit -D on the command line still applies when the
+  # environment variable is unset.
+  if(DEFINED ENV{DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION})
+    set(
+      DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
+      "$ENV{DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION}"
+      CACHE BOOL
+      "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds"
+      FORCE
+    )
+  endif()
   dart_configure_msvc_runtime_library()
 else()
   dart_option(BUILD_SHARED_LIBS "Build shared libraries" ON CATEGORY build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,10 +215,11 @@ if(MSVC)
     "Force /MD (Release DLL runtime) for all configurations to match pre-built packages (conda-forge, vcpkg, etc.)" ON
     CATEGORY msvc
   )
-  # Whole-program optimization (/GL + link-time /LTCG) roughly triples the MSVC
-  # Release build time and cannot be cached by sccache. Keep it ON by default so
-  # shipped wheels stay optimized, but let the CI C++ test build disable it to
-  # keep the Windows job fast (the wheel jobs still exercise an optimized build).
+  # Whole-program optimization (/GL) defers code generation to a link-time /LTCG
+  # pass that optimizes across every translation unit at once, which roughly
+  # triples the MSVC Release build time. Keep it ON by default so shipped wheels
+  # stay optimized, but let the CI C++ test build disable it to keep the Windows
+  # job fast (the wheel jobs still exercise an optimized build).
   #
   # Seed the cache from the environment BEFORE dart_option() so CI can toggle it
   # for every cmake configure in the job without editing each pixi config task.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,14 +219,13 @@ if(MSVC)
   # Release build time and cannot be cached by sccache. Keep it ON by default so
   # shipped wheels stay optimized, but let the CI C++ test build disable it to
   # keep the Windows job fast (the wheel jobs still exercise an optimized build).
-  dart_option(DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
-    "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds" OFF
-    CATEGORY msvc
-  )
-  # Honor the environment so CI can toggle this for every cmake configure in the
-  # job (the C++ and dartpy builds use different pixi config tasks) without
-  # editing each task. An explicit -D on the command line still applies when the
-  # environment variable is unset.
+  #
+  # Seed the cache from the environment BEFORE dart_option() so CI can toggle it
+  # for every cmake configure in the job without editing each pixi config task.
+  # dart_option() also sets a normal (non-cache) variable of the same name, which
+  # would shadow a cache value forced after it and leave the first configure on
+  # the default; seeding first makes dart_option() normalize the intended value.
+  # An explicit -D still applies when the environment variable is unset.
   if(DEFINED ENV{DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION})
     set(
       DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
@@ -236,6 +235,10 @@ if(MSVC)
       FORCE
     )
   endif()
+  dart_option(DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION
+    "Disable MSVC whole-program optimization (/GL, /LTCG) in Release builds" OFF
+    CATEGORY msvc
+  )
   dart_configure_msvc_runtime_library()
 else()
   dart_option(BUILD_SHARED_LIBS "Build shared libraries" ON CATEGORY build)

--- a/cmake/dart_defs.cmake
+++ b/cmake/dart_defs.cmake
@@ -671,7 +671,7 @@ function(dart_configure_msvc_toolchain)
       $<$<COMPILE_LANGUAGE:CXX>:/W1>
       $<$<COMPILE_LANGUAGE:CXX>:/Zi>
       $<$<COMPILE_LANGUAGE:CXX>:/Gy>
-      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:/GL>
+      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>,$<NOT:$<BOOL:${DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION}>>>:/GL>
     )
     add_link_options($<$<CONFIG:Release>:/INCREMENTAL:NO>)
   endif()

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -316,7 +316,9 @@ endforeach()
 unset(_dart_legacy_collision_component)
 unset(_dart_legacy_collision_target)
 
-if(MSVC)
+if(MSVC AND NOT DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION)
+  # /LTCG pairs with the /GL whole-program objects; skip it when whole-program
+  # optimization is disabled so no uncached link-time codegen remains.
   set_target_properties(dart PROPERTIES STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
 endif()
 

--- a/dart/CMakeLists.txt
+++ b/dart/CMakeLists.txt
@@ -318,7 +318,7 @@ unset(_dart_legacy_collision_target)
 
 if(MSVC AND NOT DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION)
   # /LTCG pairs with the /GL whole-program objects; skip it when whole-program
-  # optimization is disabled so no uncached link-time codegen remains.
+  # optimization is disabled so no link-time codegen pass remains.
   set_target_properties(dart PROPERTIES STATIC_LIBRARY_FLAGS_RELEASE "/LTCG")
 endif()
 


### PR DESCRIPTION
## Summary

- Stop building the Windows CI C++/dartpy **test** build with MSVC whole-program
  optimization (`/GL` + link-time `/LTCG`) to keep the Windows job fast and
  `sccache`-cacheable. Mirrors the release-6.20 fix (#3395) so the build option
  stays in sync across branches.

## Motivation / Problem

- DART compiles Windows Release with `/GL` (whole-program optimization), which
  triggers link-time `/LTCG`. **`sccache` cannot cache `/GL`/LTCG compilation**,
  so every Windows build repeats a full whole-program rebuild that dominates the
  job wall-clock.
- On `release-6.20` this pushes the MSVC build past the job timeout (the build
  alone ran ~5h, cancelling `ctest`); see #3395. `main`'s Windows job is not
  currently timing out (120-minute limit), but it carries the same uncacheable
  `/GL` cost and the same option should exist on `main` so a future
  release→main merge does not diverge on this setting.

## Changes / Key Changes

- Add CMake option `DART_MSVC_DISABLE_WHOLE_PROGRAM_OPTIMIZATION` (default `OFF`,
  MSVC-only) that drops `/GL` from the Release compile options, also honored from
  the environment so one job-level variable toggles every cmake configure in the
  job.
- Set it `ON` for the `CI Windows` test job only.
- Published wheels (`publish_dartpy.yml`) do not set the flag, so they keep
  whole-program optimization and are still exercised (pytest) by the wheel jobs.

## Testing

- `gersemi --check`, `codespell`, `python scripts/check_ai_infrastructure.py`,
  and YAML load all pass locally.
- MSVC-only change (guarded by `if(MSVC)` / `$<CONFIG:Release>`); the effective
  validation is the `CI Windows` job on this PR. Will monitor.

## Breaking Changes

- [x] None (default `OFF` preserves existing behavior; wheels unchanged).

## Related Issues / PRs (backports)

- Release-6.20 counterpart: #3395.

---

#### Checklist

- [x] Milestone set (DART 7.0)
- [x] CHANGELOG.md updated (Build, Packaging, and Developer Tooling)
- [ ] Add unit tests for new functionality (N/A — CI/build-config change)
- [ ] Document new methods and classes (N/A)
- [ ] Add Python bindings (dartpy) if applicable (N/A)
