### PR TITLE
Read ImGui draw-list count from CmdLists.Size

### DIFF
--- a/examples/demos/tests/test_memory_diagnostics.cpp
+++ b/examples/demos/tests/test_memory_diagnostics.cpp
@@ -404,14 +404,19 @@ TEST(MemoryDiagnostics, DenseMapStaysBelowTheOpenGL2DrawIndexLimit)
     stats.windowVisible = windowVisible;
     const ImDrawData* drawData = ImGui::GetDrawData();
     if (drawData != nullptr) {
-      stats.drawListCount = drawData->CmdListsCount;
-      for (int index = 0; index < drawData->CmdListsCount; ++index) {
+      // Read the draw-list count from CmdLists.Size rather than the obsolete
+      // CmdListsCount mirror: ImGui 1.92.9 regressed that field to always
+      // report 0 (fixed upstream in 1.92.9b), which silently emptied every
+      // measurement below. CmdLists is the canonical member on every ImGui
+      // version this branch supports (>= 1.91.9).
+      stats.drawListCount = drawData->CmdLists.Size;
+      for (int index = 0; index < drawData->CmdLists.Size; ++index) {
         stats.maximumVertices = std::max(
             stats.maximumVertices, drawData->CmdLists[index]->VtxBuffer.Size);
       }
-      if (drawData->CmdListsCount > 0) {
+      if (drawData->CmdLists.Size > 0) {
         stats.lastDrawListVertices
-            = drawData->CmdLists[drawData->CmdListsCount - 1]->VtxBuffer.Size;
+            = drawData->CmdLists[drawData->CmdLists.Size - 1]->VtxBuffer.Size;
       }
     }
     return stats;


### PR DESCRIPTION
## Summary

- Fixes the red `CI Toolchain (Linux)` jobs on `release-6.20` by reading the
  ImGui draw-list count from `ImDrawData::CmdLists.Size` instead of the
  obsolete `CmdListsCount` mirror, which Dear ImGui 1.92.9 regressed to always
  report 0.

## Motivation / Problem

`MemoryDiagnostics.DenseMapStaysBelowTheOpenGL2DrawIndexLimit` has failed on
every `release-6.20` push since [#3421][pr3421] with:

```
test_memory_diagnostics.cpp:438: Expected: (baseline.drawListCount) > (0), actual: 0 vs 0
test_memory_diagnostics.cpp:439: Expected: (maximumDrawListVertices) > (32 * 1024), actual: 0 vs 32768
test_memory_diagnostics.cpp:441: Value of: tooltipExercised  Actual: false
```

The cause is upstream, not in this repo. Dear ImGui's 1.92.9b hotfix notes say:

> ImDrawData: fixed a regression in 1.92.9 where legacy/obsoleted
> `ImDrawData::CmdListsCount` was always 0. Prefer using
> `ImDrawData::CmdLists.Size` anyway.

[#3421][pr3421] refreshed the pixi lockfile, moving imgui 1.92.8 -> 1.92.9. The
test's `renderFrame` helper reads `CmdListsCount`, so it saw zero draw lists:
`drawListCount` became 0, the vertex scan loop never executed (leaving
`maximumVertices` at 0), and `lastDrawListVertices` was never set so the
tooltip probe could never fire. That is exactly the three-assertion signature
above, and it explains why `EXPECT_TRUE(baseline.windowVisible)` still passed —
the frame rendered fine, only the obsolete counter lied.

This is **not** compiler-specific. It is visible as a clang-only failure on
`73cd91e69` purely because the gcc job was still running; both gcc and clang
failed on `22c406595` and `fe9cb9ebd`.

[pr3421]: https://github.com/dartsim/dart/pull/3421

## Changes / Key Changes

- `examples/demos/tests/test_memory_diagnostics.cpp`: read `CmdLists.Size` for
  the count, the loop bound, and the last-draw-list index.
- Comment records why, so the obsolete mirror is not reintroduced.

`CmdLists` is the canonical member that `CmdListsCount` mirrors — imgui.h marks
the latter `(OBSOLETE: exists for legacy reasons)` — and it is an
`ImVector<ImDrawList*>` on every version this branch supports
(`imgui = ">=1.91.9,<2"`). So this is correct on 1.92.8, 1.92.9, and 1.92.9b
alike, and does not couple the test to whichever imgui the lockfile resolves.
Bumping the lockfile to 1.92.9b would mask the symptom but leave an obsolete
API in place that upstream will eventually remove.

## Testing

Verified against **real imgui 1.92.9** (the regressed version) in a
`release-6.20` worktree whose pixi env resolves the current lockfile:

- **Test now passes**: `UNIT_examples_demos_MemoryDiagnostics` →
  `100% tests passed`, same test #159 CI failed on.
- **Negative control in the same tree**: reverting just this change and
  rebuilding reproduces the CI failure (`***Failed`); restoring it passes
  again. So the local tree genuinely reproduces CI, and this change is what
  closes it.
- **Isolated the upstream mechanism** with a standalone program compiled
  against both imgui versions, same source:

  | | imgui 1.92.8 | imgui 1.92.9 |
  |---|---|---|
  | `CmdListsCount` | 1 | **0** |
  | `CmdLists.Size` | 1 | 1 |
  | `TotalVtxCount` | 11990 | 11990 |

  confirming the field is the regression and `.Size` is the version-stable
  read.
- `pixi run lint` — clean.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Triggered by [#3421](https://github.com/dartsim/dart/pull/3421) (lockfile
  refresh to imgui 1.92.9). Upstream regression:
  [ocornut/imgui v1.92.9b](https://github.com/ocornut/imgui/releases/tag/v1.92.9b).
- **`main` needs a separate, larger fix and is not covered here.** On `main`
  the same obsolete field is used in two *production* rendering paths
  (`dart/gui/detail/imgui_overlay.cpp`, `dart/gui/detail/imgui_draw_data.hpp`),
  where 1.92.9 silently drops the entire Filament ImGui overlay rather than
  just failing a test. Filed as a branch-appropriate DART 7 PR.
  `release-6.20` has no such production use — the only occurrences on this
  branch are in this test.

---

#### Checklist

- [x] Milestone set (DART 6.20.0 for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required —
      **not required.** Test-only change with no user-visible behavior
      difference; the shipped DART 6 code contains no use of the affected
      field. The user-visible half of this bug is on `main` and is where the
      changelog entry goes.
- [x] Add unit tests for new functionality — n/a; this repairs an existing
      regression test, which is itself the guard.
- [x] Document new methods and classes — n/a; comment added at the call site.
- [x] Add Python bindings (dartpy) if applicable — n/a.
