### PR TITLE
fix: load SDF `<soft_shape>` links as SoftBodyNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,13 @@
 
 * Dynamics
 
+  * Fix `dart::utils::SdfParser` loading every SDF `<soft_shape>` link as a
+    rigid `BodyNode`: the parser forwarded only the joint type to
+    `createJointAndBodyNodePair`, so the body-node type defaulted to `BodyNode`
+    and `SoftBodyNode::Properties` was sliced away. Soft SDF links now load as
+    `SoftBodyNode`s; rigid links are unchanged and there is no API/ABI change:
+    [#3399](https://github.com/dartsim/dart/pull/3399)
+
   * Fix `BoxedLcpConstraintSolver` propagating non-finite constraint impulses:
     a near-singular contact (e.g. a thin, hard, frictionless geometry) could
     make the primary solver report success while emitting an *infinite* impulse

--- a/dart/utils/sdf/SdfParser.cpp
+++ b/dart/utils/sdf/SdfParser.cpp
@@ -723,41 +723,52 @@ std::pair<dynamics::Joint*, dynamics::BodyNode*> createJointAndNodePair(
 {
   const std::string& type = joint.type;
 
+  // NodeType is forwarded as the BodyNode type so that a <soft_shape> link
+  // (NodeType == SoftBodyNode) actually creates a SoftBodyNode. Without the
+  // second template argument this defaults to a rigid dynamics::BodyNode and
+  // silently slices SoftBodyNode::Properties down to BodyNode::Properties,
+  // making every soft SDF body load as rigid.
   if (std::string("prismatic") == type)
-    return skeleton->createJointAndBodyNodePair<dynamics::PrismaticJoint>(
-        parent,
-        static_cast<const dynamics::PrismaticJoint::Properties&>(
-            *joint.properties),
-        static_cast<const typename NodeType::Properties&>(*node.properties));
+    return skeleton
+        ->createJointAndBodyNodePair<dynamics::PrismaticJoint, NodeType>(
+            parent,
+            static_cast<const dynamics::PrismaticJoint::Properties&>(
+                *joint.properties),
+            static_cast<const typename NodeType::Properties&>(
+                *node.properties));
   else if (std::string("revolute") == type)
-    return skeleton->createJointAndBodyNodePair<dynamics::RevoluteJoint>(
-        parent,
-        static_cast<const dynamics::RevoluteJoint::Properties&>(
-            *joint.properties),
-        static_cast<const typename NodeType::Properties&>(*node.properties));
+    return skeleton
+        ->createJointAndBodyNodePair<dynamics::RevoluteJoint, NodeType>(
+            parent,
+            static_cast<const dynamics::RevoluteJoint::Properties&>(
+                *joint.properties),
+            static_cast<const typename NodeType::Properties&>(
+                *node.properties));
   else if (std::string("screw") == type)
-    return skeleton->createJointAndBodyNodePair<dynamics::ScrewJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::ScrewJoint, NodeType>(
         parent,
         static_cast<const dynamics::ScrewJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));
   else if (std::string("revolute2") == type || std::string("universal") == type)
-    return skeleton->createJointAndBodyNodePair<dynamics::UniversalJoint>(
-        parent,
-        static_cast<const dynamics::UniversalJoint::Properties&>(
-            *joint.properties),
-        static_cast<const typename NodeType::Properties&>(*node.properties));
+    return skeleton
+        ->createJointAndBodyNodePair<dynamics::UniversalJoint, NodeType>(
+            parent,
+            static_cast<const dynamics::UniversalJoint::Properties&>(
+                *joint.properties),
+            static_cast<const typename NodeType::Properties&>(
+                *node.properties));
   else if (std::string("ball") == type)
-    return skeleton->createJointAndBodyNodePair<dynamics::BallJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::BallJoint, NodeType>(
         parent,
         static_cast<const dynamics::BallJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));
   else if (std::string("fixed") == type)
-    return skeleton->createJointAndBodyNodePair<dynamics::WeldJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::WeldJoint, NodeType>(
         parent,
         static_cast<const dynamics::WeldJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));
   else if (std::string("free") == type)
-    return skeleton->createJointAndBodyNodePair<dynamics::FreeJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::FreeJoint, NodeType>(
         parent,
         static_cast<const dynamics::FreeJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));

--- a/tests/integration/test_SdfParser.cpp
+++ b/tests/integration/test_SdfParser.cpp
@@ -165,6 +165,30 @@ TEST(SdfParser, ParsingSDFFiles)
 }
 
 //==============================================================================
+// Regression: an SDF <soft_shape> link must load as a SoftBodyNode. Before
+// SdfParser forwarded the NodeType template argument to
+// createJointAndBodyNodePair, every soft SDF body loaded as a rigid BodyNode
+// (SoftBodyNode::Properties sliced away), so the soft-feet Atlas reported zero
+// soft bodies.
+TEST(SdfParser, SoftShapeLinkLoadsAsSoftBodyNode)
+{
+  auto softAtlas = SdfParser::readSkeleton(
+      "dart://sample/sdf/atlas/atlas_v3_no_head_soft_feet.sdf");
+  ASSERT_NE(nullptr, softAtlas);
+  EXPECT_EQ(2u, softAtlas->getNumSoftBodyNodes());
+  EXPECT_NE(nullptr, softAtlas->getSoftBodyNode("l_foot"));
+  EXPECT_NE(nullptr, softAtlas->getSoftBodyNode("r_foot"));
+  ASSERT_NE(nullptr, softAtlas->getBodyNode("l_foot"));
+  EXPECT_NE(nullptr, softAtlas->getBodyNode("l_foot")->asSoftBodyNode());
+
+  // Control: the rigid variant of the same model stays fully rigid.
+  auto rigidAtlas = SdfParser::readSkeleton(
+      "dart://sample/sdf/atlas/atlas_v3_no_head.sdf");
+  ASSERT_NE(nullptr, rigidAtlas);
+  EXPECT_EQ(0u, rigidAtlas->getNumSoftBodyNodes());
+}
+
+//==============================================================================
 TEST(SdfParser, PlaneShapeOption)
 {
   const std::string sdfFilename = "dart://sample/sdf/test/plane_shape.sdf";

--- a/tests/integration/test_SdfParser.cpp
+++ b/tests/integration/test_SdfParser.cpp
@@ -182,8 +182,8 @@ TEST(SdfParser, SoftShapeLinkLoadsAsSoftBodyNode)
   EXPECT_NE(nullptr, softAtlas->getBodyNode("l_foot")->asSoftBodyNode());
 
   // Control: the rigid variant of the same model stays fully rigid.
-  auto rigidAtlas = SdfParser::readSkeleton(
-      "dart://sample/sdf/atlas/atlas_v3_no_head.sdf");
+  auto rigidAtlas
+      = SdfParser::readSkeleton("dart://sample/sdf/atlas/atlas_v3_no_head.sdf");
   ASSERT_NE(nullptr, rigidAtlas);
   EXPECT_EQ(0u, rigidAtlas->getNumSoftBodyNodes());
 }


### PR DESCRIPTION
## Summary

`dart::utils::SdfParser` never created `SoftBodyNode`s: its internal
`createJointAndNodePair<NodeType>` template called
`skeleton->createJointAndBodyNodePair<JointType>(...)` with only the *joint*
template argument, so the body-node type defaulted to rigid
`dynamics::BodyNode` and the `SoftBodyNode::Properties` argument was sliced to
`BodyNode::Properties`. **Every SDF `<soft_shape>` link has therefore loaded
as a rigid body.**

## Fix

Forward `NodeType` as the second template argument at all seven joint sites
(`createJointAndBodyNodePair<JointType, NodeType>`). A `<soft_shape>` link
(NodeType == `SoftBodyNode`) now creates a real `SoftBodyNode`; rigid links are
unchanged because `NodeType == BodyNode` reproduces the prior default. This is an
internal `.cpp` template change only — no public header, signature, or ABI
change.

## Test

Adds `SdfParser.SoftShapeLinkLoadsAsSoftBodyNode`: the soft-feet Atlas asset now
reports two `SoftBodyNode`s (`l_foot`/`r_foot`), while its rigid variant reports
zero. The regression fails before the fix (0 soft bodies) and passes after.

## Impact

The only in-tree SDF asset with `<soft_shape>` is
`atlas_v3_no_head_soft_feet.sdf`; `.skel` soft bodies use `SkelParser` and are
unaffected. Local `test_SdfParser` passes 7/7 and `test_ConstraintSolver`
passes 55/55 with the fix.

## Related

The same defect exists on `main`; a matching dual-PR follows per the dual-PR
policy.

## Breaking Changes

- [x] None (behavior correction for a previously-broken path; no API/ABI change).