### PR TITLE
Keep the ImGui overlay rendering on Dear ImGui 1.92.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,15 @@ compatibility remains on the active DART 6 LTS branch._
   discarded `ImDrawCmd::ClipRect`, letting scrolled-off geometry escape the
   panel viewport. This applies to every GUI build, not only diagnostics builds.
   ([#3378](https://github.com/dartsim/dart/pull/3378))
+- Fixed the Dear ImGui overlay rendering nothing when built against system
+  Dear ImGui 1.92.9. That release regressed the obsolete
+  `ImDrawData::CmdListsCount` mirror to always report 0 (fixed upstream in
+  1.92.9b), so the Filament overlay gathered no vertices, produced an empty
+  draw plan, and dropped its renderable entirely. The overlay paths now read
+  the canonical `ImDrawData::CmdLists.Size`, which is correct on every
+  supported Dear ImGui version. Affects builds using
+  `DART_USE_SYSTEM_IMGUI=ON` (the recommendation for package distributions);
+  the fetched default pin is 1.92.8 and was never affected.
 - Rebuilt the maintained GUI stack on Filament, GLFW3, and Dear ImGui, including
   headless rendering/capture paths for CI and visual verification.
   ([#2466](https://github.com/dartsim/dart/pull/2466))

--- a/dart/gui/detail/imgui_draw_data.hpp
+++ b/dart/gui/detail/imgui_draw_data.hpp
@@ -60,7 +60,10 @@ inline ImGuiOverlayDrawPlan buildImGuiOverlayDrawPlan(
   plan.indices.reserve(static_cast<std::size_t>(drawData.TotalIdxCount));
 
   std::uint32_t vertexBase = 0u;
-  for (int listIndex = 0; listIndex < drawData.CmdListsCount; ++listIndex) {
+  // CmdLists.Size, not the obsolete CmdListsCount mirror: ImGui 1.92.9
+  // regressed that field to always report 0 (fixed upstream in 1.92.9b), which
+  // makes this loop produce an empty plan and drops the whole overlay.
+  for (int listIndex = 0; listIndex < drawData.CmdLists.Size; ++listIndex) {
     const ImDrawList& commandList = *drawData.CmdLists[listIndex];
     for (const ImDrawCmd& command : commandList.CmdBuffer) {
       if (command.UserCallback != nullptr || command.ElemCount == 0u) {

--- a/dart/gui/detail/imgui_overlay.cpp
+++ b/dart/gui/detail/imgui_overlay.cpp
@@ -536,7 +536,10 @@ void updateImGuiOverlay(
   std::vector<ImGuiVertex> vertices;
   vertices.reserve(static_cast<std::size_t>(drawData->TotalVtxCount));
 
-  for (int listIndex = 0; listIndex < drawData->CmdListsCount; ++listIndex) {
+  // CmdLists.Size, not the obsolete CmdListsCount mirror: ImGui 1.92.9
+  // regressed that field to always report 0 (fixed upstream in 1.92.9b), which
+  // leaves this vertex buffer empty and blanks the overlay.
+  for (int listIndex = 0; listIndex < drawData->CmdLists.Size; ++listIndex) {
     const ImDrawList* commandList = drawData->CmdLists[listIndex];
 
     for (const ImDrawVert& vertex : commandList->VtxBuffer) {

--- a/tests/unit/gui/test_imgui_overlay_indices.cpp
+++ b/tests/unit/gui/test_imgui_overlay_indices.cpp
@@ -74,7 +74,9 @@ TEST(ImGuiOverlayIndices, PreservesLargeDrawListVertexOffsets)
       static_cast<int>(std::numeric_limits<ImDrawIdx>::max()));
 
   bool hasNonzeroVertexOffset = false;
-  for (int listIndex = 0; listIndex < drawData->CmdListsCount; ++listIndex) {
+  // CmdLists.Size, not the obsolete CmdListsCount mirror, which ImGui 1.92.9
+  // regressed to always report 0 (fixed upstream in 1.92.9b).
+  for (int listIndex = 0; listIndex < drawData->CmdLists.Size; ++listIndex) {
     for (const ImDrawCmd& command : drawData->CmdLists[listIndex]->CmdBuffer) {
       hasNonzeroVertexOffset |= command.VtxOffset != 0u;
     }


### PR DESCRIPTION
## Summary

- Fixes the Dear ImGui overlay rendering **nothing** when DART is built against
  system Dear ImGui 1.92.9, which is the state of `main` today. The overlay
  paths now read `ImDrawData::CmdLists.Size` instead of the obsolete
  `CmdListsCount` mirror that 1.92.9 regressed to always report 0.

## Motivation / Problem

Dear ImGui's 1.92.9b hotfix notes:

> ImDrawData: fixed a regression in 1.92.9 where legacy/obsoleted
> `ImDrawData::CmdListsCount` was always 0. Prefer using
> `ImDrawData::CmdLists.Size` anyway.

[#3422](https://github.com/dartsim/dart/pull/3422) refreshed the pixi lockfile
from imgui 1.92.8 to 1.92.9, and the default pixi `config` task builds with
`DART_USE_SYSTEM_IMGUI=ON` (`:-ON`). Two **production** paths read the
regressed field:

- `dart/gui/detail/imgui_overlay.cpp` — the vertex gathering loop
- `dart/gui/detail/imgui_draw_data.hpp` — `buildImGuiOverlayDrawPlan`

With the field pinned at 0, both loops iterate zero times. `vertices` stays
empty, the draw plan comes back empty, and the `drawPlan.commands.empty()`
guard immediately below then calls `removeOverlayRenderable(...)` — so the
entire Dear ImGui overlay disappears.

This fails **silently**: it is not a crash, and the `TotalVtxCount` /
`TotalIdxCount` early-out above the loop is *not* affected by the regression
(those fields are still populated correctly), so nothing trips before the
overlay is discarded. The 3D scene keeps rendering normally, which is why
`Headless Rendering Tests` still passes on `main`.

The fetched default pin (`v1.92.8-docking`) was never affected. This bites
builds using system ImGui — which `DART_USE_SYSTEM_IMGUI` documents as
"recommended for package distributions" — and `IMGUI_MIN_VERSION` is `1.92`,
so 1.92.9 is squarely inside the supported range.

## Changes / Key Changes

- `dart/gui/detail/imgui_overlay.cpp`, `dart/gui/detail/imgui_draw_data.hpp`:
  read `CmdLists.Size`.
- `tests/unit/gui/test_imgui_overlay_indices.cpp`: same, so the guard test
  measures the overlay rather than tripping over the same obsolete field.
- CHANGELOG entry under *GUI, Examples, and Tutorials*, next to the related
  overlay fix from #3378.

`CmdLists` is the canonical member `CmdListsCount` mirrors — imgui.h marks the
latter `(OBSOLETE: exists for legacy reasons)` — so this is correct on 1.92.8,
1.92.9, and 1.92.9b alike and does not couple the renderer to whichever imgui
the lockfile resolves. Bumping the lockfile to 1.92.9b instead would mask the
symptom while leaving an obsolete API upstream intends to remove.

## Testing

All verification below ran against **real imgui 1.92.9** (the regressed
version), with the local env synced to this branch's lockfile.

- **Reproduced the production failure and its fix directly.** Compiled the real
  `buildImGuiOverlayDrawPlan` from `imgui_draw_data.hpp` into a standalone
  harness against imgui 1.92.9, once with the pre-fix header and once with the
  fixed one:

  | | before fix | after fix |
  |---|---|---|
  | `TotalIdxCount` | 120000 | 120000 |
  | `plan.indices` | **0** | 120000 |
  | `plan.commands` | **0** | 2 |
  | overlay renders | **NO** | YES |

- **Unit test, before and after, same tree**: `UNIT_gui_ImGuiOverlayIndices`
  **fails** on 1.92.9 without this change
  (`test_imgui_overlay_indices.cpp:82` — `ASSERT_TRUE(hasNonzeroVertexOffset)`
  — plus line 143) and **passes** with it.
- **No regression on the pinned version**: the same test passes on imgui
  1.92.8, and `libdart-gui-core` rebuilds cleanly.
- **Isolated the upstream mechanism** with a second standalone program, same
  source compiled against both versions: `CmdListsCount` is 1 on 1.92.8 and
  **0** on 1.92.9, while `CmdLists.Size` is 1 on both and `TotalVtxCount` is
  identical.
- `pixi run lint` — clean.

Not covered locally: an end-to-end visual capture of the overlay. The failure
is fully characterized at the draw-plan level above, which is the input the
Filament renderable is built from.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Triggered by [#3422](https://github.com/dartsim/dart/pull/3422) (lockfile
  refresh to imgui 1.92.9). Upstream regression:
  [ocornut/imgui v1.92.9b](https://github.com/ocornut/imgui/releases/tag/v1.92.9b).
- DART 6 LTS counterpart: [#3429](https://github.com/dartsim/dart/pull/3429).
  `release-6.20` hit the same upstream regression but only in a demos test —
  it has no production use of the field — so that PR is test-only and this one
  carries the user-visible fix.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` — added under
      *GUI, Examples, and Tutorials*, which already carries fixes at this
      granularity (see the #3378 overlay entry it sits beside).
- [x] Add unit tests for new functionality — the existing
      `UNIT_gui_ImGuiOverlayIndices` covers this and is demonstrated above to
      fail without the change and pass with it on the affected imgui version.
- [x] Document new methods and classes — n/a; comments added at each call site.
- [x] Add Python bindings (dartpy) if applicable — n/a.
