### PR TITLE
Re-arm the black formatting gate in pixi lint tasks (release-6.20)

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -78,7 +78,7 @@ lint-cpp = { cmd = """
 """, depends-on = ["config"], env = { BUILD_TYPE = "Release" } }
 
 lint-py = { cmd = """
-    black . --exclude '\\..*' \
+    black . --extend-exclude '/\\.[^/]+' \
     && isort . --skip-glob '.*'
 """, depends-on = ["config"] }
 
@@ -138,7 +138,7 @@ check-lint-cpp = { cmd = """
 """, depends-on = ["config"], env = { BUILD_TYPE = "Release" } }
 
 check-lint-py = { cmd = """
-    black . --check --exclude '\\..*' \
+    black . --check --extend-exclude '/\\.[^/]+' \
     && isort . --check --skip-glob '.*'
 """, depends-on = ["config"] }
 
@@ -801,7 +801,7 @@ config = { cmd = """
 """, env = { DART_VERBOSE = "OFF" } }
 
 lint-py = { cmd = """
-    black . --exclude '\\..*' && isort . --skip-glob '.*'
+    black . --extend-exclude '/\\.[^/]+' && isort . --skip-glob '.*'
 """, depends-on = ["config"] }
 
 lint-spell = { cmd = "codespell --write-changes --config .codespellrc" }
@@ -809,7 +809,7 @@ lint-spell = { cmd = "codespell --write-changes --config .codespellrc" }
 lint = { depends-on = ["lint-spell", "lint-py"] }
 
 check-lint-py = { cmd = """
-    black . --check --exclude '\\..*' && isort . --check --skip-glob '.*'
+    black . --check --extend-exclude '/\\.[^/]+' && isort . --check --skip-glob '.*'
 """, depends-on = ["config"] }
 
 check-lint-spell = { cmd = "codespell --config .codespellrc" }

--- a/scripts/compare_soft_body_performance.py
+++ b/scripts/compare_soft_body_performance.py
@@ -909,8 +909,7 @@ def write_detector_winner_graph(
             units = min(bar_width, max(1, units))
             marker = "*" if detector == item["winner"] else " "
             parts.append(
-                f"{marker}{detector}:{'#' * units:<{bar_width}} "
-                f"{cpu_ms:.3f}ms"
+                f"{marker}{detector}:{'#' * units:<{bar_width}} " f"{cpu_ms:.3f}ms"
             )
 
         lines.append(


### PR DESCRIPTION
## Summary

- Re-arms the black formatting gate in the `pixi` lint tasks, which has been excluding every Python file in the repository, and applies the one formatting fix it reports.

## Motivation / Problem

`Publish dartpy` → `Check format` is failing on `6c88ac1d774` because
`scripts/compare_soft_body_performance.py` is not black-formatted.

The more important problem is why nothing caught it earlier. `lint-py` and
`check-lint-py` passed `--exclude '\..*'` to black. Black matches `--exclude`
with `re.search` against the candidate path, so `\..*` matched the literal dot
in every `.py` suffix and excluded the whole repository:

```console
$ black --check . --exclude '\..*'      # what check-lint-py ran
No Python files are present to be formatted. Nothing to do 😴

$ black --check .                       # what publish_dartpy runs
1 file would be reformatted, 43 files would be left unchanged.
```

So the black half of the required CI Linux **"Check Lint"** context — and of the
`pixi run lint` that `AGENTS.md` asks every contributor to run before
committing — has been a silent no-op. That is why "Check Lint" passed while
`Publish dartpy` failed on the same commit. The flag was also redundant:
`--exclude` *overrode* the `[tool.black]` excludes already declared in
`pyproject.toml`.

This is not a one-off. The last four `Publish dartpy` failures on this branch
are all the identical `Check format` step — `6c88ac1d774`, #3388, #3385, and
#3374 — and #3390 was a whole PR spent cleaning up drift the dead gate let
through.

## Changes / Key Changes

- `pixi.toml`: `--exclude '\..*'` → `--extend-exclude '/\.[^/]+'` in `lint-py`
  and `check-lint-py`, in both `[tasks]` and `[target.win-64.tasks]`. This is
  exactly what `main` already carries: additive, so the `pyproject.toml`
  excludes stay in effect, and anchored on `/` so it only matches dot-entries at
  a path boundary. The original "exclude hidden folders" intent from
  `d8396ee0d64` is preserved — the gate now scans 44 files instead of 0.
- `scripts/compare_soft_body_performance.py`: the single formatting fix the
  re-armed gate reports (one implicit-concat f-string pair joined).

## Testing

- `pixi run check-lint` — full aggregate, exit 0, with `check-lint-py` now
  reporting `44 files would be left unchanged` instead of `No Python files are
  present to be formatted`.
- `pixi run black --check --diff .` — the exact failing step, now passes.
- `pixi run isort --check --diff .` — the `Check import` step that was skipped
  behind the format failure and therefore never validated on this commit; also
  passes, so it will not be the next failure.

No C++ or Python library behavior is touched, so no build/test gates are
implicated. `scripts/compare_soft_body_performance.py` is a developer benchmark
script and the change is formatting-only.

## Breaking Changes

- [x] None

The re-armed gate does make the required CI Linux "Check Lint" context genuinely
stricter than it has been. The full aggregate passes on this branch, so the tree
is already clean under it.

## Related Issues / PRs (backports)

- No companion `main` PR needed: `main` already carries
  `--extend-exclude '/\.[^/]+'` (4 occurrences, 0 broken). This is a
  release-branch-only catch-up.
- Prior failures with this root cause: #3388, #3385, #3374; cleanup PR #3390.

---

#### Checklist

- [x] Milestone set (DART 6.20.0)
- [x] CHANGELOG.md updated if required — not required; internal lint tooling with
      no user-visible change, matching the #3390 precedent and
      `docs/onboarding/changelog.md`
- [ ] Add unit tests for new functionality — n/a, no new functionality
- [ ] Document new methods and classes — n/a
- [ ] Add Python bindings (dartpy) if applicable — n/a
