### PR TITLE
Build dart-demos for the ASAN test target

### DIFF
--- a/examples/demos/CMakeLists.txt
+++ b/examples/demos/CMakeLists.txt
@@ -154,7 +154,11 @@ if(TARGET dart-demos)
     )
     unset(_dart_demos_memory_artifact_label)
     unset(_dart_demos_memory_artifact_test)
-    foreach(test_target IN ITEMS tests tests_and_run)
+    # tests_no_simulation is the ASAN build target, and the ASAN ctest run only
+    # filters out the `simulation` label. The artifact tests registered above
+    # carry no such label, so they still run there and need the executable
+    # built; without this dependency they fail on a missing dart-demos.
+    foreach(test_target IN ITEMS tests tests_no_simulation tests_and_run)
       if(TARGET ${test_target})
         add_dependencies(${test_target} dart-demos)
       endif()
@@ -253,6 +257,9 @@ if(
     UNIT_examples_demos_MemoryDiagnostics
     PROPERTIES LABELS "examples;gui;memory-diagnostics;simulation"
   )
+  # Deliberately excludes tests_no_simulation: this test carries the
+  # `simulation` label, so the ASAN ctest run filters it out and never needs
+  # the executable built.
   foreach(test_target IN ITEMS tests tests_and_run)
     if(TARGET ${test_target})
       add_dependencies(${test_target} UNIT_examples_demos_MemoryDiagnostics)


### PR DESCRIPTION
## Summary

- Fixes the red `ASAN Tests` job on `main` by making `tests_no_simulation` —
  the target the ASAN job builds — depend on `dart-demos`. The job has failed
  on every `main` push since #3378 with
  `CMake Error ... check_memory_diagnostics_artifact.cmake:14 (message): dart-demos executable is required`.

## Motivation / Problem

The ASAN job builds the `tests_no_simulation` target and then runs
`ctest -LE simulation`, so the invariant is: every test that survives that
label filter must be built by that target.

`examples/demos/CMakeLists.txt` registered `dart-demos` as a build dependency
of only `tests` and `tests_and_run`. That list predates `tests_no_simulation`,
which was introduced later in #3286 and was never added here.

The gap stayed latent because the only demos test without a `simulation` label,
`EXAMPLE_dart_demos_list`, is `DISABLED` under ASAN (Filament dlopens SDL3 and
aborts at startup), so it never tried to exec the missing binary.

#3378 then added `EXAMPLE_dart_demos_memory_diagnostics_excluded`
(labels `examples;gui;memory-diagnostics;zero-overhead`). It is enabled and
also unlabelled for `simulation`, so it ran under ASAN against an executable
that was never built and failed hard.

Confirmed failing on b15e7a652 ([run 30685076295][run]), 81694a08e, and
1c4fa3f86 — same test, same message each time.

[run]: https://github.com/dartsim/dart/actions/runs/30685076295/job/91329419936

## Changes / Key Changes

- Add `tests_no_simulation` to the `foreach` that registers the `dart-demos`
  build dependency.
- Leave the `UNIT_examples_demos_MemoryDiagnostics` loop as-is on purpose: that
  test carries the `simulation` label, so ASAN's `-LE simulation` filters it
  out and building it there would be wasted work on an already ~2h job.
- Comment both loops so the ASAN/label coupling is stated where the next
  person will edit it.

Cost is small: `dart-gui`, `dart-simulation`, and `dart-collision-native` are
already built in the ASAN job today; this adds only `demos_scenes` (3 TUs),
`app/main.cpp`, and one link. It also makes the existing comment at
`examples/demos/CMakeLists.txt:104` ("dart-demos is still built under ASan")
true again.

## Testing

- `pixi run lint` — clean, no reformatting churn.
- **Reproduced the CI failure locally.** In a configured tree, deleted
  `bin/dart-demos` and ran the test: fails with the exact CI error
  (`dart-demos executable is required`, test #311, same labels).
- **Verified the fix end-to-end.** With the change, `ninja tests_no_simulation`
  rebuilds `bin/dart-demos` and test #311 passes (`100% tests passed`).
- **Verified the build graph.** `ninja -t inputs tests_no_simulation` went from
  **0** demos inputs to **10** (including `bin/dart-demos`), while still
  pulling in **0** inputs for `UNIT_examples_demos_MemoryDiagnostics`
  (`tests` still pulls it in, as intended).
- **Audited for other instances of the same gap.** Cross-referenced every
  executable referenced by the `ctest -LE simulation` inventory (229 enabled
  tests, matching the CI count) against `tests_no_simulation`'s build inputs:
  **0 remaining gaps**. Negative control — dropping `dart-demos` from the input
  set — correctly re-reports the gap, so the audit is not vacuous.
- Confirmed `DART_ENABLE_ASAN` only adds `-fsanitize=address` /
  `-fno-omit-frame-pointer` and changes no target linkage, so the artifact
  oracle behaves under ASAN as it already does in Release, where it passes.
  Also checked all three local `libasan` runtimes contain **0** occurrences of
  the sentinel strings/symbols the check greps for, so the ASAN runtime cannot
  trip the "excluded" assertion.

Not run locally: a full instrumented ASAN build (~2h cold). The failure and fix
are in the build graph, which is verified directly above.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Regressed by #3378 (added the enabled, unlabelled demos artifact test).
- Root cause introduced by #3286 (added `tests_no_simulation`).
- `main` / DART 7 only; DART 6 LTS has neither target nor test, so no backport.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required —
      **not required.** Build-graph-only fix with no user-visible behavior
      change. Matches the precedent of #3286, the direct analogue (ASAN build
      target change to `tests/CMakeLists.txt` + `pixi.toml`), which added no
      entry.
- [x] Add unit tests for new functionality — n/a; this repairs an existing
      test's build dependency rather than adding behavior. The restored test
      is itself the regression guard.
- [x] Document new methods and classes — n/a; comments added at both loops.
- [x] Add Python bindings (dartpy) if applicable — n/a.
