### PR TITLE
Black-format scripts/agent_capture.py to unbreak the lint gate

### DIFF
--- a/scripts/agent_capture.py
+++ b/scripts/agent_capture.py
@@ -181,9 +181,7 @@ def _make_dart_shape_contacts(dart: Any) -> Any:
     )
     for name, shape, position, color in shape_specs:
         world.addSkeleton(
-            _shape_skeleton(
-                dart, name, shape, position, static=False, color=color
-            )
+            _shape_skeleton(dart, name, shape, position, static=False, color=color)
         )
     return world
 
@@ -583,9 +581,7 @@ def run_capture(args: argparse.Namespace) -> dict[str, Any]:
                 if tracker is not None:
                     tracker.sample()
             last_collision_result = (
-                world.getLastCollisionResult()
-                if "contacts" in args.layers
-                else None
+                world.getLastCollisionResult() if "contacts" in args.layers else None
             )
             contacts = (
                 list(last_collision_result.getContacts())


### PR DESCRIPTION
## Summary

`release-6.20` is currently failing its own **Check Lint** step, and so is every
pull request based on it, including #3404.

`black --check` wants to reformat `scripts/agent_capture.py`:

```
would reformat /…/scripts/agent_capture.py
1 file would be reformatted, 43 files would be left unchanged.
```

## Cause

#3405 re-armed the black formatting gate in the pixi lint tasks, and #3381 then
landed changes to `scripts/agent_capture.py` that predate that gate. Each was
fine on its own; the combination leaves the file unformatted while the gate is
now enforced.

## Change

Runs `black` on the one offending file. Whitespace only — two call sites that
fit within the line limit are joined:

- `_make_dart_shape_contacts`: the `_shape_skeleton(...)` argument list
- `run_capture`: the `last_collision_result` conditional expression

No behavior change, no logic touched, 2 insertions and 6 deletions.

## Verification

```bash
pixi run check-lint-py   # black --check + isort --check
```

passes after the change, and the full C++ format gate (`check-format`, 1174
files) was already clean.

## Breaking Changes

- [x] None