### PR TITLE
Validate default Python lock policy

### DIFF
--- a/.github/workflows/update_lockfiles.yml
+++ b/.github/workflows/update_lockfiles.yml
@@ -69,6 +69,62 @@ jobs:
         run: |
           set -o pipefail
           pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
+      - name: Validate default Python lock policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expected_spec=""
+          mapfile -t platforms < <(
+            pixi workspace platform list --json |
+              jq -r '.platforms[] | select(.name != "current") | .subdir'
+          )
+
+          if (( ${#platforms[@]} == 0 )); then
+            echo "No declared workspace platforms found" >&2
+            exit 1
+          fi
+
+          for platform in "${platforms[@]}"; do
+            python_package=$(
+              pixi list --locked --json -e default --platform "${platform}" '^python$'
+            )
+            if ! jq -e '
+              length == 1
+              and .[0].name == "python"
+              and .[0].requested_spec != null
+            ' <<< "${python_package}" > /dev/null; then
+              echo "Default Python lock policy failed for ${platform}:" >&2
+              jq >&2 <<< "${python_package}"
+              exit 1
+            fi
+
+            version=$(jq -r '.[0].version' <<< "${python_package}")
+            requested_spec=$(jq -r '.[0].requested_spec' <<< "${python_package}")
+            if [[ ! "${requested_spec}" =~ ^[0-9]+\.[0-9]+\.\*$ ]]; then
+              echo "Default Python must use an explicit minor-version pin;" \
+                "${platform} requested '${requested_spec}'" >&2
+              exit 1
+            fi
+
+            version_prefix=${requested_spec%\*}
+            if [[ "${version}" != "${version_prefix}"* ]]; then
+              echo "Default Python ${version} does not satisfy" \
+                "${requested_spec} on ${platform}" >&2
+              exit 1
+            fi
+
+            if [[ -z "${expected_spec}" ]]; then
+              expected_spec=${requested_spec}
+            elif [[ "${requested_spec}" != "${expected_spec}" ]]; then
+              echo "Default Python pins differ across platforms:" \
+                "expected ${expected_spec}, found ${requested_spec} on ${platform}" >&2
+              exit 1
+            fi
+
+            printf '%s: python %s (%s)\n' \
+              "${platform}" "${version}" "${requested_spec}"
+          done
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
         with:


### PR DESCRIPTION
## Summary

- Make scheduled Pixi updates fail before opening a PR when the default environment loses its explicit, cross-platform Python minor-version contract.

## Motivation / Problem

- PR #3449 repaired a generated lockfile where the default environment was not explicitly pinned and one platform silently resolved an older Python line. The maintenance workflow should detect that class of drift at generation time instead of relying on review to notice it.

## Changes / Key Changes

- After `pixi update`, enumerate every declared workspace platform.
- Require exactly one explicit default-environment Python package on each platform.
- Require a uniform `major.minor.*` requested spec and verify each resolved version matches it.
- Stop before `create-pull-request` when any platform violates the policy.

## Testing

- `pixi run lint`
- Ran the guard against `main`: Python 3.14.7 with `3.14.*` on linux-64, linux-aarch64, osx-64, osx-arm64, and win-64.
- Ran the guard against the landed `release-6.20` fix: Python 3.14.7 with `3.14.*` on linux-64, osx-64, osx-arm64, and win-64.
- Confirmed the guard rejects the pre-fix #3449 lockfile because its Python package has no explicit requested spec.
- Product build and unit tests are not applicable to this workflow-only validation change.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3449

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md not required for workflow-only maintenance
- [x] Workflow behavior covered by positive and negative local checks
- [x] No public methods or classes to document
- [x] No dartpy binding changes
