### PR TITLE
Keep the degenerate boxed-LCP fallback off the global heap

### DIFF
--- a/dart/math/lcp/projection/pgs_solver.cpp
+++ b/dart/math/lcp/projection/pgs_solver.cpp
@@ -63,6 +63,42 @@ bool validateParameters(
 
 } // namespace
 
+//==============================================================================
+void PgsSolver::Scratch::reserve(int size)
+{
+  if (size <= 0) {
+    return;
+  }
+  const auto problemSize = static_cast<std::size_t>(size);
+  const auto paddedSize = static_cast<std::size_t>(padding(size));
+  Adata.reserve(problemSize * paddedSize);
+  xdata.reserve(problemSize);
+  bdata.reserve(problemSize);
+  loData.reserve(problemSize);
+  hiData.reserve(problemSize);
+  w.reserve(problemSize);
+  loEff.reserve(problemSize);
+  hiEff.reserve(problemSize);
+  findexData.reserve(problemSize);
+  order.reserve(problemSize);
+}
+
+//==============================================================================
+void PgsSolver::Scratch::clear() noexcept
+{
+  Adata.clear();
+  xdata.clear();
+  bdata.clear();
+  loData.clear();
+  hiData.clear();
+  w.clear();
+  loEff.clear();
+  hiEff.clear();
+  findexData.clear();
+  order.clear();
+}
+
+//==============================================================================
 PgsSolver::PgsSolver()
 {
   mDefaultOptions.maxIterations = 30;
@@ -88,13 +124,18 @@ const PgsSolver::Parameters& PgsSolver::getParameters() const
 LcpResult PgsSolver::solve(
     const LcpProblem& problem, Eigen::VectorXd& x, const LcpOptions& options)
 {
-  LcpResult result;
+  Scratch scratch;
+  return solve(problem, x, scratch, options);
+}
 
-  const auto& A = problem.A;
-  const auto& b = problem.b;
-  const auto& lo = problem.lo;
-  const auto& hi = problem.hi;
-  const auto& findex = problem.findex;
+//==============================================================================
+LcpResult PgsSolver::solve(
+    const LcpProblem& problem,
+    Eigen::VectorXd& x,
+    Scratch& scratch,
+    const LcpOptions& options)
+{
+  LcpResult result;
 
   std::string problemMessage;
   if (!detail::validateProblem(problem, &problemMessage)) {
@@ -103,7 +144,7 @@ LcpResult PgsSolver::solve(
     return result;
   }
 
-  const auto n = std::ssize(b);
+  const auto n = std::ssize(problem.b);
   if (n == 0) {
     x.resize(0);
     result.status = LcpSolverStatus::Success;
@@ -116,6 +157,53 @@ LcpResult PgsSolver::solve(
 
   if (x.size() != n) {
     x = Eigen::VectorXd::Zero(n);
+  }
+
+  return solve(
+      problem.A,
+      problem.b,
+      problem.lo,
+      problem.hi,
+      problem.findex,
+      x,
+      scratch,
+      options);
+}
+
+//==============================================================================
+LcpResult PgsSolver::solve(
+    const Eigen::Ref<const Eigen::MatrixXd>& A,
+    const Eigen::Ref<const Eigen::VectorXd>& b,
+    const Eigen::Ref<const Eigen::VectorXd>& lo,
+    const Eigen::Ref<const Eigen::VectorXd>& hi,
+    const Eigen::Ref<const Eigen::VectorXi>& findex,
+    Eigen::Ref<Eigen::VectorXd> x,
+    Scratch& scratch,
+    const LcpOptions& options)
+{
+  LcpResult result;
+
+  std::string problemMessage;
+  if (!detail::validateProblemView(A, b, lo, hi, findex, &problemMessage)) {
+    result.status = LcpSolverStatus::InvalidProblem;
+    result.message = problemMessage;
+    return result;
+  }
+
+  const Eigen::Index n = b.size();
+  if (x.size() != n) {
+    result.status = LcpSolverStatus::InvalidProblem;
+    result.message = "Solution vector dimensions inconsistent";
+    return result;
+  }
+
+  if (n == 0) {
+    result.status = LcpSolverStatus::Success;
+    result.iterations = 0;
+    result.residual = 0.0;
+    result.complementarity = 0.0;
+    result.validated = options.validateSolution;
+    return result;
   }
 
   const Parameters* params
@@ -152,19 +240,19 @@ LcpResult PgsSolver::solve(
   const auto problemSize = static_cast<std::size_t>(n);
   const auto paddedSize = static_cast<std::size_t>(nSkip);
 
-  std::vector<double> Adata(problemSize * paddedSize, 0.0);
-  std::vector<double> xdata(problemSize, 0.0);
-  std::vector<double> bdata(problemSize, 0.0);
-  std::vector<double> loData(problemSize, 0.0);
-  std::vector<double> hiData(problemSize, 0.0);
-  std::vector<int> findexData(problemSize, -1);
+  scratch.Adata.assign(problemSize * paddedSize, 0.0);
+  scratch.xdata.assign(problemSize, 0.0);
+  scratch.bdata.assign(problemSize, 0.0);
+  scratch.loData.assign(problemSize, 0.0);
+  scratch.hiData.assign(problemSize, 0.0);
+  scratch.findexData.assign(problemSize, -1);
 
-  std::span<double> aValues{Adata};
-  std::span<double> xValues{xdata};
-  std::span<double> bValues{bdata};
-  std::span<double> loValues{loData};
-  std::span<double> hiValues{hiData};
-  std::span<int> findexValues{findexData};
+  std::span<double> aValues{scratch.Adata};
+  std::span<double> xValues{scratch.xdata};
+  std::span<double> bValues{scratch.bdata};
+  std::span<double> loValues{scratch.loData};
+  std::span<double> hiValues{scratch.hiData};
+  std::span<int> findexValues{scratch.findexData};
 
   auto aRow = [&](int row) -> std::span<double> {
     return aValues.subspan(
@@ -195,7 +283,8 @@ LcpResult PgsSolver::solve(
     }
   }
 
-  std::vector<int> order;
+  auto& order = scratch.order;
+  order.clear();
   order.reserve(static_cast<std::size_t>(n));
 
   bool possibleToTerminate = true;
@@ -295,15 +384,20 @@ LcpResult PgsSolver::solve(
     }
   }
 
-  x = Eigen::Map<Eigen::VectorXd>(xdata.data(), n);
+  x = Eigen::Map<const Eigen::VectorXd>(scratch.xdata.data(), n);
 
-  Eigen::VectorXd wVec = A * x - b;
+  scratch.w.resize(problemSize);
+  Eigen::Map<Eigen::VectorXd> wVec(scratch.w.data(), n);
+  wVec.noalias() = A * x;
+  wVec -= b;
   result.iterations = iterationsUsed;
 
-  Eigen::VectorXd loEff;
-  Eigen::VectorXd hiEff;
+  scratch.loEff.resize(problemSize);
+  scratch.hiEff.resize(problemSize);
+  Eigen::Map<Eigen::VectorXd> loEff(scratch.loEff.data(), n);
+  Eigen::Map<Eigen::VectorXd> hiEff(scratch.hiEff.data(), n);
   std::string boundsMessage;
-  const bool boundsOk = detail::computeEffectiveBounds(
+  const bool boundsOk = detail::computeEffectiveBoundsInto(
       lo, hi, findex, x, loEff, hiEff, &boundsMessage);
   if (!boundsOk) {
     result.status = LcpSolverStatus::InvalidProblem;
@@ -311,8 +405,9 @@ LcpResult PgsSolver::solve(
     return result;
   }
 
-  result.residual = detail::naturalResidualInfinityNorm(x, wVec, loEff, hiEff);
-  result.complementarity = detail::complementarityInfinityNorm(
+  result.residual
+      = detail::naturalResidualInfinityNormView(x, wVec, loEff, hiEff);
+  result.complementarity = detail::complementarityInfinityNormView(
       x, wVec, loEff, hiEff, absTolerance);
   if (x.hasNaN()) {
     result.status = LcpSolverStatus::Failed;
@@ -329,7 +424,7 @@ LcpResult PgsSolver::solve(
     const double validationTol = std::max(absTolerance, compTol);
 
     std::string validationMessage;
-    const bool valid = detail::validateSolution(
+    const bool valid = detail::validateSolutionView(
         x, wVec, loEff, hiEff, validationTol, &validationMessage);
     result.validated = true;
     if (!valid) {

--- a/dart/math/lcp/projection/pgs_solver.hpp
+++ b/dart/math/lcp/projection/pgs_solver.hpp
@@ -34,6 +34,10 @@
 
 #include <dart/math/lcp/lcp_solver.hpp>
 
+#include <dart/common/stl_allocator.hpp>
+
+#include <vector>
+
 namespace dart::math {
 
 /// Projected Gauss-Seidel solver for standard and boxed LCPs.
@@ -46,6 +50,51 @@ public:
     bool randomizeConstraintOrder{false};
   };
 
+  /// Reusable work storage for repeated same-shape PGS solves.
+  ///
+  /// Construct with a `dart::common::MemoryAllocator` and warm with
+  /// `reserve()` so repeated solves of the same problem size route every
+  /// work-buffer allocation through the provided allocator instead of the
+  /// global heap (allocator correctness for real-time callers).
+  struct DART_API Scratch
+  {
+    using DoubleAllocator = dart::common::StlAllocator<double>;
+    using IntAllocator = dart::common::StlAllocator<int>;
+
+    Scratch() = default;
+
+    explicit Scratch(dart::common::MemoryAllocator& allocator)
+      : Adata(DoubleAllocator{allocator}),
+        xdata(DoubleAllocator{allocator}),
+        bdata(DoubleAllocator{allocator}),
+        loData(DoubleAllocator{allocator}),
+        hiData(DoubleAllocator{allocator}),
+        w(DoubleAllocator{allocator}),
+        loEff(DoubleAllocator{allocator}),
+        hiEff(DoubleAllocator{allocator}),
+        findexData(IntAllocator{allocator}),
+        order(IntAllocator{allocator})
+    {
+    }
+
+    /// Grow buffer capacities for problems of up to `size` rows so
+    /// repeated same-shape solves do not allocate.
+    void reserve(int size);
+
+    void clear() noexcept;
+
+    std::vector<double, DoubleAllocator> Adata;
+    std::vector<double, DoubleAllocator> xdata;
+    std::vector<double, DoubleAllocator> bdata;
+    std::vector<double, DoubleAllocator> loData;
+    std::vector<double, DoubleAllocator> hiData;
+    std::vector<double, DoubleAllocator> w;
+    std::vector<double, DoubleAllocator> loEff;
+    std::vector<double, DoubleAllocator> hiEff;
+    std::vector<int, IntAllocator> findexData;
+    std::vector<int, IntAllocator> order;
+  };
+
   PgsSolver();
   ~PgsSolver() override = default;
 
@@ -55,6 +104,28 @@ public:
       const LcpProblem& problem,
       Eigen::VectorXd& x,
       const LcpOptions& options) override;
+
+  LcpResult solve(
+      const LcpProblem& problem,
+      Eigen::VectorXd& x,
+      Scratch& scratch,
+      const LcpOptions& options);
+
+  /// Solve on caller-owned storage without copying the problem.
+  ///
+  /// `x` must already have `b.size()` entries and is solved in place. With an
+  /// allocator-constructed, `reserve()`-warmed scratch this overload performs
+  /// no global-heap allocation, which is what the boxed-LCP contact path's
+  /// degenerate fallback relies on.
+  LcpResult solve(
+      const Eigen::Ref<const Eigen::MatrixXd>& A,
+      const Eigen::Ref<const Eigen::VectorXd>& b,
+      const Eigen::Ref<const Eigen::VectorXd>& lo,
+      const Eigen::Ref<const Eigen::VectorXd>& hi,
+      const Eigen::Ref<const Eigen::VectorXi>& findex,
+      Eigen::Ref<Eigen::VectorXd> x,
+      Scratch& scratch,
+      const LcpOptions& options);
 
   /// Set solver-specific parameters (e.g., division epsilon, ordering).
   void setParameters(const Parameters& params);

--- a/dart/simulation/detail/rigid_contact/boxed_lcp_contact.cpp
+++ b/dart/simulation/detail/rigid_contact/boxed_lcp_contact.cpp
@@ -101,6 +101,7 @@ void BoxedLcpContactScratch::reserve(
   dantzig.hiData.reserve(vectorSize);
   dantzig.findexData.reserve(vectorSize);
   dantzig.w.resize(rows);
+  pgsFallback.reserve(static_cast<int>(rows));
   dantzig.loEff.resize(rows);
   dantzig.hiEff.resize(rows);
   dantzig.lcp.L.reserve(matrixSize);
@@ -379,23 +380,21 @@ BoxedLcpContactSnapshot& solveBoxedLcpContactsImpl(
   f.setZero();
   // Degenerate flat contact stacks can hit a non-positive pivot; allow the
   // pivoting solve to terminate early and fall back to the bounded iterative
-  // solver when it fails or returns a non-finite contact force. The pivoting
-  // solve stays on the allocator-backed scratch; the rare degenerate fallback
-  // uses a temporary that does not touch the world allocator.
+  // solver when it fails or returns a non-finite contact force. Both solves
+  // run on allocator-backed scratch and operate on the assembled system in
+  // place, so even fallback steps never touch the global heap.
   options.earlyTermination = true;
   const math::LcpResult result
       = solver.solve(A, b, lo, hi, findex, f, scratch.dantzig, options);
   if (!result.succeeded() || !f.allFinite()) {
-    Eigen::VectorXd fallbackForce = f;
     math::PgsSolver fallback;
     math::LcpOptions fallbackOptions = math::LcpOptions::realTime();
     fallbackOptions.maxIterations = 120;
     fallbackOptions.relativeTolerance = 1e-6;
     fallbackOptions.validateSolution = false;
-    fallbackOptions.warmStart = fallbackForce.allFinite();
-    const math::LcpProblem problem(A, b, lo, hi, findex);
-    fallback.solve(problem, fallbackForce, fallbackOptions);
-    f = fallbackForce;
+    fallbackOptions.warmStart = f.allFinite();
+    [[maybe_unused]] const math::LcpResult fallbackResult = fallback.solve(
+        A, b, lo, hi, findex, f, scratch.pgsFallback, fallbackOptions);
   }
   for (Eigen::Index i = 0; i < n; ++i) {
     // Normal impulses are push-only; sanitize non-finite/negative values.

--- a/dart/simulation/detail/rigid_contact/boxed_lcp_contact.hpp
+++ b/dart/simulation/detail/rigid_contact/boxed_lcp_contact.hpp
@@ -53,6 +53,7 @@
 #include <dart/simulation/fwd.hpp>
 
 #include <dart/math/lcp/pivoting/dantzig_solver.hpp>
+#include <dart/math/lcp/projection/pgs_solver.hpp>
 
 #include <dart/common/memory_allocator.hpp>
 #include <dart/common/stl_allocator.hpp>
@@ -146,7 +147,8 @@ struct DART_SIMULATION_API BoxedLcpContactScratch
       JMinv(DoubleAllocator{allocator}),
       jtImpulse(DoubleAllocator{allocator}),
       deltaV(DoubleAllocator{allocator}),
-      dantzig(allocator)
+      dantzig(allocator),
+      pgsFallback(allocator)
   {
   }
 
@@ -168,6 +170,9 @@ struct DART_SIMULATION_API BoxedLcpContactScratch
   DoubleVector jtImpulse;
   DoubleVector deltaV;
   math::DantzigSolver::Scratch dantzig;
+  /// Work storage for the degenerate-pivot PGS fallback solve so that path
+  /// stays off the global heap like the primary Dantzig solve.
+  math::PgsSolver::Scratch pgsFallback;
 };
 
 DART_SIMULATION_API void reserveBoxedLcpContactScratch(

--- a/tests/unit/math/lcp/test_pgs.cpp
+++ b/tests/unit/math/lcp/test_pgs.cpp
@@ -36,6 +36,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <vector>
 
 #include <cmath>
 
@@ -244,4 +245,222 @@ TEST(PgsSolver, HandlesZeroDiagonalEntries)
   EXPECT_NE(result.status, LcpSolverStatus::InvalidProblem);
   EXPECT_TRUE(x.array().isFinite().all());
   EXPECT_NEAR(x[0], 0.0, 1e-12);
+}
+
+//==============================================================================
+namespace {
+
+// The boxed friction-index problem from SolvesBoxedProblemWithFrictionIndex,
+// shared by the scratch-overload tests below.
+struct BoxedFrictionProblem
+{
+  Eigen::Matrix3d A;
+  Eigen::Vector3d b;
+  Eigen::Vector3d lo = Eigen::Vector3d::Zero();
+  Eigen::Vector3d hi;
+  Eigen::Vector3i findex;
+
+  BoxedFrictionProblem()
+  {
+    A << 4.0, 0.5, 0.0, 0.5, 3.0, 0.25, 0.0, 0.25, 2.5;
+    b = A * Eigen::Vector3d(1.0, 0.2, -0.1);
+    hi << std::numeric_limits<double>::infinity(), 0.5, 0.5;
+    findex << -1, 0, 0;
+  }
+};
+
+} // namespace
+
+//==============================================================================
+TEST(PgsSolver, ScratchOverloadMatchesOwningSolve)
+{
+  const BoxedFrictionProblem fixture;
+
+  PgsSolver solver;
+  LcpOptions options = solver.getDefaultOptions();
+  options.maxIterations = 5000;
+  options.warmStart = false;
+  options.complementarityTolerance = 1e-3;
+
+  Eigen::VectorXd owningX = Eigen::VectorXd::Zero(3);
+  const LcpProblem problem(
+      fixture.A, fixture.b, fixture.lo, fixture.hi, fixture.findex);
+  const auto owningResult = solver.solve(problem, owningX, options);
+  ASSERT_TRUE(owningResult.succeeded());
+
+  PgsSolver::Scratch scratch;
+  Eigen::VectorXd scratchX = Eigen::VectorXd::Zero(3);
+  const auto scratchResult = solver.solve(
+      fixture.A,
+      fixture.b,
+      fixture.lo,
+      fixture.hi,
+      fixture.findex,
+      scratchX,
+      scratch,
+      options);
+
+  EXPECT_EQ(scratchResult.status, owningResult.status);
+  EXPECT_EQ(scratchResult.iterations, owningResult.iterations);
+  for (Eigen::Index i = 0; i < 3; ++i) {
+    EXPECT_DOUBLE_EQ(scratchX[i], owningX[i]);
+  }
+}
+
+//==============================================================================
+TEST(PgsSolver, ScratchOverloadSolvesInPlaceThroughMaps)
+{
+  const BoxedFrictionProblem fixture;
+
+  PgsSolver solver;
+  LcpOptions options = solver.getDefaultOptions();
+  options.maxIterations = 5000;
+  options.warmStart = false;
+  options.complementarityTolerance = 1e-3;
+
+  // Mirror the boxed-LCP contact fallback: every operand, including the
+  // solution, is a map over caller-owned storage.
+  std::vector<double> aData(9), bData(3), loData(3), hiData(3), xData(3, 0.0);
+  std::vector<int> findexData(3);
+  Eigen::Map<Eigen::MatrixXd>(aData.data(), 3, 3) = fixture.A;
+  Eigen::Map<Eigen::Vector3d>(bData.data()) = fixture.b;
+  Eigen::Map<Eigen::Vector3d>(loData.data()) = fixture.lo;
+  Eigen::Map<Eigen::Vector3d>(hiData.data()) = fixture.hi;
+  Eigen::Map<Eigen::Vector3i>(findexData.data()) = fixture.findex;
+
+  PgsSolver::Scratch scratch;
+  Eigen::Map<Eigen::VectorXd> x(xData.data(), 3);
+  const auto result = solver.solve(
+      Eigen::Map<const Eigen::MatrixXd>(aData.data(), 3, 3),
+      Eigen::Map<const Eigen::VectorXd>(bData.data(), 3),
+      Eigen::Map<const Eigen::VectorXd>(loData.data(), 3),
+      Eigen::Map<const Eigen::VectorXd>(hiData.data(), 3),
+      Eigen::Map<const Eigen::VectorXi>(findexData.data(), 3),
+      x,
+      scratch,
+      options);
+
+  ASSERT_TRUE(result.succeeded());
+  Eigen::VectorXd owningX = Eigen::VectorXd::Zero(3);
+  const LcpProblem problem(
+      fixture.A, fixture.b, fixture.lo, fixture.hi, fixture.findex);
+  ASSERT_TRUE(solver.solve(problem, owningX, options).succeeded());
+  for (Eigen::Index i = 0; i < 3; ++i) {
+    EXPECT_DOUBLE_EQ(x[i], owningX[i]);
+  }
+}
+
+//==============================================================================
+TEST(PgsSolver, ScratchOverloadZeroesNonFiniteWarmStart)
+{
+  const BoxedFrictionProblem fixture;
+
+  PgsSolver solver;
+  LcpOptions options = solver.getDefaultOptions();
+  options.maxIterations = 5000;
+  options.complementarityTolerance = 1e-3;
+
+  // The contact fallback engages exactly when the pivoting solve leaves
+  // non-finite impulses behind; those entries must restart from zero.
+  PgsSolver::Scratch scratch;
+  Eigen::VectorXd x(3);
+  x << std::numeric_limits<double>::quiet_NaN(), 0.1,
+      -std::numeric_limits<double>::infinity();
+  options.warmStart = true;
+  const auto result = solver.solve(
+      fixture.A,
+      fixture.b,
+      fixture.lo,
+      fixture.hi,
+      fixture.findex,
+      x,
+      scratch,
+      options);
+
+  ASSERT_TRUE(result.succeeded());
+  EXPECT_TRUE(x.array().isFinite().all());
+}
+
+//==============================================================================
+TEST(PgsSolver, ScratchOverloadRejectsMismatchedSolutionSize)
+{
+  const BoxedFrictionProblem fixture;
+
+  PgsSolver solver;
+  PgsSolver::Scratch scratch;
+  Eigen::VectorXd x = Eigen::VectorXd::Zero(2);
+  const auto result = solver.solve(
+      fixture.A,
+      fixture.b,
+      fixture.lo,
+      fixture.hi,
+      fixture.findex,
+      x,
+      scratch,
+      solver.getDefaultOptions());
+
+  EXPECT_EQ(result.status, LcpSolverStatus::InvalidProblem);
+}
+
+//==============================================================================
+TEST(PgsSolver, ScratchCapacityIsStableAcrossRepeatedSolves)
+{
+  const BoxedFrictionProblem fixture;
+
+  PgsSolver solver;
+  LcpOptions options = solver.getDefaultOptions();
+  options.maxIterations = 5000;
+  options.warmStart = false;
+  options.complementarityTolerance = 1e-3;
+
+  PgsSolver::Scratch scratch;
+  scratch.reserve(3);
+
+  const auto solveOnce = [&](Eigen::VectorXd& x) {
+    return solver.solve(
+        fixture.A,
+        fixture.b,
+        fixture.lo,
+        fixture.hi,
+        fixture.findex,
+        x,
+        scratch,
+        options);
+  };
+
+  Eigen::VectorXd x = Eigen::VectorXd::Zero(3);
+  ASSERT_TRUE(solveOnce(x).succeeded());
+
+  const auto aCapacity = scratch.Adata.capacity();
+  const auto xCapacity = scratch.xdata.capacity();
+  const auto wCapacity = scratch.w.capacity();
+  const auto orderCapacity = scratch.order.capacity();
+
+  // Repeated same-shape solves must reuse the warmed buffers: capacity growth
+  // here is exactly the global-heap allocation the contact fallback must not
+  // perform after the bake boundary.
+  x.setZero();
+  ASSERT_TRUE(solveOnce(x).succeeded());
+  EXPECT_EQ(scratch.Adata.capacity(), aCapacity);
+  EXPECT_EQ(scratch.xdata.capacity(), xCapacity);
+  EXPECT_EQ(scratch.w.capacity(), wCapacity);
+  EXPECT_EQ(scratch.order.capacity(), orderCapacity);
+
+  // A smaller same-scratch solve shrinks sizes, never capacities.
+  Eigen::Matrix2d smallA;
+  smallA << 4.0, 1.0, 1.0, 3.0;
+  const Eigen::Vector2d smallB = smallA * Eigen::Vector2d(0.5, 0.25);
+  Eigen::VectorXd smallX = Eigen::VectorXd::Zero(2);
+  const auto smallResult = solver.solve(
+      smallA,
+      smallB,
+      Eigen::Vector2d::Zero(),
+      Eigen::Vector2d::Constant(std::numeric_limits<double>::infinity()),
+      Eigen::Vector2i::Constant(-1),
+      smallX,
+      scratch,
+      options);
+  ASSERT_TRUE(smallResult.succeeded());
+  EXPECT_EQ(scratch.Adata.capacity(), aCapacity);
+  EXPECT_EQ(scratch.xdata.capacity(), xCapacity);
 }


### PR DESCRIPTION
## Summary

- The baked-step allocation contract restored by #3378 still has one latent
  gap: the boxed-LCP contact path's degenerate-pivot PGS fallback allocates
  on the global heap whenever it engages. This PR closes it by giving
  `PgsSolver` the same allocator-backed `Scratch` + `Eigen::Ref` in-place
  solve overload `DantzigSolver` already has, and running the fallback on
  bake-warmed scratch directly over the assembled system maps.
- Additive API only: owning `PgsSolver::solve` semantics are preserved via
  delegation; no consumer changes.

## Motivation / Problem

This started as the investigation into the four
`World.Baked*DoNotAllocateGlobalHeap` / `*DoNotMallocOnHeap` failures on
`main`. Backtrace-instrumented tracing attributed every counted allocation
to two sources — the unreserved `lastContactForces` capture buffer and the
per-step owning-snapshot population — and explicitly exonerated the EnTT 4.0
upgrade the failures first appeared alongside. #3378 landed equivalent fixes
for both while this branch was in flight, so `main` is green again and this
PR carries only the remaining piece the counters never reached: the
degenerate fallback (`Dantzig` failure or non-finite impulses) copied the
assembled system into an owning `LcpProblem` — seven owning Eigen buffers
per engagement — and `PgsSolver::solve` allocated per-call `std::vector`
work buffers plus owning Eigen epilogue temporaries. A degenerate contact
stack in a baked world would therefore allocate on exactly the steps the
contract says must not.

## Changes / Key Changes

- `PgsSolver::Scratch`: allocator-backed work buffers mirroring
  `DantzigSolver::Scratch` (`dart::common::StlAllocator`, `reserve()` warm-up,
  `clear()`).
- New `PgsSolver::solve(Ref A, Ref b, Ref lo, Ref hi, Ref findex, Ref x,
  Scratch&, options)` overload solving in place on caller storage; the
  owning overloads delegate to it. The residual/complementarity/validation
  epilogue uses the existing templated `*View`/`*Into` helpers from
  `lcp_validation.hpp` over scratch-backed maps (including a `noalias` gemv
  instead of an owning `A * x - b` temporary).
- `BoxedLcpContactScratch` gains a `pgsFallback` scratch (allocator-
  propagated, warmed in `reserveBoxedLcpContactScratch`); the fallback in
  `solveBoxedLcpContactsImpl` solves in place on the assembled maps instead
  of building an owning `LcpProblem` and copying the solution back.
- Unit tests for the new surface in `test_pgs.cpp`: parity with the owning
  overload (vector- and map-backed operands), in-place non-finite
  warm-start handling (the fallback's exact usage), solution-size
  validation, and capacity stability across repeated same-scratch solves —
  capacity growth is precisely the allocation the contract forbids.

## Testing

- `UNIT_math_lcp_math_lcp_pgs` — 12/12 (7 existing + 5 new).
- `test_world --gtest_filter='*DoNotAllocateGlobalHeap:*DoNotMallocOnHeap'`
  — 32/32 on this branch (current `main` + these changes).
- `ctest -R "lcp|pgs|boxed"` — 18/18, including `test_boxed_lcp_contact`
  (exercises the changed solve path) and the LCP comparison/generated
  coverage suites (owning-overload parity).
- Full `test_world` binary, `pixi run lint`, `pixi run test-all` (results in
  thread).

## Breaking Changes

- [x] None — additions are additive; owning-overload behavior (validation
  messages, `x` resizing, warm-start element handling) is preserved.

## Related Issues / PRs (backports)

- Follows #3378, which restored the baked-step allocation contract for the
  primary solve path; the fallback path predates it (#3264).
- #3414 (EnTT 4.0) is not involved — established by running the failing
  tests against pristine pre-/post-upgrade trees in the same build
  directory.
- Unblocks the fwd.hpp consolidation PR (branch `refactor/fwd-headers`),
  whose `test-all` run first surfaced the redness.
- No DART 6 backport: DART 7 `dart/simulation` + `dart/math/lcp` only.
- No changelog entry: closes a latent gap in an unreleased, `main`-only
  allocation contract; nothing reader-visible changes per
  `docs/onboarding/changelog.md`.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md — N/A, reason recorded above
- [x] Add unit tests for new functionality (5 new `PgsSolver` tests)
- [x] Document new methods and classes (`PgsSolver::Scratch` and the Ref
      overload carry Doxygen comments)
- [ ] Add Python bindings (dartpy) if applicable — N/A, internal solver
      plumbing
