### PR TITLE
Stabilize collision benchmark comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -613,6 +613,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Stabilized strict native/reference collision performance gates with sustained
   warm measurements and randomly interleaved repetitions, reducing CPU
   frequency and benchmark-order bias without relaxing comparison thresholds.
+  ([#3456](https://github.com/dartsim/dart/pull/3456))
 - Reorganized tests and CI coverage around DART 7 components, with focused unit,
   integration, benchmark, rendering, CUDA-smoke, collision, and simulation
   gates replacing broad stale test targets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -610,6 +610,9 @@ compatibility remains on the active DART 6 LTS branch._
 
 #### Tests, Benchmarks, and Quality Gates
 
+- Stabilized strict native/reference collision performance gates with sustained
+  warm measurements and randomly interleaved repetitions, reducing CPU
+  frequency and benchmark-order bias without relaxing comparison thresholds.
 - Reorganized tests and CI coverage around DART 7 components, with focused unit,
   integration, benchmark, rendering, CUDA-smoke, collision, and simulation
   gates replacing broad stale test targets.

--- a/docs/onboarding/testing.md
+++ b/docs/onboarding/testing.md
@@ -408,6 +408,19 @@ policy work until the production registry allocator path consistently beats the
 selected baselines. Use `--only-entt-registry` for focused registry allocator
 optimization loops without rerunning the broader allocator benchmark set.
 
+The strict native/reference collision performance gate runs with:
+
+```bash
+pixi run -e collision-reference bm-collision-check
+```
+
+`scripts/check_collision_benchmarks.py` owns the sampling protocol: sustained
+one-second measurements, a short warmup, three repetitions, aggregate-only
+reporting, and random interleaving to reduce benchmark-order, thermal, and CPU
+frequency bias. Individual Pixi tasks own only their benchmark filter and ratio
+threshold; use the checker's named sampling options for a deliberate local
+override instead of passing Google Benchmark timing flags through `--`.
+
 ### DART 7 Simulation-Loop Allocation Gates
 
 For DART 7 `World::step()` work, the no-allocation contract is "after bake":

--- a/pixi.toml
+++ b/pixi.toml
@@ -1876,10 +1876,7 @@ bm-collision-check-narrow = { cmd = """
       --target bm_comparative_narrow_phase \
       --output .benchmark_results/collision_check_narrow.json \
       --benchmark-filter 'BM_NarrowPhase_(SphereSphere|BoxBox|SphereBox)_(Native|FCL|Bullet|ODE)$' \
-      --max-native-ratio 1.10 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=3
+      --max-native-ratio 1.10
 """, depends-on = [
   "config-bm-collision",
 ] }
@@ -1888,10 +1885,7 @@ bm-collision-check-narrow-adapter = { cmd = """
       --target bm_comparative_narrow_phase \
       --output .benchmark_results/collision_check_narrow_adapter.json \
       --benchmark-filter 'BM_NarrowPhaseAdapter_EdgeCases_(Native|FCL|Bullet|ODE)/(SphereSphere|BoxBox|SphereBox)_Touching/1$' \
-      --max-native-ratio 1.10 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=3
+      --max-native-ratio 1.10
 """, depends-on = [
   "config-bm-collision",
 ] }
@@ -1900,10 +1894,7 @@ bm-collision-check-narrow-raw-reference = { cmd = """
       --target bm_comparative_narrow_phase \
       --output .benchmark_results/collision_check_narrow_raw_reference.json \
       --benchmark-filter 'BM_NarrowPhaseRawReference_(SphereSphere|BoxBox|SphereBox)_(Native|FCL|Bullet|ODE)$|BM_NarrowPhaseRawReference_EdgeCases_(Native|FCL|Bullet|ODE)/(SphereSphere|BoxBox|CapsuleCapsule|SphereBox|CapsuleSphere|CapsuleBox)_(Touching|DeepPenetration|Grazing|ThinFeature)/1$' \
-      --max-native-ratio 1.10 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=3
+      --max-native-ratio 1.10
 """, depends-on = [
   "config-bm-collision",
 ] }
@@ -1912,10 +1903,7 @@ bm-collision-check-distance = { cmd = """
       --target bm_comparative_distance \
       --output .benchmark_results/collision_check_distance.json \
       --benchmark-filter 'BM_Distance_(SphereSphere|BoxBox|CapsuleCapsule)_(Native|FCL|Bullet)$' \
-      --max-native-ratio 1.10 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=3
+      --max-native-ratio 1.10
 """, depends-on = [
   "config-bm-collision",
 ] }
@@ -1924,10 +1912,7 @@ bm-collision-check-raycast = { cmd = """
       --target bm_comparative_raycast \
       --output .benchmark_results/collision_check_raycast.json \
       --benchmark-filter 'BM_Raycast_(Sphere|Box|Capsule|Cylinder|Plane)_(Native|Bullet)$' \
-      --max-native-ratio 1.10 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=3
+      --max-native-ratio 1.10
 """, depends-on = [
   "config-bm-collision",
 ] }
@@ -1937,9 +1922,7 @@ bm-collision-check-mixed = { cmd = """
       --output .benchmark_results/collision_check_mixed.json \
       --benchmark-filter 'BM_Scenario_MixedPrimitives_(Dense|Sparse)_(Native|FCL|Bullet|ODE)/(100|1000)$' \
       --max-native-ratio 1.20 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=5
+      --benchmark-repetitions 5
 """, depends-on = [
   "config-bm-collision",
 ] }
@@ -1948,20 +1931,14 @@ bm-collision-check-mesh = { cmd = """
       --target bm_scenarios_mesh_heavy \
       --output .benchmark_results/collision_check_mesh.json \
       --benchmark-filter 'BM_Scenario_MeshHeavy_(Native|FCL|Bullet)/1000$' \
-      --max-native-ratio 1.10 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=3
+      --max-native-ratio 1.10
 """, depends-on = ["config-bm-collision"] }
 bm-collision-check-raycast-batch = { cmd = """
     python scripts/check_collision_benchmarks.py \
       --target bm_scenarios_raycast_batch \
       --output .benchmark_results/collision_check_raycast_batch.json \
       --benchmark-filter 'BM_Scenario_RaycastBatch_(Dense|Sparse)_(Native|Bullet)/1000$' \
-      --max-native-ratio 1.10 \
-      -- \
-      --benchmark_min_time=1ms \
-      --benchmark_repetitions=3
+      --max-native-ratio 1.10
 """, depends-on = [
   "config-bm-collision",
 ] }

--- a/scripts/check_collision_benchmarks.py
+++ b/scripts/check_collision_benchmarks.py
@@ -51,6 +51,37 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="CMake build type for the default build directory.",
     )
     parser.add_argument(
+        "--benchmark-min-time",
+        default="1.0s",
+        help=(
+            "Minimum time per benchmark repetition. Use Google Benchmark's "
+            "'<float>s' format."
+        ),
+    )
+    parser.add_argument(
+        "--benchmark-min-warmup-time",
+        default="0.1",
+        help=(
+            "Minimum warmup time in seconds before each benchmark. Google "
+            "Benchmark expects a bare number for this option."
+        ),
+    )
+    parser.add_argument(
+        "--benchmark-repetitions",
+        type=int,
+        default=3,
+        help="Number of repetitions used to compute aggregate timings.",
+    )
+    parser.add_argument(
+        "--benchmark-random-interleaving",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Randomly interleave repeated benchmarks to reduce ordering, "
+            "thermal, and CPU-frequency bias."
+        ),
+    )
+    parser.add_argument(
         "--metric",
         choices=["cpu_time", "real_time"],
         default="cpu_time",
@@ -146,6 +177,16 @@ def _run_target(args: argparse.Namespace) -> Path:
     ]
     if args.benchmark_filter:
         cmd.append(f"--benchmark_filter={args.benchmark_filter}")
+    cmd.extend(
+        [
+            f"--benchmark_min_time={args.benchmark_min_time}",
+            f"--benchmark_min_warmup_time={args.benchmark_min_warmup_time}",
+            f"--benchmark_repetitions={args.benchmark_repetitions}",
+            "--benchmark_report_aggregates_only=true",
+        ]
+    )
+    if args.benchmark_random_interleaving:
+        cmd.append("--benchmark_enable_random_interleaving=true")
     cmd.extend(arg for arg in args.benchmark_args if arg != "--")
     subprocess.run(cmd, check=True)
     return args.output

--- a/tests/test_check_collision_benchmarks.py
+++ b/tests/test_check_collision_benchmarks.py
@@ -1,0 +1,83 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_check_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    scripts_dir = repo_root / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "dart_check_collision_benchmarks",
+        scripts_dir / "check_collision_benchmarks.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _capture_benchmark_command(module, monkeypatch, tmp_path, argv):
+    calls = []
+    build_dir = tmp_path / "build"
+    binary = build_dir / "bin" / "bm_collision"
+
+    monkeypatch.setattr(module, "_resolve_build_dir", lambda *_: build_dir)
+    monkeypatch.setattr(module, "_find_binary", lambda *_: binary)
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append((cmd, kwargs)),
+    )
+
+    args = module.parse_args(
+        [
+            "--target",
+            "bm_collision",
+            "--output",
+            str(tmp_path / "result.json"),
+            *argv,
+        ]
+    )
+    module._run_target(args)
+
+    assert len(calls) == 2
+    return calls[1][0]
+
+
+def test_run_target_uses_stable_interleaved_measurement_defaults(monkeypatch, tmp_path):
+    module = load_check_module()
+
+    command = _capture_benchmark_command(module, monkeypatch, tmp_path, [])
+
+    assert "--benchmark_min_time=1.0s" in command
+    assert "--benchmark_min_warmup_time=0.1" in command
+    assert "--benchmark_repetitions=3" in command
+    assert "--benchmark_report_aggregates_only=true" in command
+    assert "--benchmark_enable_random_interleaving=true" in command
+
+
+def test_run_target_supports_explicit_sampling_and_interleaving_opt_out(
+    monkeypatch, tmp_path
+):
+    module = load_check_module()
+
+    command = _capture_benchmark_command(
+        module,
+        monkeypatch,
+        tmp_path,
+        [
+            "--benchmark-min-time",
+            "0.5s",
+            "--benchmark-min-warmup-time",
+            "0.2",
+            "--benchmark-repetitions",
+            "5",
+            "--no-benchmark-random-interleaving",
+        ],
+    )
+
+    assert "--benchmark_min_time=0.5s" in command
+    assert "--benchmark_min_warmup_time=0.2" in command
+    assert "--benchmark_repetitions=5" in command
+    assert "--benchmark_enable_random_interleaving=true" not in command


### PR DESCRIPTION
## Summary

- Stabilize the strict native/reference collision performance gates without relaxing their comparison thresholds.

## Motivation / Problem

- Scheduled CI on `main` failed only `BM_NarrowPhaseRawReference_EdgeCases/CapsuleBox_Grazing/1`, where a sequential run measured native at 1.218x ODE against the existing 1.10 limit. Retrying the same job and commit passed at 42.4 ns native versus 61.0 ns ODE, confirming measurement-order/frequency sensitivity rather than a nanobind or collision-code regression.
- The harness also passed `--benchmark_min_time=1ms`, but the installed Google Benchmark parser documents seconds (`<float>s`) or iteration counts (`<integer>x`), so the intended duration was not explicit.

## Changes / Key Changes

- Centralize a sustained 1.0-second measurement, short warmup, three repetitions, aggregate-only reporting, and random interleaving in `check_collision_benchmarks.py`.
- Keep every existing benchmark filter and 1.10/1.20 native/reference threshold unchanged; retain five repetitions for the mixed workload.
- Add regression tests for the default protocol and explicit overrides.
- Document the sampling contract and add the DART 7 quality-gate changelog entry.

## Testing

- `pixi run lint`
- `pixi run build`
- `pixi run test-unit` (170/170 passed)
- `pixi run -- python -I scripts/run_pytest.py --repository-conftest tests/test_check_collision_benchmarks.py -q` (2 passed)
- `pixi run -e collision-reference bm-collision-check-narrow-raw-reference` (24 passed, 0 failed, 0 skipped; native 24.483 ns versus ODE 29.523 ns for the previously failing pair)
- Retried the failed hosted job on the unchanged `main` commit (passed; native 42.4 ns versus ODE 61.0 ns for the previously failing pair): https://github.com/dartsim/dart/actions/runs/33299600576
- Ran the complete hosted collision guard manually on current PR head `e771828842a` (all groups passed: 3, 3, 24, 3, 5, 4, 1, and 2 comparisons; previously failing pair median 42.2 ns native versus 65.1 ns ODE): https://github.com/dartsim/dart/actions/runs/33424822289/job/99597763492
- CUDA not run locally: this changes only the host benchmark driver, tests, task arguments, and documentation; no CUDA code or runtime path changed.
- Visual verification not applicable: this is a non-visual CI benchmark-harness change.

## Breaking Changes

- [x] None
- No public API changes.

## Related Issues / PRs (backports)

- Exposed by the scheduled `main` run above on the merge commit of #3455; unrelated to its nanobind change.
- No DART 6 backport: the affected DART 7 collision benchmark gate and CI tooling are on `main` only.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md`
- [x] Add unit tests for new functionality
- [x] Document new methods and classes (no new methods/classes; sampling protocol documented)
- [x] Add Python bindings (dartpy) if applicable (not applicable)
