### PR TITLE
Force-refresh gh-pages before publishing community signals

### DIFF
--- a/.github/workflows/community_signals.yml
+++ b/.github/workflows/community_signals.yml
@@ -51,7 +51,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --depth=1 origin gh-pages:refs/remotes/origin/gh-pages
+          git fetch --depth=1 origin \
+            +refs/heads/gh-pages:refs/remotes/origin/gh-pages
           git worktree prune
 
           worktree_parent="$(mktemp -d "${RUNNER_TEMP:-/tmp}/community-signals-gh-pages.XXXXXX")"


### PR DESCRIPTION
## Summary

- Make the Community Signals publisher refresh its local `origin/gh-pages`
  tracking ref before creating the temporary publishing worktree, so reused
  self-hosted runner workspaces cannot reject a newer branch tip.

## Motivation / Problem

- Persistent self-hosted runner workspaces can retain an older
  `origin/gh-pages` ref after `actions/checkout` cleans the checked-out files.
- Community Signals run
  https://github.com/dartsim/dart/actions/runs/29700374222 then failed before
  publication with `gh-pages -> origin/gh-pages (non-fast-forward)`.
- A scheduled run at the same `main` SHA succeeded on a workspace without that
  retained ref (https://github.com/dartsim/dart/actions/runs/29724972934),
  confirming that the failure is local fetch state rather than the generated
  dashboard or remote branch history.

## Changes / Key Changes

- Fully qualify the `gh-pages` fetch refspec and prefix it with `+` so Git
  force-refreshes only `refs/remotes/origin/gh-pages`.
- Keep the existing normal `HEAD:gh-pages` push unchanged; this does not
  force-push or rewrite the remote branch.
- Leave the runner image and persistent workspace volumes unchanged.

## Testing

- `pixi run lint`
- `pixi run check-lint`
- `pixi run check-lint-yaml`
- YAML parse with the Pixi Python environment
- Extracted publish shell block checked with `bash -n`
- Forced fetch refspec checked with `git fetch --dry-run`
- `git diff --check`
- `DART_DISABLE_COMPILER_CACHE=ON pixi run test-all`: lint, Release/Debug
  builds, and all 227 core tests passed. The simulation tier stopped on
  deterministic pre-existing current-`main` allocation assertions in
  `test_world_global_heap` and `test_world_raw_malloc`. This PR changes only
  the workflow YAML; the `dart/`, `tests/`, and `python/` tree objects exactly
  match the base, and a targeted rerun reproduced the same counts.
- `DART_DISABLE_COMPILER_CACHE=ON pixi run -e cuda test-all`: lint,
  Release/Debug CUDA builds, and all 213 core tests passed, then reproduced the
  same two unchanged simulation allocation failures.
- `DART_DISABLE_COMPILER_CACHE=ON pixi run -e cuda test-cuda`: all 8 CUDA
  runtime tests and every configured benchmark smoke filter passed on an
  NVIDIA RTX 5000 Ada Generation Laptop GPU.
- Confirmed failed run 29700374222 rejected the retained local remote-tracking
  ref before worktree creation.
- Confirmed same-SHA scheduled run 29724972934 fetched `gh-pages` as a new local
  ref and published successfully.
- The exact `main`-only publish path will be verified by the fresh post-merge
  Community Signals run; rerunning the old failed attempt would use its
  original workflow definition.

## Breaking Changes

- [x] None
- No public API, dashboard contract, or runner configuration changes.

## Related Issues / PRs (backports)

- Follow-up to #3243 and #3254.
- No DART 6 backport: this dashboard workflow exists only on `main`.

---

#### Checklist

- [x] Milestone set (`DART 7.0` for `main`).
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required — N/A:
      narrow reliability correction to an already documented dashboard
      publisher; no dashboard content, cadence, public contract, or contributor
      workflow changes.
- [x] Add unit tests for new functionality — N/A: workflow ref-fetch semantics;
      covered by YAML checks and live failure/success evidence.
- [x] Document new methods and classes — N/A.
- [x] Add Python bindings (dartpy) if applicable — N/A.
