### PR TITLE
fix: load SDF `<soft_shape>` links as SoftBodyNode

### DIFF
--- a/dart/io/sdf/sdf_parser.cpp
+++ b/dart/io/sdf/sdf_parser.cpp
@@ -994,23 +994,27 @@ std::pair<dynamics::Joint*, dynamics::BodyNode*> createJointAndNodePair(
 
   if (joint.sdfType == sdf::JointType::PRISMATIC
       || std::string("prismatic") == type) {
-    return skeleton->createJointAndBodyNodePair<dynamics::PrismaticJoint>(
-        parent,
-        static_cast<const dynamics::PrismaticJoint::Properties&>(
-            *joint.properties),
-        static_cast<const typename NodeType::Properties&>(*node.properties));
+    return skeleton
+        ->createJointAndBodyNodePair<dynamics::PrismaticJoint, NodeType>(
+            parent,
+            static_cast<const dynamics::PrismaticJoint::Properties&>(
+                *joint.properties),
+            static_cast<const typename NodeType::Properties&>(
+                *node.properties));
   } else if (
       joint.sdfType == sdf::JointType::REVOLUTE
       || joint.sdfType == sdf::JointType::CONTINUOUS
       || std::string("revolute") == type) {
-    return skeleton->createJointAndBodyNodePair<dynamics::RevoluteJoint>(
-        parent,
-        static_cast<const dynamics::RevoluteJoint::Properties&>(
-            *joint.properties),
-        static_cast<const typename NodeType::Properties&>(*node.properties));
+    return skeleton
+        ->createJointAndBodyNodePair<dynamics::RevoluteJoint, NodeType>(
+            parent,
+            static_cast<const dynamics::RevoluteJoint::Properties&>(
+                *joint.properties),
+            static_cast<const typename NodeType::Properties&>(
+                *node.properties));
   } else if (
       joint.sdfType == sdf::JointType::SCREW || std::string("screw") == type) {
-    return skeleton->createJointAndBodyNodePair<dynamics::ScrewJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::ScrewJoint, NodeType>(
         parent,
         static_cast<const dynamics::ScrewJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));
@@ -1018,25 +1022,27 @@ std::pair<dynamics::Joint*, dynamics::BodyNode*> createJointAndNodePair(
       joint.sdfType == sdf::JointType::REVOLUTE2
       || joint.sdfType == sdf::JointType::UNIVERSAL
       || std::string("revolute2") == type || std::string("universal") == type) {
-    return skeleton->createJointAndBodyNodePair<dynamics::UniversalJoint>(
-        parent,
-        static_cast<const dynamics::UniversalJoint::Properties&>(
-            *joint.properties),
-        static_cast<const typename NodeType::Properties&>(*node.properties));
+    return skeleton
+        ->createJointAndBodyNodePair<dynamics::UniversalJoint, NodeType>(
+            parent,
+            static_cast<const dynamics::UniversalJoint::Properties&>(
+                *joint.properties),
+            static_cast<const typename NodeType::Properties&>(
+                *node.properties));
   } else if (
       joint.sdfType == sdf::JointType::BALL || std::string("ball") == type) {
-    return skeleton->createJointAndBodyNodePair<dynamics::BallJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::BallJoint, NodeType>(
         parent,
         static_cast<const dynamics::BallJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));
   } else if (
       joint.sdfType == sdf::JointType::FIXED || std::string("fixed") == type) {
-    return skeleton->createJointAndBodyNodePair<dynamics::WeldJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::WeldJoint, NodeType>(
         parent,
         static_cast<const dynamics::WeldJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));
   } else if (std::string("free") == type) {
-    return skeleton->createJointAndBodyNodePair<dynamics::FreeJoint>(
+    return skeleton->createJointAndBodyNodePair<dynamics::FreeJoint, NodeType>(
         parent,
         static_cast<const dynamics::FreeJoint::Properties&>(*joint.properties),
         static_cast<const typename NodeType::Properties&>(*node.properties));

--- a/tests/integration/io/test_sdf_parser.cpp
+++ b/tests/integration/io/test_sdf_parser.cpp
@@ -251,6 +251,46 @@ SkeletonPtr readSkeletonFromSdfString(
 } // namespace
 
 //==============================================================================
+// Regression: an SDF <soft_shape> link must load as a SoftBodyNode. The parser
+// forwarded only the joint type to createJointAndBodyNodePair, so the body-node
+// type defaulted to a rigid BodyNode and SoftBodyNode::Properties was sliced
+// away, making every soft SDF body load rigid.
+TEST(SdfParser, SoftShapeLinkLoadsAsSoftBodyNode)
+{
+  auto retriever = std::make_shared<MemoryResourceRetriever>();
+  const std::string uri = "memory://pkg/soft_shape/model.sdf";
+  const std::string softSdf = R"(
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <model name="soft_box">
+    <link name="soft_link">
+      <soft_shape>
+        <total_mass>0.5</total_mass>
+        <geometry>
+          <box>
+            <size>0.2 0.2 0.2</size>
+            <frags>3 3 3</frags>
+          </box>
+        </geometry>
+        <kv>1000.0</kv>
+        <ke>10.0</ke>
+        <damp>10.0</damp>
+      </soft_shape>
+    </link>
+  </model>
+</sdf>
+ )";
+
+  auto skeleton = readSkeletonFromSdfString(uri, softSdf, retriever);
+  ASSERT_NE(skeleton, nullptr);
+  ASSERT_EQ(skeleton->getNumBodyNodes(), 1u);
+  EXPECT_EQ(skeleton->getNumSoftBodyNodes(), 1u);
+  auto* body = skeleton->getBodyNode("soft_link");
+  ASSERT_NE(body, nullptr);
+  EXPECT_NE(body->asSoftBodyNode(), nullptr);
+}
+
+//==============================================================================
 TEST(SdfParser, SelectsNamedWorldModel)
 {
   auto retriever = std::make_shared<MemoryResourceRetriever>();


### PR DESCRIPTION
## Summary

Dual-PR to `main` of the DART 6 fix in
[#3399](https://github.com/dartsim/dart/pull/3399). `dart::io::SdfParser`'s
`createJointAndNodePair<NodeType>` template called
`skeleton->createJointAndBodyNodePair<JointType>(...)` with only the *joint*
template argument, so the body-node type defaulted to rigid
`dynamics::BodyNode` and the `SoftBodyNode::Properties` argument was sliced to
`BodyNode::Properties`. **Every SDF `<soft_shape>` link therefore loaded as a
rigid body** on `main` as well.

## Fix

Forward `NodeType` as the second template argument at all seven joint sites in
`dart/io/sdf/sdf_parser.cpp`. A soft link (NodeType == `SoftBodyNode`) now
creates a real `SoftBodyNode`; rigid links are unchanged. Internal `.cpp`
template change only — no public header, signature, or ABI change.

## Test

Adds `SdfParser.SoftShapeLinkLoadsAsSoftBodyNode` to
`tests/integration/io/test_sdf_parser.cpp`, a self-contained regression that
loads a minimal inline `<soft_shape>` box via the memory-retriever SDF-string
helper and asserts the link is a `SoftBodyNode` (`getNumSoftBodyNodes() == 1`,
`asSoftBodyNode() != nullptr`).

## Validation

The identical fix and an equivalent regression are locally validated on the
DART 6 twin #3399 (`test_SdfParser` 7/7, `test_ConstraintSolver` 55/55). This
`main` branch was **not rebuilt locally** (DART 7 base); **draft pending CI**
validation of the build and the new test. No CHANGELOG entry: DART 7's changelog
is a curated release-highlights document and this is an unreleased-code bugfix.

## Breaking Changes

- [x] None.