### PR TITLE
Add Claude Code model-routing lane and harden the model-upgrade audit path

### DIFF
--- a/.agents/skills/dart-model-upgrade/SKILL.md
+++ b/.agents/skills/dart-model-upgrade/SKILL.md
@@ -133,16 +133,20 @@ well it investigates simulation state with text-first and visual/debug evidence.
    where possible, record the exact limitation, and do not turn structural tool
    availability into a model-quality claim.
 
-6. **Route model and reasoning by task shape.** For the GPT-5.6 family, use Sol
-   for the hardest ambiguous work, Terra for everyday or read-heavy work, and
-   Luna for clear repeatable work. Max gives one difficult task more reasoning
-   time. Ultra is for independently parallelizable work when the user
-   authorized delegation. Most tasks need neither. An explicitly requested Sol
-   Max evaluation must exercise that lane, not turn it into a global default.
-   For another target family, derive routing from its refreshed guidance rather
-   than carrying these names forward. Update or replace this bounded
-   target-specific example when it becomes stale; do not clone the workflow or
-   append an ever-growing section for every model family.
+6. **Route model and reasoning by task shape.** Derive routing for the target
+   family from its refreshed official guidance, then record the result in the
+   model-routing owner, `docs/ai/README.md` § "Model Routing", which keeps one
+   bounded entry per validated tool lane. Match capability tiers to task
+   shape: the top tier for the hardest ambiguous work, the middle tier for
+   everyday or read-heavy work, and the light tier for clear repeatable work.
+   Do not carry one family's tier or reasoning-mode names into another
+   family's guidance.
+   Deeper reasoning modes give one difficult task more time; parallel lanes
+   need explicit user authorization for delegation; most tasks need neither.
+   An explicitly requested top-tier evaluation must exercise that lane, not
+   turn it into a global default. Replace a stale per-family entry in the
+   owner doc; do not clone the workflow or append a section per model family
+   here.
 7. **Implement only in `apply` mode.** In `audit-only`, skip implementation and
    continue only with non-mutating verification and the evidence report. In
    `apply`, implement the smallest supported delta. Keep outcome, success

--- a/.agents/skills/dart-verify-sim/SKILL.md
+++ b/.agents/skills/dart-verify-sim/SKILL.md
@@ -43,7 +43,9 @@ report or `image-verdict` is not visual review.
 
 ## Image-capable review loop
 
-GPT-5.6 Sol Max supports native image input and original-detail inspection.
+Current image-capable targets (GPT-5.6 Sol Max in Codex; Claude Fable 5 and
+Opus 5 in Claude Code) support native image input and original-detail
+inspection.
 Keep this loop capability-based so a future model-upgrade audit can replace the
 target-specific note without cloning the skill.
 

--- a/.claude/commands/dart-model-upgrade.md
+++ b/.claude/commands/dart-model-upgrade.md
@@ -112,16 +112,20 @@ well it investigates simulation state with text-first and visual/debug evidence.
    where possible, record the exact limitation, and do not turn structural tool
    availability into a model-quality claim.
 
-6. **Route model and reasoning by task shape.** For the GPT-5.6 family, use Sol
-   for the hardest ambiguous work, Terra for everyday or read-heavy work, and
-   Luna for clear repeatable work. Max gives one difficult task more reasoning
-   time. Ultra is for independently parallelizable work when the user
-   authorized delegation. Most tasks need neither. An explicitly requested Sol
-   Max evaluation must exercise that lane, not turn it into a global default.
-   For another target family, derive routing from its refreshed guidance rather
-   than carrying these names forward. Update or replace this bounded
-   target-specific example when it becomes stale; do not clone the workflow or
-   append an ever-growing section for every model family.
+6. **Route model and reasoning by task shape.** Derive routing for the target
+   family from its refreshed official guidance, then record the result in the
+   model-routing owner, `docs/ai/README.md` § "Model Routing", which keeps one
+   bounded entry per validated tool lane. Match capability tiers to task
+   shape: the top tier for the hardest ambiguous work, the middle tier for
+   everyday or read-heavy work, and the light tier for clear repeatable work.
+   Do not carry one family's tier or reasoning-mode names into another
+   family's guidance.
+   Deeper reasoning modes give one difficult task more time; parallel lanes
+   need explicit user authorization for delegation; most tasks need neither.
+   An explicitly requested top-tier evaluation must exercise that lane, not
+   turn it into a global default. Replace a stale per-family entry in the
+   owner doc; do not clone the workflow or append a section per model family
+   here.
 7. **Implement only in `apply` mode.** In `audit-only`, skip implementation and
    continue only with non-mutating verification and the evidence report. In
    `apply`, implement the smallest supported delta. Keep outcome, success

--- a/.claude/skills/dart-verify-sim/SKILL.md
+++ b/.claude/skills/dart-verify-sim/SKILL.md
@@ -38,7 +38,9 @@ report or `image-verdict` is not visual review.
 
 ## Image-capable review loop
 
-GPT-5.6 Sol Max supports native image input and original-detail inspection.
+Current image-capable targets (GPT-5.6 Sol Max in Codex; Claude Fable 5 and
+Opus 5 in Claude Code) support native image input and original-detail
+inspection.
 Keep this loop capability-based so a future model-upgrade audit can replace the
 target-specific note without cloning the skill.
 

--- a/.opencode/command/dart-model-upgrade.md
+++ b/.opencode/command/dart-model-upgrade.md
@@ -117,16 +117,20 @@ well it investigates simulation state with text-first and visual/debug evidence.
    where possible, record the exact limitation, and do not turn structural tool
    availability into a model-quality claim.
 
-6. **Route model and reasoning by task shape.** For the GPT-5.6 family, use Sol
-   for the hardest ambiguous work, Terra for everyday or read-heavy work, and
-   Luna for clear repeatable work. Max gives one difficult task more reasoning
-   time. Ultra is for independently parallelizable work when the user
-   authorized delegation. Most tasks need neither. An explicitly requested Sol
-   Max evaluation must exercise that lane, not turn it into a global default.
-   For another target family, derive routing from its refreshed guidance rather
-   than carrying these names forward. Update or replace this bounded
-   target-specific example when it becomes stale; do not clone the workflow or
-   append an ever-growing section for every model family.
+6. **Route model and reasoning by task shape.** Derive routing for the target
+   family from its refreshed official guidance, then record the result in the
+   model-routing owner, `docs/ai/README.md` § "Model Routing", which keeps one
+   bounded entry per validated tool lane. Match capability tiers to task
+   shape: the top tier for the hardest ambiguous work, the middle tier for
+   everyday or read-heavy work, and the light tier for clear repeatable work.
+   Do not carry one family's tier or reasoning-mode names into another
+   family's guidance.
+   Deeper reasoning modes give one difficult task more time; parallel lanes
+   need explicit user authorization for delegation; most tasks need neither.
+   An explicitly requested top-tier evaluation must exercise that lane, not
+   turn it into a global default. Replace a stale per-family entry in the
+   owner doc; do not clone the workflow or append a section per model family
+   here.
 7. **Implement only in `apply` mode.** In `audit-only`, skip implementation and
    continue only with non-mutating verification and the evidence report. In
    `apply`, implement the smallest supported delta. Keep outcome, success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,8 +430,10 @@ compatibility remains on the active DART 6 LTS branch._
   routes through that single owner instead of duplicating per-family tiers,
   and the simulation image-review guidance names image-capable targets
   capability-neutrally across both lanes.
+  ([#3416](https://github.com/dartsim/dart/pull/3416))
 - Fixed the trajectory recorder so its `--factory module:callable` path works
   instead of tripping its own scene/factory exclusivity guard.
+  ([#3416](https://github.com/dartsim/dart/pull/3416))
 - Made canonical Python, C++, AI-infrastructure, and visual-verification test
   gates fail closed against ambient pytest/GoogleTest selectors, plugin
   injection, collection-only success, and empty test inventories, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -424,6 +424,14 @@ compatibility remains on the active DART 6 LTS branch._
   contacts instead of deep interpenetration.
   ([#3403](https://github.com/dartsim/dart/pull/3403),
   [#3411](https://github.com/dartsim/dart/pull/3411))
+- Extended the task-shaped AI model-routing guidance to the Claude Code lane
+  (Claude Fable 5 and Opus 5): `docs/ai/README.md` now keeps one bounded
+  routing entry per validated tool lane, the reusable model-upgrade workflow
+  routes through that single owner instead of duplicating per-family tiers,
+  and the simulation image-review guidance names image-capable targets
+  capability-neutrally across both lanes.
+- Fixed the trajectory recorder so its `--factory module:callable` path works
+  instead of tripping its own scene/factory exclusivity guard.
 - Made canonical Python, C++, AI-infrastructure, and visual-verification test
   gates fail closed against ambient pytest/GoogleTest selectors, plugin
   injection, collection-only success, and empty test inventories, with

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -166,12 +166,29 @@ DART uses the two-role operating model in `docs/ai/orchestration.md`: an
 orchestrator session owns understanding, decomposition, sequencing, and review,
 while executor sessions implement one well-defined work packet at a time.
 
-No project model or reasoning effort is pinned. For the current GPT-5.6 family,
-use Sol for difficult ambiguous work, Terra for everyday or read-heavy work,
-and Luna for clear repeatable work. Max gives one hard task more reasoning
-time; Ultra is for independently parallelizable work when the user explicitly
-authorized delegation. Most tasks need neither. The read-only project profiles
-in `.codex/agents/` inherit the selected parent model.
+No project model or reasoning effort is pinned. Routing is per tool lane, one
+bounded entry per validated lane:
+
+- **Codex — GPT-5.6 family.** Use Sol for difficult ambiguous work, Terra for
+  everyday or read-heavy work, and Luna for clear repeatable work. Max gives
+  one hard task more reasoning time; Ultra is for independently parallelizable
+  work when the user explicitly authorized delegation. Most tasks need
+  neither.
+- **Claude Code — current Claude models.** Use Fable 5 (`claude-fable-5`,
+  the Mythos-class tier above Opus) for the hardest ambiguous or
+  long-horizon work; Opus 5 (`claude-opus-5`) as the everyday strong default
+  for substantial engineering work such as architecture, deep analysis, and
+  agentic coding (Claude Code fast mode also runs on Opus); Sonnet 5 for
+  standard bounded work; and Haiku 4.5 for quick lookups. Reasoning effort
+  is a session-level setting; reserve `max` effort for one hard task rather
+  than making it a default. Fable 5 and Opus 5 ship safety classifiers that
+  can occasionally refuse dual-use content; treat such a refusal as expected
+  model behavior rather than a DART harness defect. If the refused task is
+  legitimate DART work, restate it with its physics/simulation context made
+  explicit, and surface it to a maintainer if it still refuses.
+
+The read-only project profiles in `.codex/agents/` inherit the selected parent
+model.
 
 Treat this routing as versioned guidance, not a permanent model taxonomy. Run
 `dart-model-upgrade` for future model or Codex changes, keep task contracts

--- a/docs/onboarding/agent-sim-verification.md
+++ b/docs/onboarding/agent-sim-verification.md
@@ -44,12 +44,14 @@ dynamic failures (explosions, tunneling); use text to decide correctness.
 
 - **Native semantic review** — after view assessment and capture, an
   image-capable agent must actually open the selected image and describe the
-  visible evidence tied to the claim. For GPT-5.6 Sol Max, use native image
-  input and original detail when contacts, labels, bounds, or frame axes are
-  small; start with one focused ~1280 px view and add another view or grid only
-  for motion, occlusion, or ambiguity. `image-verdict` checks pixels and
-  reference thresholds; its pass does not mean the scene was semantically
-  inspected. Record five fields: **claim and expected observation**, **text
+  visible evidence tied to the claim. For image-capable targets (currently
+  GPT-5.6 Sol Max in Codex; Claude Fable 5 and Opus 5 in Claude Code), use
+  native image input and original detail when contacts, labels, bounds, or
+  frame axes are small; start with one focused ~1280 px view and add another
+  view or grid only for motion, occlusion, or ambiguity. `image-verdict`
+  checks pixels and reference thresholds; its pass does not mean the scene
+  was semantically inspected. Record five fields: **claim and expected
+  observation**, **text
   oracle**, **visible observation**, **reconciliation and verdict**, and **not
   proven / limitations**. Text/image disagreement is fail/uncertain until the
   camera, artifact, or simulation state explains it. When native image input is

--- a/docs/onboarding/ai-tools.md
+++ b/docs/onboarding/ai-tools.md
@@ -2,12 +2,13 @@
 
 This document tracks AI coding assistant compatibility with DART's documentation structure.
 
-> **Last Verified**: 2026-07-29. Command/skill/adapter surfaces are
+> **Last Verified**: 2026-07-31. Command/skill/adapter surfaces are
 > continuously machine-verified by `pixi run check-ai-commands` in CI. Claude
-> Code and OpenCode terminology notes were checked against current public docs;
-> Codex notes were checked against the locally tested version recorded in
-> [OpenAI Codex](#openai-codex) plus current OpenAI Codex docs. Gemini notes
-> remain a manual-reference path.
+> Code notes were behaviorally verified on the tested version recorded in
+> [Claude Code](#claude-code); OpenCode terminology notes were checked against
+> current public docs; Codex notes were checked against the locally tested
+> version recorded in [OpenAI Codex](#openai-codex) plus current OpenAI Codex
+> docs. Gemini notes remain a manual-reference path.
 > **Review Cadence**: Verify when updating tool versions or experiencing unexpected behavior.
 
 ## For Collaborators: Tool Selection
@@ -366,8 +367,13 @@ directly. There is no separate prompt-template folder.
 
 ### Claude Code
 
-**Verified**: capability and adapter surfaces continuously via `pixi run
-check-ai-commands` in CI; behavior notes hand-checked 2026-07
+**Tested Versions**: Claude Code CLI 2.1.220 on Claude Fable 5
+(`claude-fable-5`), 2026-07-31 — `/dart-model-upgrade` exercised end to end:
+command and skill loading, the PreToolUse hook, and native image review of
+`agent-capture` output. Opus 5 routing and image guidance is sourced from
+current official docs; that lane was not separately exercised. Capability and
+adapter surfaces stay continuously machine-verified via
+`pixi run check-ai-commands` in CI.
 
 | Feature      | Location                    | Status                             |
 | ------------ | --------------------------- | ---------------------------------- |
@@ -385,6 +391,13 @@ check-ai-commands` in CI; behavior notes hand-checked 2026-07
   with `ulw:` or the common typo `ultrawok:`, normalize it to the canonical
   `/dart-ultrawork` workflow. These are prompt-level shorthands, not separate
   shared capabilities.
+- Model and reasoning routing for current Claude models lives in
+  `docs/ai/README.md` § "Model Routing"; do not duplicate or pin it here.
+
+Current references:
+[Claude Fable 5 and Mythos 5 announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5),
+[Introducing Claude Fable 5 (API surface)](https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5), and
+[Claude models overview](https://platform.claude.com/docs/en/about-claude/models/overview).
 
 ### OpenCode
 
@@ -878,9 +891,10 @@ when nothing is pending, any check fails, or the head SHA moves.
 
 ## Changelog
 
-| Date     | Change                                                                                       |
-| -------- | -------------------------------------------------------------------------------------------- |
-| Jan 2025 | Initial setup with Claude Code, OpenCode, Gemini CLI, Codex support                          |
-| Jan 2025 | Added collaborator guide and maintenance conventions                                         |
-| Jul 2026 | Refreshed verification metadata to CI-checked adapter sync; added independent review lane    |
-| Jul 2026 | Migrated Codex skills, added project agents/hooks, diagnosis, scenarios, and branch profiles |
+| Date     | Change                                                                                                                                   |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Jan 2025 | Initial setup with Claude Code, OpenCode, Gemini CLI, Codex support                                                                      |
+| Jan 2025 | Added collaborator guide and maintenance conventions                                                                                     |
+| Jul 2026 | Refreshed verification metadata to CI-checked adapter sync; added independent review lane                                                |
+| Jul 2026 | Migrated Codex skills, added project agents/hooks, diagnosis, scenarios, and branch profiles                                             |
+| Jul 2026 | Fable 5 audit: Claude 5 lane added to the model-routing owner, capability-based image-review wording, refreshed Claude Code verification |

--- a/python/tests/unit/test_trajectory_record_compare.py
+++ b/python/tests/unit/test_trajectory_record_compare.py
@@ -153,3 +153,32 @@ def test_combined_trajectory_and_contact_recording_shares_runner() -> None:
     assert trajectory_frames
     assert contact_frames
     assert contact_frames <= trajectory_frames
+
+
+def test_main_factory_alone_does_not_trip_scene_exclusivity_guard(
+    monkeypatch, tmp_path
+) -> None:
+    captured: dict[str, str | None] = {}
+
+    def fake_resolve(*, scene=None, factory=None):
+        captured["scene"] = scene
+        captured["factory"] = factory
+        return trajectory_record.WorldRunner(
+            scene_id="fake", world=object(), step_once=None
+        )
+
+    monkeypatch.setattr(trajectory_record, "resolve_world_runner", fake_resolve)
+    monkeypatch.setattr(
+        trajectory_record,
+        "record_trajectory",
+        lambda runner, steps, bodies: "# fake\n",
+    )
+
+    out = tmp_path / "traj.tsv"
+    exit_code = trajectory_record.main(
+        ["--factory", "some_module:make_world", "--steps", "1", "--out", str(out)]
+    )
+
+    assert exit_code == 0
+    assert captured == {"scene": None, "factory": "some_module:make_world"}
+    assert out.read_text() == "# fake\n"

--- a/scripts/trajectory_record.py
+++ b/scripts/trajectory_record.py
@@ -511,7 +511,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        runner = resolve_world_runner(scene=args.scene, factory=args.factory)
+        runner = resolve_world_runner(
+            scene=None if args.factory else args.scene, factory=args.factory
+        )
         if args.contacts:
             text = record_contact_events(runner, args.steps)
         else:

--- a/tests/test_ai_infrastructure.py
+++ b/tests/test_ai_infrastructure.py
@@ -1031,8 +1031,9 @@ def test_model_upgrade_workflow_keeps_comparison_and_trigger_boundaries():
         "existing model with existing prompt/settings",
         "target at the preserved effort and one lower effort",
         "structural checks into model-quality",
-        "Max gives one difficult task more reasoning",
-        "Ultra is for independently parallelizable work",
+        "Deeper reasoning modes give one difficult task more time",
+        "explicit user authorization for delegation",
+        '`docs/ai/README.md` § "Model Routing"',
         "Do not silently substitute a different model",
         "durable context and project-state layer",
         "`docs/plans/dashboard.md`",
@@ -1053,6 +1054,11 @@ def test_model_upgrade_workflow_keeps_comparison_and_trigger_boundaries():
         "text/image disagreement",
     ):
         assert marker in text
+
+    routing_owner = (ROOT / "docs" / "ai" / "README.md").read_text()
+    assert "## Model Routing" in routing_owner
+    assert "**Codex — " in routing_owner
+    assert "**Claude Code — " in routing_owner
 
     compliance = sync.parse_command_frontmatter(
         (ROOT / ".claude" / "commands" / "dart-audit-agent-compliance.md").read_text()


### PR DESCRIPTION
## Summary

- Adds a Claude Code lane (Claude Fable 5 and Opus 5) to DART's task-shaped AI
  model-routing guidance, consolidates routing into a single owner
  (`docs/ai/README.md` § "Model Routing"), makes the simulation image-review
  guidance capability-based across tool lanes, and fixes the trajectory
  recorder's `--factory module:callable` path that its own scene/factory guard
  made unreachable.

## Motivation / Problem

- `apply`-mode `/dart-model-upgrade` run for Claude Fable 5 and Opus 5 (Claude
  Code CLI 2.1.220, 2026-07-31). The routing guidance covered only the Codex
  GPT-5.6 family; the model-upgrade workflow duplicated those tiers, leaving
  one fast-changing fact with two owners; the image-review notes named a
  single model; and the audit's representative `dart-verify-sim` investigation
  surfaced a real CLI bug — `pixi run trajectory-record -- --factory
  module:callable` always tripped its own "pass either --scene or --factory"
  guard because the defaulted `--scene` was forwarded alongside the factory.

## Changes / Key Changes

- `docs/ai/README.md`: per-lane Model Routing (one bounded entry per validated
  tool lane: Codex GPT-5.6; Claude Code current Claude models), with refusal
  guidance that treats classifier refusals as expected model behavior —
  restate legitimate DART work with explicit physics/simulation context, and
  surface it to a maintainer if it still refuses.
- `.claude/commands/dart-model-upgrade.md`: step 6 routes through the single
  routing owner instead of duplicating per-family tiers, and keeps the
  model-agnostic boundaries (anti-carry-forward, no workflow cloning,
  delegation needs explicit authorization). Generated OpenCode/Codex adapters
  resynced.
- `.claude/skills/dart-verify-sim/SKILL.md` and
  `docs/onboarding/agent-sim-verification.md`: capability-based image-review
  wording naming the current image-capable targets in both lanes.
- `docs/onboarding/ai-tools.md`: refreshed verification metadata (Claude Code
  CLI 2.1.220 on `claude-fable-5`, 2026-07-31; the Opus 5 lane is doc-sourced
  and marked not separately exercised) plus current Claude reference links.
- `scripts/trajectory_record.py`: `--factory` no longer collides with the
  defaulted `--scene` (matches the `agent_capture.py` precedence idiom), with
  a regression test in `python/tests/unit/test_trajectory_record_compare.py`.
- `tests/test_ai_infrastructure.py`: two GPT-5.6-mode-specific markers
  replaced with model-agnostic invariants, and the routing owner section plus
  its lane entries are now gate-pinned.
- `CHANGELOG.md`: two entries under DART 7 → Build, Packaging, and Developer
  Tooling.

## Testing

- `pixi run lint`, `pixi run check-ai-infra`, `pixi run test-ai-infra`
  (526 passed), `pixi run exercise-agent-scenarios` (8/8 routing scenarios),
  `pixi run check-docs-policy` (pre-existing report-only advisories only),
  `pixi run check-lint-md`, `pixi run check-lint-spell`, plus the focused
  regression test through the guarded pytest runner (1 passed).
- Representative `dart-verify-sim` investigation: `box_on_ground` settle claim
  and a seeded interpenetration defect. Text oracles (trajectory TSV, contact
  JSONL): steady contact depth ≈ 3e-5 m nominal vs 0.026 m onset depth for the
  defect. Corroborated end to end with assessed `agent-capture` stills using
  claim-tied debug layers, `image-verdict` integrity passes, native semantic
  image review, a harness-rejected poor view repaired via `--auto-views`, and
  a `verification-bundle` fallback package. Rendering/model output behavior is
  unchanged by this PR, so no before/after visual evidence is required.
- Review evidence: two independent role-separated review passes, both clean on
  the final state after a find–fix–verify cycle. Principle audit recorded:
  routing tiers now have exactly one owner, scope is surgical, the CLI failure
  was root-caused and fixed with regression coverage, and all workflows keep
  tracked-docs/`pixi run` public paths.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up after merge: branch-local `release-6.20` adapt/omit pass (its
  routing owner differs — no § "Model Routing" — and
  `docs/onboarding/agent-sim-verification.md` does not exist there).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality
- [ ] Document new methods and classes (n/a — no new methods or classes)
- [ ] Add Python bindings (dartpy) if applicable (n/a)
