### PR TITLE
Default the Filament provider to conda-forge and simplify the GUI options

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -981,7 +981,6 @@ jobs:
             extra_cxxflags: "-D__cpp_concepts=202002L -Wno-builtin-macro-redefined"
     env:
       DART_PARALLEL_JOBS: 2
-      LIBCXX_PREFIX: ${{ github.workspace }}/.pixi/envs/default
     steps:
       - name: Clean stale Linux workspace
         if: runner.os == 'Linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -449,7 +449,7 @@ compatibility remains on the active DART 6 LTS branch._
   `pip install` source builds self-sufficient. Removed the workarounds the
   default libc++ archive fetch used to require — the linux-64 libc++ pins and
   the CUDA host-compiler/glibc override — so CUDA builds use the conda
-  toolchain end to end. ([#TBD](https://github.com/dartsim/dart/pulls))
+  toolchain end to end. ([#3463](https://github.com/dartsim/dart/pull/3463))
 - Refreshed the DART 7 README and Read the Docs package guidance so the
   published install, dartpy smoke-test, and Python example paths match the
   current `package.xml`, wheel workflow, and `dart::simulation::World` API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,6 +438,18 @@ compatibility remains on the active DART 6 LTS branch._
 
 #### Build, Packaging, and Developer Tooling
 
+- Made the conda-forge `filament` package (1.76.x) the default Filament
+  provider on every workspace platform: the Pixi environments install it
+  directly, official dartpy wheels link it from the wheel environment and
+  graft its shared libraries during wheel repair, and `DART_BUILD_GUI` now
+  defaults to `ON` everywhere, failing the configure when GUI dependencies
+  are missing. `DART_USE_SYSTEM_FILAMENT=OFF` fetches the pinned upstream
+  1.76.x archive (imgui-style provider toggle, replacing
+  `DART_FETCH_FILAMENT` and `DART_FILAMENT_VERSION`), which also keeps plain
+  `pip install` source builds self-sufficient. Removed the workarounds the
+  default libc++ archive fetch used to require — the linux-64 libc++ pins and
+  the CUDA host-compiler/glibc override — so CUDA builds use the conda
+  toolchain end to end. ([#TBD](https://github.com/dartsim/dart/pulls))
 - Refreshed the DART 7 README and Read the Docs package guidance so the
   published install, dartpy smoke-test, and Python example paths match the
   current `package.xml`, wheel workflow, and `dart::simulation::World` API

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,14 +250,10 @@ dart_option(
   "Build Debug dartpy/nanobind binding objects with debug symbols" OFF
   CATEGORY performance
 )
-set(_dart_default_gui OFF)
-if(
-  CMAKE_SYSTEM_NAME STREQUAL "Linux"
-  AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$"
-)
-  set(_dart_default_gui ON)
-endif()
-dart_option(DART_BUILD_GUI "Build the Filament-backed GUI library" ${_dart_default_gui} CATEGORY build)
+# The configure fails when the GUI is enabled but Filament (or another GUI
+# dependency) is unavailable; choose the Filament provider with
+# DART_USE_SYSTEM_FILAMENT and disable the GUI explicitly for headless builds.
+dart_option(DART_BUILD_GUI "Build the Filament-backed GUI library" ON CATEGORY build)
 # OpenUSD (pxr) scene loader for dart-io. Defaults OFF because OpenUSD is not a
 # default dependency; enable only in an environment that provides pxr.
 dart_option(DART_BUILD_IO_USD "Build the OpenUSD (pxr) scene loader in dart-io" OFF CATEGORY build)
@@ -291,6 +287,23 @@ unset(DART_USE_SYSTEM_RAYLIB CACHE)
 unset(DART_RAYLIB_GIT_TAG CACHE)
 set(DART_BUILD_GUI_RAYLIB OFF)
 unset(_dart_user_set_build_gui_raylib)
+# DART_FETCH_FILAMENT and DART_FILAMENT_VERSION have been folded into
+# DART_USE_SYSTEM_FILAMENT (OFF fetches the pinned upstream archive). Warn
+# instead of erroring so build directories that still cache the retired options
+# self-heal on reconfigure, and clear the stale cache entries.
+foreach(_dart_removed_filament_option DART_FETCH_FILAMENT DART_FILAMENT_VERSION)
+  if(DEFINED ${_dart_removed_filament_option})
+    message(
+      WARNING
+      "${_dart_removed_filament_option} has been removed and is ignored. "
+      "Use DART_USE_SYSTEM_FILAMENT instead: ON discovers a packaged Filament "
+      "install (e.g. the conda-forge `filament` package, or Filament_ROOT); "
+      "OFF fetches the pinned upstream archive."
+    )
+    unset(${_dart_removed_filament_option} CACHE)
+  endif()
+endforeach()
+unset(_dart_removed_filament_option)
 dart_option(DART_STRICT_SYMBOL_VISIBILITY
   "Build shared libraries with hidden default symbol visibility so exported public ABI must use component *_API macros" OFF
   CATEGORY build
@@ -397,27 +410,8 @@ dart_option(DART_USE_SYSTEM_IMGUI
   "Use system-installed ImGui instead of fetching from GitHub (recommended for package distributions)" OFF CATEGORY system
 )
 dart_option(DART_USE_SYSTEM_FILAMENT
-  "Use system-installed Filament instead of an explicit fetched copy (recommended for package distributions)" ON CATEGORY system
+  "Use a packaged Filament install (e.g. conda-forge filament, or Filament_ROOT) instead of fetching the pinned upstream archive" ON CATEGORY system
 )
-set(_dart_fetch_filament_default OFF)
-if(
-  CMAKE_SYSTEM_NAME STREQUAL "Linux"
-  AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$"
-)
-  set(_dart_fetch_filament_default ON)
-endif()
-dart_option(DART_FETCH_FILAMENT
-  "Fetch the pinned Filament archive when a packaged Filament install is unavailable" ${_dart_fetch_filament_default} CATEGORY system
-)
-unset(_dart_default_gui)
-unset(_dart_fetch_filament_default)
-set(
-  DART_FILAMENT_VERSION
-  "1.71.3"
-  CACHE STRING
-  "Filament version for future explicit fetch support"
-)
-mark_as_advanced(DART_FILAMENT_VERSION)
 dart_option(DART_USE_SYSTEM_FMT
   "Use system-installed fmt instead of building it from source (set OFF only when system fmt is unavailable or broken)" ON CATEGORY system
 )

--- a/cmake/dart_find_dependencies.cmake
+++ b/cmake/dart_find_dependencies.cmake
@@ -498,40 +498,27 @@ endif()
 # Filament GUI
 if(DART_BUILD_GUI)
   if(DART_USE_SYSTEM_FILAMENT)
-    set(_dart_filament_find_quietly_was_defined FALSE)
-    if(DEFINED Filament_FIND_QUIETLY)
-      set(_dart_filament_find_quietly_was_defined TRUE)
-      set(_dart_filament_find_quietly_saved "${Filament_FIND_QUIETLY}")
-    endif()
-    if(DART_FETCH_FILAMENT)
-      set(Filament_FIND_QUIETLY TRUE)
-    endif()
     dart_find_package(Filament)
-    if(_dart_filament_find_quietly_was_defined)
-      set(Filament_FIND_QUIETLY "${_dart_filament_find_quietly_saved}")
-    else()
-      unset(Filament_FIND_QUIETLY)
-    endif()
-    unset(_dart_filament_find_quietly_saved)
-    unset(_dart_filament_find_quietly_was_defined)
-  elseif(NOT DART_FETCH_FILAMENT)
-    message(
-      FATAL_ERROR
-      "DART_BUILD_GUI=ON requires DART_USE_SYSTEM_FILAMENT=ON unless DART_FETCH_FILAMENT=ON is explicitly set."
-    )
-  endif()
-
-  if(NOT Filament_FOUND AND DART_FETCH_FILAMENT)
-    message(
-      STATUS
-      "Filament was not found in system paths; fetching Filament ${DART_FILAMENT_VERSION}"
-    )
-    if(NOT DART_FILAMENT_VERSION STREQUAL "1.71.3")
+    if(NOT Filament_FOUND)
       message(
         FATAL_ERROR
-        "DART_FETCH_FILAMENT has a pinned hash only for DART_FILAMENT_VERSION=1.71.3. Update the URL hash before changing the version."
+        "Filament GUI was requested (DART_BUILD_GUI=ON) but no packaged "
+        "Filament was found. Install the conda-forge `filament` package, set "
+        "Filament_ROOT to a Filament install tree that contains include/, "
+        "lib/, and bin/matc, configure with -DDART_USE_SYSTEM_FILAMENT=OFF to "
+        "fetch the pinned upstream archive, or disable the GUI with "
+        "-DDART_BUILD_GUI=OFF."
       )
     endif()
+  else()
+    # Fetch the pinned upstream Filament release archive. Keep this pin inside
+    # the conda-forge `filament` window pinned in pixi.toml so both providers
+    # tell one version story; update the per-platform hashes when bumping.
+    set(_dart_filament_fetch_version "1.76.0")
+    message(
+      STATUS
+      "DART_USE_SYSTEM_FILAMENT=OFF; fetching Filament ${_dart_filament_fetch_version}"
+    )
 
     set(_dart_filament_target_arch "${CMAKE_SYSTEM_PROCESSOR}")
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
@@ -569,7 +556,7 @@ if(DART_BUILD_GUI)
       set(_dart_filament_archive_platform "linux")
       set(
         _dart_filament_archive_hash
-        "d41963799c156e2eceff6c8f89d76ce26c3213972f63aa90add5e446a712e12e"
+        "08f96fbce1432d7a5faf34b3e96a186639b89663f8a215e6d2c36ad6cb73fa4a"
       )
     elseif(
       CMAKE_SYSTEM_NAME STREQUAL "Linux"
@@ -578,13 +565,13 @@ if(DART_BUILD_GUI)
       set(_dart_filament_archive_platform "arm-linux")
       set(
         _dart_filament_archive_hash
-        "048b5bffffcafcec7fcfa718fe65ef512514c65c00ed954e7bf340e003c146c2"
+        "e93995247a6064838290b40249eeddabbf1cc99b0be05f149675ec652b99bd35"
       )
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
       set(_dart_filament_archive_platform "mac")
       set(
         _dart_filament_archive_hash
-        "d8f253e262d731fb60f8be7d5ae6af76651bdc597d564171790bc78ac3696e04"
+        "6f067ac0931b305c32be108679cf5b0c59a3fb51753d0c64d60d290b4f28b2db"
       )
     elseif(
       CMAKE_SYSTEM_NAME STREQUAL "Windows"
@@ -593,20 +580,20 @@ if(DART_BUILD_GUI)
       set(_dart_filament_archive_platform "windows")
       set(
         _dart_filament_archive_hash
-        "67c08eb259aec39061b02b06f56bf7910ab78c97a95da03b1f83b86b61d1d7e2"
+        "1f58ebac557dd9ce9551ad67cede02db962c31a8c6abc9c87f74dc7ee50b0098"
       )
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
       message(
         FATAL_ERROR
-        "DART_FETCH_FILAMENT has a pinned Windows Filament archive only for "
-        "x64 targets, but the configured target architecture is "
-        "'${_dart_filament_target_arch}'. Provide Filament_ROOT for this "
-        "target architecture or disable DART_BUILD_GUI."
+        "DART_USE_SYSTEM_FILAMENT=OFF has a pinned Windows Filament archive "
+        "only for x64 targets, but the configured target architecture is "
+        "'${_dart_filament_target_arch}'. Provide a packaged Filament or "
+        "Filament_ROOT for this target architecture, or disable DART_BUILD_GUI."
       )
     else()
       message(
         FATAL_ERROR
-        "DART_FETCH_FILAMENT does not have a pinned Filament archive for ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}. Provide Filament_ROOT or disable DART_BUILD_GUI."
+        "DART_USE_SYSTEM_FILAMENT=OFF does not have a pinned Filament archive for ${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}. Provide a packaged Filament or Filament_ROOT, or disable DART_BUILD_GUI."
       )
     endif()
 
@@ -616,7 +603,7 @@ if(DART_BUILD_GUI)
       FetchContent_Populate(
         filament_prebuilt
         URL
-          "https://github.com/google/filament/releases/download/v${DART_FILAMENT_VERSION}/filament-v${DART_FILAMENT_VERSION}-${_dart_filament_archive_platform}.tgz"
+          "https://github.com/google/filament/releases/download/v${_dart_filament_fetch_version}/filament-v${_dart_filament_fetch_version}-${_dart_filament_archive_platform}.tgz"
         URL_HASH SHA256=${_dart_filament_archive_hash}
         DOWNLOAD_EXTRACT_TIMESTAMP
         TRUE
@@ -634,20 +621,21 @@ if(DART_BUILD_GUI)
       "Fetched Filament install tree"
       FORCE
     )
+    unset(_dart_filament_fetch_version)
     unset(_dart_filament_archive_hash)
     unset(_dart_filament_archive_platform)
     unset(_dart_filament_arch_candidate)
     unset(_dart_filament_target_arch)
     unset(_dart_filament_target_arch_lower)
+    unset(_dart_fetched_filament_root)
 
     dart_find_package(Filament)
-  endif()
-
-  if(NOT Filament_FOUND)
-    message(
-      FATAL_ERROR
-      "Filament GUI was requested (DART_BUILD_GUI=ON) but Filament could not be found. Set Filament_ROOT to a Filament install tree that contains include/, lib/, and bin/matc."
-    )
+    if(NOT Filament_FOUND)
+      message(
+        FATAL_ERROR
+        "The fetched Filament archive did not provide a usable install tree (expected include/, lib/, and bin/matc under Filament_ROOT=${Filament_ROOT})."
+      )
+    endif()
   endif()
 
   find_package(glfw3 CONFIG REQUIRED)

--- a/cmake/dart_find_filament.cmake
+++ b/cmake/dart_find_filament.cmake
@@ -1,18 +1,18 @@
-# Find a Filament install tree for the experimental Filament GUI example.
-#
-# This module accepts Filament_ROOT or FILAMENT_ROOT and creates:
+# Find Filament for the DART GUI and create:
 #   Filament::filament
 #   Filament::matc
 #
-# Upstream Filament release archives do not currently ship CMake package files,
-# so this finder also supports the archive layout:
+# The preferred provider is the conda-forge `filament` package, whose CMake
+# package config (FilamentConfig.cmake) already defines both targets; the
+# CONFIG-first find below picks it up from the environment prefix.
+#
+# Upstream Filament release archives do not ship CMake package files, so this
+# finder also accepts Filament_ROOT or FILAMENT_ROOT pointing at the archive
+# layout:
 #   include/
 #   lib/<arch>/libfilament.a
 #   bin/matc
-#
-# The planned conda-forge recipe splits build artifacts into a `filament-static`
-# development output and a `filament` tool output. Installing `filament-static`
-# should make include/, lib/, and bin/matc visible from the same prefix.
+# including the libc++/libc++abi link handling those upstream binaries need.
 
 include(FindPackageHandleStandardArgs)
 
@@ -66,8 +66,13 @@ foreach(
   _dart_filament_unset_missing_cache_path(${_dart_filament_cache_var})
 endforeach()
 
-find_package(filament CONFIG QUIET)
-find_package(Filament CONFIG QUIET)
+# Skip the packaged-config search when DART explicitly selects the fetched
+# archive (DART_USE_SYSTEM_FILAMENT=OFF): a conda environment on the search
+# path could otherwise shadow the Filament_ROOT tree this finder should use.
+if(NOT DEFINED DART_USE_SYSTEM_FILAMENT OR DART_USE_SYSTEM_FILAMENT)
+  find_package(filament CONFIG QUIET)
+  find_package(Filament CONFIG QUIET)
+endif()
 
 if(TARGET filament::filament AND NOT TARGET Filament::filament)
   add_library(Filament::filament ALIAS filament::filament)
@@ -82,6 +87,20 @@ if(TARGET matc AND NOT TARGET Filament::matc)
   add_executable(Filament::matc ALIAS matc)
 endif()
 
+# When explicit roots are given they take precedence over every default search
+# location (CMAKE_PREFIX_PATH/CMAKE_LIBRARY_PATH rank above HINTS, so e.g. a
+# conda environment on the search path could otherwise shadow Filament_ROOT):
+# probe the roots exclusively first, then fall back to the regular search for
+# rootless setups. The second call is a no-op once the cache variable is set.
+if(_dart_filament_roots)
+  find_path(
+    Filament_INCLUDE_DIR
+    NAMES filament/Engine.h
+    PATHS ${_dart_filament_roots}
+    PATH_SUFFIXES include
+    NO_DEFAULT_PATH
+  )
+endif()
 find_path(
   Filament_INCLUDE_DIR
   NAMES filament/Engine.h
@@ -125,6 +144,15 @@ foreach(
     shaders
 )
   string(REPLACE "-" "_" _lib_var "${_lib}")
+  if(_dart_filament_roots)
+    find_library(
+      Filament_${_lib_var}_LIBRARY
+      NAMES ${_lib}
+      PATHS ${_dart_filament_roots}
+      PATH_SUFFIXES ${_dart_filament_library_suffixes}
+      NO_DEFAULT_PATH
+    )
+  endif()
   find_library(
     Filament_${_lib_var}_LIBRARY
     NAMES ${_lib}
@@ -136,6 +164,15 @@ foreach(
   endif()
 endforeach()
 
+if(_dart_filament_roots)
+  find_library(
+    Filament_zstd_LIBRARY
+    NAMES zstd
+    PATHS ${_dart_filament_roots}
+    PATH_SUFFIXES ${_dart_filament_library_suffixes}
+    NO_DEFAULT_PATH
+  )
+endif()
 find_library(
   Filament_zstd_LIBRARY
   NAMES zstd
@@ -222,6 +259,15 @@ if(_dart_filament_requires_libcxx)
   endif()
 endif()
 
+if(_dart_filament_roots)
+  find_program(
+    Filament_MATC_EXECUTABLE
+    NAMES matc matc.exe
+    PATHS ${_dart_filament_roots}
+    PATH_SUFFIXES bin
+    NO_DEFAULT_PATH
+  )
+endif()
 find_program(
   Filament_MATC_EXECUTABLE
   NAMES matc matc.exe
@@ -260,7 +306,7 @@ else()
     Filament
     REQUIRED_VARS ${_dart_filament_required_vars}
     REASON_FAILURE_MESSAGE
-      "Install a Filament development package such as conda-forge filament-static, set Filament_ROOT to a Filament install tree, or provide an upstream archive plus any required libc++/libc++abi libraries."
+      "Install a Filament development package such as conda-forge `filament`, set Filament_ROOT to a Filament install tree, or provide an upstream archive plus any required libc++/libc++abi libraries."
   )
 endif()
 

--- a/cmake/dart_find_filament.cmake
+++ b/cmake/dart_find_filament.cmake
@@ -66,10 +66,29 @@ foreach(
   _dart_filament_unset_missing_cache_path(${_dart_filament_cache_var})
 endforeach()
 
-# Skip the packaged-config search when DART explicitly selects the fetched
-# archive (DART_USE_SYSTEM_FILAMENT=OFF): a conda environment on the search
-# path could otherwise shadow the Filament_ROOT tree this finder should use.
-if(NOT DEFINED DART_USE_SYSTEM_FILAMENT OR DART_USE_SYSTEM_FILAMENT)
+# An explicit root must win. Filament_ROOT only *hints* the config search, so
+# a root without CMake package files would silently lose to a packaged config
+# elsewhere on the prefix path (e.g. a conda environment): when roots are
+# given, probe them for package configs exclusively and otherwise fall through
+# to the archive-layout search below. The default config search also stays off
+# when DART explicitly selects the fetched archive
+# (DART_USE_SYSTEM_FILAMENT=OFF).
+if(_dart_filament_roots)
+  find_package(
+    filament
+    CONFIG
+    QUIET
+    PATHS ${_dart_filament_roots}
+    NO_DEFAULT_PATH
+  )
+  find_package(
+    Filament
+    CONFIG
+    QUIET
+    PATHS ${_dart_filament_roots}
+    NO_DEFAULT_PATH
+  )
+elseif(NOT DEFINED DART_USE_SYSTEM_FILAMENT OR DART_USE_SYSTEM_FILAMENT)
   find_package(filament CONFIG QUIET)
   find_package(Filament CONFIG QUIET)
 endif()

--- a/cmake/dart_find_filament.cmake
+++ b/cmake/dart_find_filament.cmake
@@ -106,11 +106,15 @@ if(TARGET matc AND NOT TARGET Filament::matc)
   add_executable(Filament::matc ALIAS matc)
 endif()
 
-# When explicit roots are given they take precedence over every default search
-# location (CMAKE_PREFIX_PATH/CMAKE_LIBRARY_PATH rank above HINTS, so e.g. a
-# conda environment on the search path could otherwise shadow Filament_ROOT):
-# probe the roots exclusively first, then fall back to the regular search for
-# rootless setups. The second call is a no-op once the cache variable is set.
+# When explicit roots are given, every Filament-owned component (headers, the
+# Filament libraries, and matc) is searched in the roots exclusively: default
+# locations (CMAKE_PREFIX_PATH/CMAKE_LIBRARY_PATH/PATH) rank above HINTS, so a
+# conda environment on the search path could otherwise shadow the requested
+# tree — or, for a component missing from an incomplete root, silently mix
+# installations. Components missing from the roots therefore stay NOTFOUND and
+# fail the package check below instead of falling through. Support libraries
+# that Filament does not ship in every tree (zstd, libc++/libc++abi) keep a
+# root-preferred search with the regular fallback.
 if(_dart_filament_roots)
   find_path(
     Filament_INCLUDE_DIR
@@ -119,13 +123,9 @@ if(_dart_filament_roots)
     PATH_SUFFIXES include
     NO_DEFAULT_PATH
   )
+else()
+  find_path(Filament_INCLUDE_DIR NAMES filament/Engine.h PATH_SUFFIXES include)
 endif()
-find_path(
-  Filament_INCLUDE_DIR
-  NAMES filament/Engine.h
-  HINTS ${_dart_filament_roots}
-  PATH_SUFFIXES include
-)
 
 set(Filament_LIBRARIES)
 
@@ -171,18 +171,20 @@ foreach(
       PATH_SUFFIXES ${_dart_filament_library_suffixes}
       NO_DEFAULT_PATH
     )
+  else()
+    find_library(
+      Filament_${_lib_var}_LIBRARY
+      NAMES ${_lib}
+      PATH_SUFFIXES ${_dart_filament_library_suffixes}
+    )
   endif()
-  find_library(
-    Filament_${_lib_var}_LIBRARY
-    NAMES ${_lib}
-    HINTS ${_dart_filament_roots}
-    PATH_SUFFIXES ${_dart_filament_library_suffixes}
-  )
   if(Filament_${_lib_var}_LIBRARY)
     list(APPEND Filament_LIBRARIES "${Filament_${_lib_var}_LIBRARY}")
   endif()
 endforeach()
 
+# zstd is a support library: prefer the copy bundled with the roots, but allow
+# the regular search to provide it for trees that do not ship one.
 if(_dart_filament_roots)
   find_library(
     Filament_zstd_LIBRARY
@@ -286,13 +288,9 @@ if(_dart_filament_roots)
     PATH_SUFFIXES bin
     NO_DEFAULT_PATH
   )
+else()
+  find_program(Filament_MATC_EXECUTABLE NAMES matc matc.exe PATH_SUFFIXES bin)
 endif()
-find_program(
-  Filament_MATC_EXECUTABLE
-  NAMES matc matc.exe
-  HINTS ${_dart_filament_roots}
-  PATH_SUFFIXES bin
-)
 
 set(_dart_filament_required_vars)
 if(NOT TARGET Filament::filament)

--- a/docs/design/dartsim_gui_toolkit_decisions.md
+++ b/docs/design/dartsim_gui_toolkit_decisions.md
@@ -359,8 +359,19 @@ Scope it honestly:
   `metal`/`webgpu` are intentionally rejected (`render_context.cpp` `parseBackend`);
   the build defaults to OpenGL. Consequence: **macOS has no Metal material path**
   and runs via OpenGL (Apple-deprecated) or MoltenVK-Vulkan. The packaged macOS
-  story (and the pinned-Filament-archive-vs-`Filament_ROOT` split across
-  platforms) needs an explicit owner before mode 3 is promoted as cross-platform.
+  story needs an explicit owner before mode 3 is promoted as cross-platform.
+- **Update (2026-08-31): Filament provider defaults to conda-forge.** The
+  `filament` package (1.76.x, all five workspace platforms, shared libs +
+  `matc` + CMake package config) is the default provider
+  (`DART_USE_SYSTEM_FILAMENT=ON`), installed by the Pixi environments and
+  grafted into official dartpy wheels during wheel repair; the linux-64 libc++
+  pins and the CUDA host-compiler workaround it obsoleted were removed.
+  `DART_USE_SYSTEM_FILAMENT=OFF` fetches the pinned upstream 1.76.x archive
+  (imgui-style provider toggle, replacing `DART_FETCH_FILAMENT`), keeping
+  non-conda source builds and sdist `pip install` self-sufficient;
+  `Filament_ROOT` remains the bring-your-own-tree escape hatch.
+  `DART_BUILD_GUI` now defaults to `ON` on every platform and fails the
+  configure when GUI dependencies are missing.
 - **Keep the binary lean.** This is a standing advantage of ImGui and a reason
   not to adopt Qt without a trigger (Qt adds bundling weight; manageable via
   conda shared libs, but real).

--- a/docs/onboarding/build-system.md
+++ b/docs/onboarding/build-system.md
@@ -53,10 +53,9 @@ wiring). For the practical how-to-build guide, see
 ### Key Build Options
 
 ```cmake
-DART_BUILD_GUI          = ON   # Filament-backed GUI; Linux x86_64 default
+DART_BUILD_GUI          = ON   # Filament-backed GUI; fails if deps are missing
+DART_USE_SYSTEM_FILAMENT = ON  # Packaged Filament / Filament_ROOT; OFF fetches
 DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS = OFF # Opt-in dart-demos diagnostics
-DART_USE_SYSTEM_FILAMENT = ON  # Use installed Filament or Filament_ROOT
-DART_FETCH_FILAMENT     = ON   # Fetch pinned Filament archive fallback
 DART_BUILD_DARTPY           = OFF  # Build Python bindings
 DART_BUILD_PROFILE          = OFF  # Enable profiling support
 DART_PROFILE_TRACY          = OFF  # Enable Tracy profiler backend (developer-only)
@@ -205,16 +204,19 @@ dart/
 
 #### DART GUI Stack
 
-- **Version:** Filament 1.71.3 for the pinned Linux x86_64 fetch.
+- **Version:** conda-forge `filament` ≥ 1.76.0, < 1.77 (pinned in `pixi.toml`;
+  matches the package's ABI run-export window).
 - **Purpose:** Maintained built-in 3D visualization and interaction renderer.
 - **Windowing/UI:** GLFW3 and Dear ImGui are private backend dependencies.
 - **Options:**
-  - `DART_BUILD_GUI=ON` builds `dart-gui`, the `dartsim` executable, and the
-    Filament smoke-test target. It defaults to `ON` only on Linux x86_64, where
-    the pinned Filament archive is supported.
-  - `DART_FETCH_FILAMENT=ON` fetches the pinned Filament archive for supported
-    platforms.
-  - `DART_USE_SYSTEM_FILAMENT=ON` discovers an installed package or `Filament_ROOT`.
+  - `DART_BUILD_GUI` builds `dart-gui`, the `dartsim` executable, and the
+    Filament smoke-test target. Defaults to `ON` on every platform; the
+    configure fails when Filament (or another GUI dependency) is unavailable,
+    so pass `OFF` explicitly for headless builds. The Pixi environments
+    install conda-forge `filament` on every workspace platform.
+  - `DART_USE_SYSTEM_FILAMENT=ON` (default) discovers a packaged Filament
+    install (conda-forge `filament` or `Filament_ROOT`); `OFF` fetches the
+    pinned upstream Filament archive, mirroring `DART_USE_SYSTEM_IMGUI`.
   - `DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS=ON` links the opt-in memory-layout
     panel/session/model into `dart-demos`. It defaults to `OFF`, which removes
     its object code and scene calls from the executable. Test builds may still
@@ -241,17 +243,23 @@ active build.
 #### Filament
 
 - **Purpose:** DART's maintained built-in GUI renderer.
-- **Options:**
-  - **Enable**: `DART_BUILD_GUI=ON`
-  - **System Mode** (`DART_USE_SYSTEM_FILAMENT=ON`): Finds an installed
-    Filament tree, typically through `Filament_ROOT`
-  - **Fetch Mode** (`DART_FETCH_FILAMENT=ON`): Explicitly fetches the pinned
-    Filament archive for supported platforms, including official dartpy wheels
+- **Provider:** The conda-forge `filament` package is the default
+  (`DART_USE_SYSTEM_FILAMENT=ON`): shared libraries, `matc` and the other
+  Filament tools, and a CMake package config exporting `Filament::filament`
+  and `Filament::matc`. Non-conda builds can instead set `Filament_ROOT` to
+  any Filament install tree with `include/`, `lib/`, and `bin/matc`
+  (`cmake/dart_find_filament.cmake` handles the upstream archive layout and
+  its libc++ linkage), or set `DART_USE_SYSTEM_FILAMENT=OFF` to fetch the
+  pinned upstream archive (kept on the same version line as the conda-forge
+  pin in `pixi.toml`). Official dartpy wheels link the conda-forge package
+  from the wheel environment and graft its shared libraries during wheel
+  repair; plain `pip install` source builds default to the fetch path via
+  `pyproject.toml`.
+- **Enable:** `DART_BUILD_GUI` (`ON` by default; see above).
 - **Public build flag:** Keep `DART_BUILD_GUI` as the single public option for
   the GUI surface. Filament is the maintained backend, so do not add
   backend-specific public toggles such as `DART_BUILD_GUI_FILAMENT`; use
-  dependency-selection options such as `DART_USE_SYSTEM_FILAMENT` and
-  `DART_FETCH_FILAMENT` for packaged versus fetched Filament.
+  `DART_USE_SYSTEM_FILAMENT` for packaged versus fetched Filament.
 - **Migration:** The full replacement plan lives in
   [gui-rendering.md](gui-rendering.md). New public GUI APIs should describe
   DART concepts and keep Filament, GLFW, Dear ImGui, OpenGL, Vulkan, Metal,

--- a/docs/onboarding/building.md
+++ b/docs/onboarding/building.md
@@ -160,7 +160,6 @@ We ship a [pixi](https://pixi.sh) environment for contributors. Pixi installs ev
    ```bash
    DART_BUILD_DARTPY_OVERRIDE=OFF pixi run config
    DART_BUILD_GUI_OVERRIDE=OFF pixi run config
-   DART_FETCH_FILAMENT_OVERRIDE=ON pixi run config
    ```
 
    On Windows, Pixi configure tasks use the Visual Studio multi-config
@@ -170,11 +169,14 @@ We ship a [pixi](https://pixi.sh) environment for contributors. Pixi installs ev
    but older Visual Studio generators are rejected by CMake.
 
    Note: Official dartpy wheels include the Filament-backed GUI surface; keep
-   `DART_BUILD_GUI` enabled when validating dartpy GUI changes. The default
-   Pixi GUI build is enabled on Linux x86_64 where the pinned Filament archive
-   is fetched by default; other supported platforms should provide
-   `Filament_ROOT`, set `DART_FETCH_FILAMENT_OVERRIDE=ON`, or set
-   `DART_BUILD_GUI_OVERRIDE=OFF` for a headless-only build.
+   `DART_BUILD_GUI` enabled when validating dartpy GUI changes. The GUI builds
+   by default on every platform: the Pixi environments install the conda-forge
+   `filament` package, so the default packaged-Filament discovery
+   (`DART_USE_SYSTEM_FILAMENT=ON`) just works; set
+   `DART_BUILD_GUI_OVERRIDE=OFF` for a headless-only build. Outside Pixi,
+   install conda-forge `filament`, point `Filament_ROOT` at a Filament install
+   tree, or set `DART_USE_SYSTEM_FILAMENT=OFF` to fetch the pinned upstream
+   archive.
 
 3. Build and test:
 
@@ -327,11 +329,12 @@ For all available CMake configuration options and their defaults, refer to [`CMa
 - `CMAKE_BUILD_TYPE` - Build configuration (Release, Debug, etc.). Only applies to single-config generators (e.g., Ninja, Unix Makefiles). Multi-config generators (Visual Studio, Xcode) expose the configuration inside the IDE or via `cmake --build` `--config`.
 - `DART_BUILD_DARTPY` - Enable Python bindings
 - `DART_BUILD_GUI` - Enable the Filament-backed GUI library, `dartsim`
-  executable, and smoke-test target. Defaults to `ON` on Linux x86_64 source
-  builds where the pinned Filament archive is supported, and `OFF` elsewhere
-  unless explicitly enabled.
-- `DART_USE_SYSTEM_FILAMENT` - Discover Filament from an installed package or `Filament_ROOT`
-- `DART_FETCH_FILAMENT` - Fetch a pinned Filament archive for supported platforms when no packaged Filament install is available
+  executable, and smoke-test target. Defaults to `ON`; the configure fails
+  when Filament (or another GUI dependency) is unavailable, so disable it
+  explicitly for headless builds.
+- `DART_USE_SYSTEM_FILAMENT` - `ON` (default) discovers a packaged Filament
+  (the conda-forge `filament` package or `Filament_ROOT`); `OFF` fetches the
+  pinned upstream Filament archive instead.
 - `DART_BUILD_TESTS` - Build C++ tests (wraps the standard `BUILD_TESTING` option)
 - `DART_BUILD_EXAMPLES` - Build the maintained example targets (defaults to `ON`; automatically skip when disabled or when `DART_BUILD_GUI=OFF`)
 - `DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS` - Link the memory-layout diagnostics

--- a/docs/onboarding/gui-rendering.md
+++ b/docs/onboarding/gui-rendering.md
@@ -61,15 +61,14 @@ implementation.
 
 ## Build Options
 
-- `DART_BUILD_GUI=ON`: builds the official Filament-backed GUI library,
-  `dartsim` executable, and smoke-test target.
-  Defaults to `ON` on Linux x86_64 source builds where DART can fetch the
-  pinned Filament archive; other platforms need an explicit Filament install or
-  `Filament_ROOT`.
-- `DART_USE_SYSTEM_FILAMENT=ON`: discovers an installed Filament tree, usually
-  through `Filament_ROOT`.
-- `DART_FETCH_FILAMENT=ON`: fetches the pinned Filament archive for supported
-  platforms when no packaged Filament install is available.
+- `DART_BUILD_GUI`: builds the official Filament-backed GUI library, `dartsim`
+  executable, and smoke-test target. Defaults to `ON` on every platform; the
+  configure fails when Filament (or another GUI dependency) is unavailable, so
+  pass `OFF` explicitly for headless builds.
+- `DART_USE_SYSTEM_FILAMENT`: `ON` (default) discovers a packaged Filament —
+  the conda-forge `filament` package (installed by the Pixi environments on
+  every workspace platform) or `Filament_ROOT` pointing at a Filament install
+  tree; `OFF` fetches the pinned upstream Filament archive.
 - `DART_ENABLE_GUI_FILAMENT_SMOKE_TESTS=ON`: registers bounded headless
   screenshot smoke tests for the DART GUI executable.
 - `DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS=ON`: links the opt-in memory-layout

--- a/pixi.lock
+++ b/pixi.lock
@@ -64,6 +64,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/entt-4.0.0-h9e02651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-h543440a_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/filament-1.76.0-h803e5e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h7118410_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
@@ -107,9 +108,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h0acdd01_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdwarf-2.1.0-h43af8da_1.conda
@@ -190,6 +188,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-lavapipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-llvmpipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-26.2.1-hf51a988_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/meshoptimizer-1.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.33.7-h877a99e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nativefiledialog-extended-1.3.0-hb524cf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -225,6 +224,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/taskflow-4.1.0-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tsl_robin_map-1.4.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-6.0.1-hf2e7533_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-3.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vulkan-headers-1.3.231.1-h924138e_0.conda
@@ -287,7 +287,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/isort-8.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libcxx-headers-22.1.8-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -360,6 +359,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/entt-4.0.0-hbd9a09b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fcl-0.7.0-h841ecf2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/filament-1.76.0-hf1f4d35_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-h0498013_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-12.1.0-h166da81_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.3-ha4b22b4_1.conda
@@ -500,6 +500,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/taskflow-4.1.0-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-11.0.0-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_hf03c496_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tsl_robin_map-1.4.0-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-6.0.1-h57aec1e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-3.0.1-h45ce4d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.26.0-h637a836_2.conda
@@ -704,6 +705,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-5.0.1-h4ff50a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/entt-4.0.0-h1b211d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fcl-0.7.0-h229c9af_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/filament-1.76.0-haecfa1e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/flann-1.9.2-h404d72e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-he6aba6a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/foonathan-memory-0.7.4-h2fb4741_1.conda
@@ -782,6 +784,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22.1.8-h8c1e6b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-hc569e58_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py314h77fa6c7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/meshoptimizer-1.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nativefiledialog-extended-1.3.0-hb171174_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.13.2-hebe015c_1.conda
@@ -812,6 +815,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/taskflow-4.1.0-hebe015c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml2-11.0.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tsl_robin_map-1.4.0-h9275861_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom-6.0.1-h14257f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom_headers-3.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libx11-1.8.13-hd3cc91f_1.conda
@@ -927,6 +931,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-5.0.1-h44d0d2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/entt-4.0.0-he4f1286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fcl-0.7.0-h64af606_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/filament-1.76.0-h9a3f704_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flann-1.9.2-h54be3fd_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h99e4e11_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/foonathan-memory-0.7.4-h784d473_1.conda
@@ -1034,6 +1039,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taskflow-4.1.0-h3feff0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-11.0.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tsl_robin_map-1.4.0-ha393de7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom-6.0.1-hb460c4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom_headers-3.0.1-hfbe1efa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libx11-1.8.13-hf948f5a_1.conda
@@ -1133,6 +1139,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-5.0.1-h5112557_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/entt-4.0.0-h56f2b75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-h16792c9_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/filament-1.76.0-h0013d43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-ha2d35b6_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h1ced75a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/foonathan-memory-0.7.4-h5112557_1.conda
@@ -1205,6 +1212,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-11.0.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tsl_robin_map-1.4.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-6.0.1-h37f4996_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-3.0.1-h477610d_1.conda
@@ -1254,6 +1262,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.194-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/entt-4.0.0-h9e02651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/filament-1.76.0-h803e5e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.4-h54a6638_1.conda
@@ -1297,9 +1306,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h0acdd01_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdwarf-2.1.0-h43af8da_1.conda
@@ -1381,6 +1387,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-lavapipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-llvmpipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-26.2.1-hf51a988_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/meshoptimizer-1.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.33.7-h877a99e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nativefiledialog-extended-1.3.0-hb524cf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -1415,6 +1422,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/taskflow-4.1.0-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tsl_robin_map-1.4.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-6.0.1-hf2e7533_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-3.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vulkan-headers-1.3.231.1-h924138e_0.conda
@@ -1487,7 +1495,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libcxx-headers-22.1.8-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.3.0-h2b852eb_104.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libnvptxcompiler-dev_linux-64-13.3.73-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.3.0-hb2c5482_104.conda
@@ -1557,6 +1564,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.194-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/entt-4.0.0-h9e02651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/filament-1.76.0-h803e5e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.4-h54a6638_1.conda
@@ -1596,9 +1604,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h0acdd01_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdwarf-2.1.0-h43af8da_1.conda
@@ -1678,6 +1683,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-lavapipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-llvmpipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-26.2.1-hf51a988_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/meshoptimizer-1.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.33.7-h877a99e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nativefiledialog-extended-1.3.0-hb524cf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -1712,6 +1718,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/taskflow-4.1.0-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tsl_robin_map-1.4.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-6.0.1-hf2e7533_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-3.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vulkan-headers-1.3.231.1-h924138e_0.conda
@@ -1774,7 +1781,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/isort-8.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libcxx-headers-22.1.8-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -1836,6 +1842,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/elfutils-0.196-h424db8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/entt-4.0.0-hbd9a09b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/epoxy-1.5.10-he30d5cf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/filament-1.76.0-hf1f4d35_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fmt-12.1.0-h166da81_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.3-ha4b22b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/foonathan-memory-0.7.4-h7ac5ae9_1.conda
@@ -1970,6 +1977,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/taskflow-4.1.0-hdc560ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tinyxml2-11.0.0-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_hf03c496_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tsl_robin_map-1.4.0-h17cf362_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-6.0.1-h57aec1e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom_headers-3.0.1-h45ce4d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wayland-1.26.0-h637a836_2.conda
@@ -2163,6 +2171,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.17.0-py313hda38850_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-5.0.1-h4ff50a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/entt-4.0.0-h1b211d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/filament-1.76.0-haecfa1e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-he6aba6a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/foonathan-memory-0.7.4-h2fb4741_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gdbm-1.18-h8a0c380_2.tar.bz2
@@ -2234,6 +2243,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22-22.1.8-h36529c3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22.1.8-h8c1e6b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py314h77fa6c7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/meshoptimizer-1.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nativefiledialog-extended-1.3.0-hb171174_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.13.2-hebe015c_1.conda
@@ -2262,6 +2272,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/taskflow-4.1.0-hebe015c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml2-11.0.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tsl_robin_map-1.4.0-h9275861_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom-6.0.1-h14257f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom_headers-3.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-had63097_3.conda
@@ -2362,6 +2373,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.17.0-py311h5836f99_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-5.0.1-h44d0d2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/entt-4.0.0-he4f1286_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/filament-1.76.0-h9a3f704_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h99e4e11_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/foonathan-memory-0.7.4-h784d473_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.25.1-h3dcc1bd_0.conda
@@ -2460,6 +2472,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taskflow-4.1.0-h3feff0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-11.0.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tsl_robin_map-1.4.0-ha393de7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom-6.0.1-hb460c4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom_headers-3.0.1-hfbe1efa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h74c22ad_3.conda
@@ -2544,6 +2557,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.17.0-py311pl5321hfd67193_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-5.0.1-h5112557_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/entt-4.0.0-h56f2b75_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/filament-1.76.0-h0013d43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h1ced75a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/foonathan-memory-0.7.4-h5112557_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.5.1-hfd05255_0.conda
@@ -2610,6 +2624,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-11.0.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tsl_robin_map-1.4.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-6.0.1-h37f4996_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-3.0.1-h477610d_1.conda
@@ -2662,6 +2677,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fcl-0.7.0-h543440a_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-9.0.1-gpl_hc45e1dd_900.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/filament-1.76.0-h803e5e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h7118410_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
@@ -2722,9 +2738,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h0acdd01_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
@@ -2841,6 +2854,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-lavapipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-llvmpipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-26.2.1-hf51a988_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/meshoptimizer-1.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.2-hb71707f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.33.7-h877a99e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
@@ -2891,6 +2905,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tsl_robin_map-1.4.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-6.0.1-hf2e7533_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-3.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
@@ -2957,7 +2972,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/isort-8.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libcxx-headers-22.1.8-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -3115,6 +3129,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/entt-4.0.0-h1b211d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fcl-0.7.0-h229c9af_8.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-9.0.1-gpl_hdb2ef11_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/filament-1.76.0-haecfa1e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/flann-1.9.2-h404d72e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-he6aba6a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.18.3-h7f3b9c9_1.conda
@@ -3257,6 +3272,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-hc569e58_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-had63097_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py314h77fa6c7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/meshoptimizer-1.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.2.1-he29b9bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mpg123-1.33.7-h8d168ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/muparser-2.3.5-hb996559_0.conda
@@ -3304,6 +3320,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2023.0.0-he3dc2fa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml2-11.0.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tsl_robin_map-1.4.0-h9275861_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom-6.0.1-h14257f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom_headers-3.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
@@ -3434,6 +3451,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/entt-4.0.0-he4f1286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fcl-0.7.0-h64af606_8.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-9.0.1-gpl_hc1f2a75_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/filament-1.76.0-h9a3f704_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flann-1.9.2-h54be3fd_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h99e4e11_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.3-h81aa574_1.conda
@@ -3622,6 +3640,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2023.0.0-he0260a5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-11.0.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tsl_robin_map-1.4.0-ha393de7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom-6.0.1-hb460c4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom_headers-3.0.1-hfbe1efa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
@@ -3736,6 +3755,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/entt-4.0.0-h56f2b75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fcl-0.7.0-h16792c9_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-9.0.1-gpl_h893bb9d_900.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/filament-1.76.0-h0013d43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-ha2d35b6_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h1ced75a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.18.3-hd47e2ca_1.conda
@@ -3873,6 +3893,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-11.0.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tsl_robin_map-1.4.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-6.0.1-h37f4996_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-3.0.1-h477610d_1.conda
@@ -3916,6 +3937,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.194-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/entt-4.0.0-h9e02651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/filament-1.76.0-h803e5e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/foonathan-memory-0.7.4-h54a6638_1.conda
@@ -3955,9 +3977,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h0acdd01_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdwarf-2.1.0-h43af8da_1.conda
@@ -4037,6 +4056,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-lavapipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesa-llvmpipe-26.2.1-h1d927ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mesalib-26.2.1-hf51a988_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/meshoptimizer-1.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.33.7-h877a99e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nativefiledialog-extended-1.3.0-hb524cf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -4074,6 +4094,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/taskflow-4.1.0-h171cf75_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tinyxml2-11.0.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tsl_robin_map-1.4.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-6.0.1-hf2e7533_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom_headers-3.0.1-h4dbf13b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.33-h2112641_0.conda
@@ -4148,7 +4169,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libcxx-headers-22.1.8-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -4313,6 +4333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.17.0-py313hda38850_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-5.0.1-h4ff50a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/entt-4.0.0-h1b211d0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/filament-1.76.0-haecfa1e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-he6aba6a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/foonathan-memory-0.7.4-h2fb4741_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gdbm-1.18-h8a0c380_2.tar.bz2
@@ -4384,6 +4405,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22-22.1.8-h36529c3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22.1.8-h8c1e6b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py314h77fa6c7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/meshoptimizer-1.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nativefiledialog-extended-1.3.0-hb171174_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nh3-0.3.7-py310h506c6ca_0.conda
@@ -4413,6 +4435,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/taskflow-4.1.0-hebe015c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tinyxml2-11.0.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tsl_robin_map-1.4.0-h9275861_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom-6.0.1-h14257f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom_headers-3.0.1-h66869c8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.33-h0bcf9e0_0.conda
@@ -4535,6 +4558,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.17.0-py311h5836f99_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-5.0.1-h44d0d2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/entt-4.0.0-he4f1286_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/filament-1.76.0-h9a3f704_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h99e4e11_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/foonathan-memory-0.7.4-h784d473_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.25.1-h3dcc1bd_0.conda
@@ -4634,6 +4658,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taskflow-4.1.0-h3feff0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tinyxml2-11.0.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tsl_robin_map-1.4.0-ha393de7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom-6.0.1-hb460c4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom_headers-3.0.1-hfbe1efa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.33-h11277c2_0.conda
@@ -4738,6 +4763,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/doxygen-1.17.0-py311pl5321hfd67193_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-5.0.1-h5112557_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/entt-4.0.0-h56f2b75_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/filament-1.76.0-h0013d43_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h1ced75a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/foonathan-memory-0.7.4-h5112557_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glfw-3.5.1-hfd05255_0.conda
@@ -4806,6 +4832,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tinyxml2-11.0.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tsl_robin_map-1.4.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom-6.0.1-h37f4996_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/urdfdom_headers-3.0.1-h477610d_1.conda
@@ -5675,6 +5702,28 @@ packages:
     - ffmpeg >=9.0.1,<10.0a0
   size: 13764967
   timestamp: 1786704879493
+- conda: https://conda.anaconda.org/conda-forge/linux-64/filament-1.76.0-h803e5e9_1.conda
+  sha256: b0ebf72e062267c46bdf5950e10c386064d9a423e91e32d0aa57b4797e3a8023
+  md5: 3ab711877e593b75d882fc564fd1d31f
+  depends:
+  - meshoptimizer
+  - tsl_robin_map
+  - zstd
+  - libstdcxx >=15
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - assimp >=6.0.5,<7.0a0
+  license: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND Zlib
+  run_exports:
+    weak:
+    - filament >=1.76.0,<1.77.0a0
+  size: 10087192
+  timestamp: 1787971489588
 - conda: https://conda.anaconda.org/conda-forge/linux-64/flann-1.9.2-h7118410_6.conda
   sha256: a14477c5399c799cdbc2363f8fad4fa9747aa30a9cb3f00efe5a70ea39383a01
   md5: b35821df209b0d29b5eee1f0d2504ea2
@@ -6702,45 +6751,6 @@ packages:
     - libcurl >=8.21.0,<9.0a0
   size: 484517
   timestamp: 1787183722915
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
-  sha256: f2841fa52775dc54b180c7f0ba3c428926f913c43ef6d06b361489999b977ef7
-  md5: 11c6906835e2b185b77201435acda628
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libcxxabi 22.1.8 h9fd08b6_0
-  - libgcc >=15
-  constrains:
-  - sysroot_linux-64 >=2.28
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  run_exports: {}
-  size: 2048158
-  timestamp: 1781673140303
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
-  sha256: e1b1e5b3acaba414612d26ca68419263cdc3ed6faf343764802b859c8652c584
-  md5: ca473af8b8425576b4c89b82a54defae
-  depends:
-  - libcxx >=22.1.8
-  - libcxx-headers >=22.1.8,<22.1.9.0a0
-  - tzdata
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  run_exports: {}
-  size: 21559
-  timestamp: 1781673152667
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
-  sha256: 99c41d393a18da1054aa37cc3026e78de1a8f0a2653f2fb9b11e10ff330aefbb
-  md5: 89319eb839c438db52f61ec439baf49e
-  depends:
-  - __glibc >=2.28,<3.0.a0
-  - libgcc >=15
-  constrains:
-  - libcxx 22.1.8.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  run_exports: {}
-  size: 168713
-  timestamp: 1781673131923
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
   sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
   md5: 40f9b31aa9cf007789867df0decd0492
@@ -8662,6 +8672,17 @@ packages:
     - mesalib >=26.2.1,<26.3.0a0
   size: 6662
   timestamp: 1787267167743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/meshoptimizer-1.0.1-h4dbf13b_1.conda
+  sha256: ecff7872e60dcb872f77dad2ed27b1b6465ad0613caeebc776fa486ee4af3f1a
+  md5: b3ae51b68c758fdd79185041a4db54aa
+  depends:
+  - libstdcxx >=15
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  run_exports: {}
+  size: 234790
+  timestamp: 1788080748329
 - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.2-hb71707f_0.conda
   sha256: 80398daac34dfe10d88c92ef64f6ff85f52950cab8b2bdfc2d00cc176ed7edff
   md5: 88450ba743694055e218d03a2fdd561e
@@ -9511,6 +9532,18 @@ packages:
     - tk >=8.6.13,<8.7.0a0
   size: 3566806
   timestamp: 1787272857910
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tsl_robin_map-1.4.0-h84d6215_0.conda
+  sha256: 79e712ed8799085501bdf651080860cd15edab1f31e63b476194252f61a435b3
+  md5: b73fdba48d83e3aba159793c1a51dc75
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 26919
+  timestamp: 1743412573095
 - conda: https://conda.anaconda.org/conda-forge/linux-64/urdfdom-6.0.1-hf2e7533_0.conda
   sha256: c4d8c6f6cf4ab81255aceb23af497ba864d64ed38d3234bdb97f5112f45a2625
   md5: 8c7007ab40976f8daf6a87ab85e66726
@@ -10477,6 +10510,26 @@ packages:
     - fcl >=0.7.0,<0.8.0a0
   size: 1454889
   timestamp: 1736132812554
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/filament-1.76.0-hf1f4d35_1.conda
+  sha256: 81cdef5e350becb496c14450808125be3037bd2f0effa5f5f0c7428f564f822c
+  md5: fab3fa2cd5911fd5af555c663f1d0b82
+  depends:
+  - tsl_robin_map
+  - zstd
+  - libstdcxx >=15
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - assimp >=6.0.5,<7.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libegl >=1.7.0,<2.0a0
+  license: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND Zlib
+  run_exports:
+    weak:
+    - filament >=1.76.0,<1.77.0a0
+  size: 10087494
+  timestamp: 1787971482272
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flann-1.9.2-h0498013_6.conda
   sha256: 2346e1941b4bb18b2ee3fc9f4683f0b2cb64feb60796341f4ca1e2aa3f225ed2
   md5: c7a0171e5c56a647a9d8568019d183e0
@@ -12515,6 +12568,17 @@ packages:
     - tk >=8.6.13,<8.7.0a0
   size: 3664220
   timestamp: 1787272859143
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tsl_robin_map-1.4.0-h17cf362_0.conda
+  sha256: bc80b5e992766419cf69e38887f91a1d22bd16f94264137a9fa1f50b70c1807d
+  md5: 6d63cecb1b5d7a8eeae0d1c16016114c
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 27186
+  timestamp: 1743412701860
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/urdfdom-6.0.1-h57aec1e_0.conda
   sha256: 8a7eaa473b9e8c3762ed30d0edea90a212df7981ddcf7a043d8f676a1ecbd919
   md5: 01536e63dceee51a3c8575d22f37956b
@@ -14951,6 +15015,25 @@ packages:
     - ffmpeg >=9.0.1,<10.0a0
   size: 11660945
   timestamp: 1786707021842
+- conda: https://conda.anaconda.org/conda-forge/osx-64/filament-1.76.0-haecfa1e_1.conda
+  sha256: ed8331cdde305cfcf59a01223407544cc0291c0486ce80ce2bc6813a0bd100f7
+  md5: 7dc4ad502363310705ec78203ae03f19
+  depends:
+  - meshoptimizer
+  - tsl_robin_map
+  - zstd
+  - libcxx >=21
+  - __osx >=11.0
+  - assimp >=6.0.5,<7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND Zlib
+  run_exports:
+    weak:
+    - filament >=1.76.0,<1.77.0a0
+  size: 8297399
+  timestamp: 1787971682931
 - conda: https://conda.anaconda.org/conda-forge/osx-64/flann-1.9.2-h404d72e_6.conda
   sha256: 2b0a27ff42130aeb75ff10c54d812e804cd0f229ba5c1f711cbbee040bcf8edd
   md5: 155325445b24f17657b22904b2c8492e
@@ -17163,6 +17246,16 @@ packages:
   run_exports: {}
   size: 26740
   timestamp: 1772445674690
+- conda: https://conda.anaconda.org/conda-forge/osx-64/meshoptimizer-1.0.1-h66869c8_1.conda
+  sha256: 26c6f988fafab71cf603a77b5a26dc35f96360a48f1253abf0ad6cd3efcf11ad
+  md5: 22b27cab6c958a7e1a0fa36a4e6ca5e5
+  depends:
+  - libcxx >=21
+  - __osx >=11.0
+  license: MIT
+  run_exports: {}
+  size: 219597
+  timestamp: 1788080883268
 - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.2.1-he29b9bd_0.conda
   sha256: 31599bfede2d1ddb7a59fdd5b4a2c4bf0ba72f683f3bcb9d07cb5446532386bf
   md5: 71a71a2bbfb3f89f2b14be38dfea90ff
@@ -17859,6 +17952,17 @@ packages:
     - tk >=8.6.13,<8.7.0a0
   size: 3512384
   timestamp: 1787272935349
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tsl_robin_map-1.4.0-h9275861_0.conda
+  sha256: dc7a970bdc0daec1634e9654c7e3ee6afb43cb7b294558e19878693fdf142ddc
+  md5: 442830d4d3ff3166bb33795fe69a0729
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 27185
+  timestamp: 1743412681518
 - conda: https://conda.anaconda.org/conda-forge/osx-64/urdfdom-6.0.1-h14257f8_0.conda
   sha256: 753c02fa93b3c316c5ffc27bac5bd3c8378d61018c0d1f6927ccb3ace5ba12b9
   md5: 5d2300b2fa7860a3b8537d5460754ad7
@@ -18688,6 +18792,24 @@ packages:
     - ffmpeg >=9.0.1,<10.0a0
   size: 10700572
   timestamp: 1786705511979
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/filament-1.76.0-h9a3f704_1.conda
+  sha256: ae8c4ac6f6b39ad72be51fa9d0e605cf1ffcdfd1d555fd0465cc7339fb79c7c0
+  md5: 25a2e4135865701063cb12a723e6cf38
+  depends:
+  - tsl_robin_map
+  - zstd
+  - libcxx >=21
+  - __osx >=11.0
+  - libpng >=1.6.58,<1.7.0a0
+  - assimp >=6.0.5,<7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND Zlib
+  run_exports:
+    weak:
+    - filament >=1.76.0,<1.77.0a0
+  size: 7788924
+  timestamp: 1787971537987
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flann-1.9.2-h54be3fd_6.conda
   sha256: e2a69d0e279db0b32d16de3cbed7584ac40b20fac4ce4683af769eb99004702c
   md5: 9b61c0117b7631d3c6a0a0a3aa330f46
@@ -21589,6 +21711,17 @@ packages:
     - tk >=8.6.13,<8.7.0a0
   size: 3342183
   timestamp: 1787272852357
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tsl_robin_map-1.4.0-ha393de7_0.conda
+  sha256: 866175ba3c6d15aed8cc78440de5ee19cfa955161e2c6b50f91f3a49fea172aa
+  md5: b6a6678201527a72a5812b0c15ac16b6
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 27143
+  timestamp: 1743412699723
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/urdfdom-6.0.1-hb460c4f_0.conda
   sha256: 303c4b30cb1d3f3c2ff37c217e73aa9fb05f684d43b8eca174215f36e4d33727
   md5: bc01e8d73814bd6344af00c87d4eef17
@@ -22235,6 +22368,25 @@ packages:
     - ffmpeg >=9.0.1,<10.0a0
   size: 11511745
   timestamp: 1786705688472
+- conda: https://conda.anaconda.org/conda-forge/win-64/filament-1.76.0-h0013d43_1.conda
+  sha256: 6a7a6c837019ede51e379a86485f3994423402bcd6f37a57f6658f841b9839dc
+  md5: 1e7d56e9fedb1c54845529e8da3a5e68
+  depends:
+  - tsl_robin_map
+  - zstd
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - assimp >=6.0.5,<7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND Zlib
+  run_exports:
+    weak:
+    - filament >=1.76.0,<1.77.0a0
+  size: 10467727
+  timestamp: 1787971500605
 - conda: https://conda.anaconda.org/conda-forge/win-64/flann-1.9.2-ha2d35b6_6.conda
   sha256: 455086b4b0a47f07a98cbe45881b2f58c5a1b988031ff01f64e49fd195429757
   md5: d2cecad14b8f198ff5802be8705d8a75
@@ -24551,6 +24703,18 @@ packages:
     - tk >=8.6.13,<8.7.0a0
   size: 3782376
   timestamp: 1787272860855
+- conda: https://conda.anaconda.org/conda-forge/win-64/tsl_robin_map-1.4.0-hc790b64_0.conda
+  sha256: b39a66b1e26ff934263612c916c3cb5e7dff0b03b496c497b38456ecb69c6f27
+  md5: 4c0f2b3b652c8bd6d700c6d24b66a592
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 28177
+  timestamp: 1743412673405
 - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
   sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
   md5: 71b24316859acd00bdb8b38f5e2ce328

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,6 +17,7 @@ console_bridge = ">=1.0.2,<2"
 doxygen = ">=1.13.2,<2"
 eigen = ">=5.0.1,<6"
 entt = ">=4.0.0,<5"
+filament = ">=1.76.0,<1.77"
 foonathan-memory = ">=0.7.4,<0.8"
 fmt = ">=12.1.0,<13"
 gersemi = ">=0.24.0,<0.25"
@@ -90,13 +91,7 @@ if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ] \
 fi
 DART_BUILD_COLLISION_REFERENCE_TESTS_VALUE=${DART_BUILD_COLLISION_REFERENCE_TESTS_OVERRIDE:-OFF}
 DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_VALUE=${DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_OVERRIDE:-OFF}
-DART_FILAMENT_PLATFORM_DEFAULT=OFF
-case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64|Linux-amd64)
-    DART_FILAMENT_PLATFORM_DEFAULT=ON
-    ;;
-esac
-DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-${DART_FILAMENT_PLATFORM_DEFAULT}}
+DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-ON}
 DART_BUILD_EXAMPLES_VALUE=${DART_BUILD_EXAMPLES_OVERRIDE:-ON}
 DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS_VALUE=${DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS_OVERRIDE:-OFF}
 # The demos panel needs the library instrumentation, so it defaults to the demos
@@ -106,11 +101,6 @@ DART_BUILD_TUTORIALS_VALUE=${DART_BUILD_TUTORIALS_OVERRIDE:-ON}
 DART_BUILD_TESTS_VALUE=${DART_BUILD_TESTS_OVERRIDE:-ON}
 DART_USE_MOLD_VALUE=${DART_USE_MOLD_OVERRIDE:-OFF}
 DART_USE_SYSTEM_IMGUI_VALUE=${DART_USE_SYSTEM_IMGUI_OVERRIDE:-{{ use_system_imgui }}}
-DART_USE_SYSTEM_FILAMENT_VALUE=${DART_USE_SYSTEM_FILAMENT_OVERRIDE:-ON}
-DART_FETCH_FILAMENT_VALUE=${DART_FETCH_FILAMENT_OVERRIDE:-}
-if [ -z "$DART_FETCH_FILAMENT_VALUE" ]; then
-  DART_FETCH_FILAMENT_VALUE=${DART_FILAMENT_PLATFORM_DEFAULT}
-fi
 DART_ENABLE_GUI_FILAMENT_SMOKE_TESTS_VALUE=${DART_ENABLE_GUI_FILAMENT_SMOKE_TESTS_OVERRIDE:-OFF}
 DART_DISABLE_COMPILER_CACHE_VALUE=${DART_DISABLE_COMPILER_CACHE:-OFF}
 if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ] \
@@ -180,8 +170,6 @@ cmake \
   -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
   -DDART_USE_SYSTEM_GOOGLETEST=ON \
   -DDART_USE_SYSTEM_IMGUI=${DART_USE_SYSTEM_IMGUI_VALUE} \
-  -DDART_USE_SYSTEM_FILAMENT=${DART_USE_SYSTEM_FILAMENT_VALUE} \
-  -DDART_FETCH_FILAMENT=${DART_FETCH_FILAMENT_VALUE} \
   -DDART_ENABLE_GUI_FILAMENT_SMOKE_TESTS=${DART_ENABLE_GUI_FILAMENT_SMOKE_TESTS_VALUE} \
   -DDART_USE_SYSTEM_NANOBIND=OFF \
   -DDART_USE_SYSTEM_TRACY=OFF \
@@ -604,13 +592,7 @@ if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ] \
 fi
 DART_BUILD_COLLISION_REFERENCE_TESTS_VALUE=${DART_BUILD_COLLISION_REFERENCE_TESTS_OVERRIDE:-OFF}
 DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_VALUE=${DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_OVERRIDE:-OFF}
-DART_FILAMENT_PLATFORM_DEFAULT=OFF
-case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64|Linux-amd64)
-    DART_FILAMENT_PLATFORM_DEFAULT=ON
-    ;;
-esac
-DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-${DART_FILAMENT_PLATFORM_DEFAULT}}
+DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-ON}
 DART_BUILD_EXAMPLES_VALUE=${DART_BUILD_EXAMPLES_OVERRIDE:-ON}
 DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS_VALUE=${DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS_OVERRIDE:-OFF}
 # The demos panel needs the library instrumentation, so it defaults to the demos
@@ -619,11 +601,6 @@ DART_BUILD_MEMORY_DIAGNOSTICS_VALUE=${DART_BUILD_MEMORY_DIAGNOSTICS_OVERRIDE:-${
 DART_BUILD_TUTORIALS_VALUE=${DART_BUILD_TUTORIALS_OVERRIDE:-ON}
 DART_BUILD_TESTS_VALUE=${DART_BUILD_TESTS_OVERRIDE:-ON}
 DART_USE_SYSTEM_IMGUI_VALUE=${DART_USE_SYSTEM_IMGUI_OVERRIDE:-ON}
-DART_USE_SYSTEM_FILAMENT_VALUE=${DART_USE_SYSTEM_FILAMENT_OVERRIDE:-ON}
-DART_FETCH_FILAMENT_VALUE=${DART_FETCH_FILAMENT_OVERRIDE:-}
-if [ -z "$DART_FETCH_FILAMENT_VALUE" ]; then
-  DART_FETCH_FILAMENT_VALUE=${DART_FILAMENT_PLATFORM_DEFAULT}
-fi
 DART_ENABLE_GUI_FILAMENT_SMOKE_TESTS_VALUE=${DART_ENABLE_GUI_FILAMENT_SMOKE_TESTS_OVERRIDE:-OFF}
 DART_DISABLE_COMPILER_CACHE_VALUE=${DART_DISABLE_COMPILER_CACHE:-OFF}
 if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ] \
@@ -692,8 +669,6 @@ cmake \
   -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
   -DDART_USE_SYSTEM_GOOGLETEST=ON \
   -DDART_USE_SYSTEM_IMGUI=${DART_USE_SYSTEM_IMGUI_VALUE} \
-  -DDART_USE_SYSTEM_FILAMENT=${DART_USE_SYSTEM_FILAMENT_VALUE} \
-  -DDART_FETCH_FILAMENT=${DART_FETCH_FILAMENT_VALUE} \
   -DDART_ENABLE_GUI_FILAMENT_SMOKE_TESTS=${DART_ENABLE_GUI_FILAMENT_SMOKE_TESTS_VALUE} \
   -DDART_USE_SYSTEM_NANOBIND=OFF \
   -DDART_USE_SYSTEM_TRACY=OFF \
@@ -964,70 +939,37 @@ if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ] \
     fi
   fi
 fi
-# Host compiler for the CUDA-enabled dartpy + GUI build. The prebuilt Filament
-# libraries reference glibc symbols newer than the conda portability sysroot
-# (glibc 2.28) exports, so the conda toolchain cannot link the GUI. Build the C
-# and C++ sources (and the final link) with the host system compiler instead (it
-# ships a newer glibc, exactly as the default environment already does), while
-# CUDA itself keeps using the conda nvcc (pinned so CMake does not pick up an
-# older system nvcc); the conda env's NVCC_PREPEND_FLAGS already routes nvcc's
-# host pass through the conda compiler, and the resulting .cu objects only need
-# older glibc symbols, so the system-compiler final link resolves everything.
-# Overridable via DART_CUDA_HOST_CC / DART_CUDA_HOST_CXX for hosts/CI whose
-# system compiler lives elsewhere. No effect on non-CUDA builds.
+# CUDA toolchain for the CUDA-enabled dartpy + GUI build. Pin nvcc to the conda
+# toolkit so CMake does not pick up an older system nvcc; the conda compiler
+# (activated by the cuda feature) builds the C/C++ sources and the final link,
+# and nvcc's host pass follows it via the env's NVCC_PREPEND_FLAGS. The
+# packaged conda-forge Filament is built against the conda sysroot, so the
+# system-host-compiler/glibc workaround that used to live here is unnecessary.
+# The cache guard resets build dirs whose cached compilers no longer match the
+# current toolchain (including dirs configured by the retired workaround) and
+# clears a stale CUDA launcher (sccache can leave nvcc/fatbinary without its
+# generated PTX input). No effect on non-CUDA builds.
 COMPILER_DEFS=""
 if [ "${DART_ENABLE_EXPERIMENTAL_CUDA_VALUE}" = "ON" ]; then
-  DART_CUDA_HOST_CC_VALUE=${DART_CUDA_HOST_CC:-/usr/bin/cc}
-  DART_CUDA_HOST_CXX_VALUE=${DART_CUDA_HOST_CXX:-/usr/bin/c++}
-  export CC=${DART_CUDA_HOST_CC_VALUE}
-  export CXX=${DART_CUDA_HOST_CXX_VALUE}
-  # The conda libc++ (which Filament needs) lives in the conda lib dir. The
-  # system compiler does not search it by default, and the conda LDFLAGS -L /
-  # -rpath are not reliably applied to every target, so add the conda lib dir as
-  # both a link-time search path (so Filaments -lc++ resolves) and a runtime
-  # rpath (so the conda GUI libraries such as libglfw load) via
-  # CMAKE_CXX_STANDARD_LIBRARIES, which is appended to every C++ link. Scoped to
-  # the cuda build, so the default environment is untouched.
-  #
-  # Use the system compiler as nvcc's host too (CMAKE_CUDA_HOST_COMPILER), so C,
-  # C++, and the CUDA host pass all target the same host glibc (2.38). Otherwise
-  # nvcc's host defaults to the conda compiler (via NVCC_PREPEND_FLAGS), whose
-  # startup objects and implicit link drag the conda sysroot glibc (libm/librt
-  # linker scripts with absolute /lib64 paths, and __libc_csu_* startup symbols
-  # removed in glibc 2.34) that the system-compiler final link cannot resolve.
-  # CMAKE_CUDA_RUNTIME_LIBRARY=Shared links the shared libcudart (the default
-  # Static runtime drags the same conda sysroot deps).
-  COMPILER_DEFS="-DCMAKE_C_COMPILER=${DART_CUDA_HOST_CC_VALUE} -DCMAKE_CXX_COMPILER=${DART_CUDA_HOST_CXX_VALUE} -DCMAKE_CUDA_COMPILER=${CONDA_PREFIX}/bin/nvcc -DCMAKE_CUDA_HOST_COMPILER=${DART_CUDA_HOST_CXX_VALUE} -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared -DCMAKE_CXX_STANDARD_LIBRARIES=-Wl,-L,${CONDA_PREFIX}/lib,-rpath,${CONDA_PREFIX}/lib"
-  # nvcc still reports the conda CUDA toolkit's sysroot lib dirs as implicit link
-  # dirs, so -lm/-lrt could resolve to the conda sysroot glibc linker scripts
-  # (absolute /lib64 paths). Prepend the host multiarch lib dir so they resolve
-  # to the valid host glibc first. Safe now that the CUDA host is the system
-  # compiler too. Defaults to the linux-64 layout (the cuda feature is linux-64
-  # only); override with DART_CUDA_HOST_LIBDIR if your distro differs.
-  DART_CUDA_HOST_LIBDIR_VALUE=${DART_CUDA_HOST_LIBDIR:-/usr/lib/x86_64-linux-gnu}
-  export LDFLAGS="-L${DART_CUDA_HOST_LIBDIR_VALUE} ${LDFLAGS:-}"
+  COMPILER_DEFS="-DCMAKE_CUDA_COMPILER=${CONDA_PREFIX}/bin/nvcc"
   CMAKE_BUILD_DIR=build/$PIXI_ENVIRONMENT_NAME/cpp/${BUILD_DIR_NAME}
   CMAKE_CACHE=${CMAKE_BUILD_DIR}/CMakeCache.txt
   if [ -f "${CMAKE_CACHE}" ]; then
     cached_c_compiler=
     cached_cxx_compiler=
     cached_cuda_compiler=
-    cached_cuda_host_compiler=
     cached_cuda_compiler_launcher=
     while IFS='=' read -r cache_key cache_value; do
       case "${cache_key}" in
         CMAKE_C_COMPILER:*) cached_c_compiler=${cache_value} ;;
         CMAKE_CXX_COMPILER:*) cached_cxx_compiler=${cache_value} ;;
         CMAKE_CUDA_COMPILER:*) cached_cuda_compiler=${cache_value} ;;
-        CMAKE_CUDA_HOST_COMPILER:*) cached_cuda_host_compiler=${cache_value} ;;
         CMAKE_CUDA_COMPILER_LAUNCHER:*) cached_cuda_compiler_launcher=${cache_value} ;;
       esac
     done < "${CMAKE_CACHE}"
-    if [ "${cached_c_compiler}" != "${DART_CUDA_HOST_CC_VALUE}" ] \
-      || [ "${cached_cxx_compiler}" != "${DART_CUDA_HOST_CXX_VALUE}" ] \
-      || [ "${cached_cuda_compiler}" != "${CONDA_PREFIX}/bin/nvcc" ] \
-      || { [ -n "${cached_cuda_host_compiler}" ] \
-        && [ "${cached_cuda_host_compiler}" != "${DART_CUDA_HOST_CXX_VALUE}" ]; } \
+    if [ "${cached_cuda_compiler}" != "${CONDA_PREFIX}/bin/nvcc" ] \
+      || { [ -n "${CC:-}" ] && [ "${cached_c_compiler}" != "${CC}" ]; } \
+      || { [ -n "${CXX:-}" ] && [ "${cached_cxx_compiler}" != "${CXX}" ]; } \
       || { [ -z "${CMAKE_CUDA_COMPILER_LAUNCHER:-}" ] \
         && [ -n "${cached_cuda_compiler_launcher}" ]; }; then
       echo "CMake compiler cache changed for ${CMAKE_BUILD_DIR}; resetting cache metadata."
@@ -1507,7 +1449,7 @@ test-dart-gui-smoke = { cmd = [
   "--pixi-smoke",
 ], depends-on = [
   "config",
-], env = { BUILD_TYPE = "Release", DART_VERBOSE = "OFF", DART_BUILD_DARTPY_OVERRIDE = "OFF", DART_BUILD_GUI_OVERRIDE = "ON", DART_FETCH_FILAMENT_OVERRIDE = "ON", DART_USE_SYSTEM_FILAMENT_OVERRIDE = "OFF" } }
+], env = { BUILD_TYPE = "Release", DART_VERBOSE = "OFF", DART_BUILD_DARTPY_OVERRIDE = "OFF", DART_BUILD_GUI_OVERRIDE = "ON" } }
 
 test-filament-gui-smoke = { depends-on = ["test-dart-gui-smoke"] }
 
@@ -1544,14 +1486,7 @@ DART_BUILD_DARTPY_VALUE=${DART_BUILD_DARTPY_OVERRIDE:-OFF}
 DART_BUILD_COLLISION_REFERENCE_TESTS_VALUE=${DART_BUILD_COLLISION_REFERENCE_TESTS_OVERRIDE:-OFF}
 DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_VALUE=${DART_BUILD_COLLISION_REFERENCE_BENCHMARKS_OVERRIDE:-OFF}
 DART_DISABLE_COMPILER_CACHE_VALUE=${DART_DISABLE_COMPILER_CACHE:-OFF}
-DART_FILAMENT_PLATFORM_DEFAULT=OFF
-case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64|Linux-amd64)
-    DART_FILAMENT_PLATFORM_DEFAULT=ON
-    ;;
-esac
-DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-${DART_FILAMENT_PLATFORM_DEFAULT}}
-DART_FETCH_FILAMENT_VALUE=${DART_FETCH_FILAMENT_OVERRIDE:-${DART_FILAMENT_PLATFORM_DEFAULT}}
+DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-ON}
 if [ "${SCCACHE_GHA_ENABLED:-}" = "false" ]; then
   DART_DISABLE_COMPILER_CACHE_VALUE=ON
   unset DART_COMPILER_CACHE
@@ -1593,7 +1528,6 @@ cmake \
     -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
     -DDART_USE_SYSTEM_GOOGLETEST=ON \
     -DDART_USE_SYSTEM_IMGUI=ON \
-    -DDART_FETCH_FILAMENT=${DART_FETCH_FILAMENT_VALUE} \
     -DDART_USE_SYSTEM_TRACY=OFF \
     -DDART_VERBOSE=$DART_VERBOSE \
     ${HOST_LINKER_DEFS[@]+"${HOST_LINKER_DEFS[@]}"} \
@@ -1660,7 +1594,7 @@ dartsim = { cmd = [
   "python",
   "scripts/run_cpp_example.py",
   "dartsim",
-], env = { BUILD_TYPE = "Release", DART_VERBOSE = "OFF", DART_BUILD_DARTPY_OVERRIDE = "OFF", DART_BUILD_GUI_OVERRIDE = "ON", DART_FETCH_FILAMENT_OVERRIDE = "ON", DART_USE_SYSTEM_FILAMENT_OVERRIDE = "OFF", DART_USE_SYSTEM_IMGUI_OVERRIDE = "OFF" } }
+], env = { BUILD_TYPE = "Release", DART_VERBOSE = "OFF", DART_BUILD_DARTPY_OVERRIDE = "OFF", DART_BUILD_GUI_OVERRIDE = "ON", DART_USE_SYSTEM_IMGUI_OVERRIDE = "OFF" } }
 
 # Diagnostic (not part of the default test suite): render the dartsim scene
 # headlessly to both the swapchain and an offscreen Filament RenderTarget and
@@ -1677,7 +1611,7 @@ gui-offscreen-parity = { cmd = [
   "--backend",
   "opengl",
   "--demo",
-], env = { BUILD_TYPE = "Release", DART_VERBOSE = "OFF", DART_GUI_OFFSCREEN_PARITY = "1", DART_BUILD_DARTPY_OVERRIDE = "OFF", DART_BUILD_GUI_OVERRIDE = "ON", DART_FETCH_FILAMENT_OVERRIDE = "ON", DART_USE_SYSTEM_FILAMENT_OVERRIDE = "OFF", DART_USE_SYSTEM_IMGUI_OVERRIDE = "OFF" } }
+], env = { BUILD_TYPE = "Release", DART_VERBOSE = "OFF", DART_GUI_OFFSCREEN_PARITY = "1", DART_BUILD_DARTPY_OVERRIDE = "OFF", DART_BUILD_GUI_OVERRIDE = "ON", DART_USE_SYSTEM_IMGUI_OVERRIDE = "OFF" } }
 
 # Launch the consolidated dart-demos GUI app (all GUI examples as runtime-
 # switchable scenes). Builds against the fetched ImGui docking branch
@@ -2101,17 +2035,7 @@ config-install = { cmd = [
   "-lc",
   """
 set -euo pipefail
-DART_FILAMENT_PLATFORM_DEFAULT=OFF
-case "$(uname -s)-$(uname -m)" in
-  Linux-x86_64|Linux-amd64)
-    DART_FILAMENT_PLATFORM_DEFAULT=ON
-    ;;
-esac
-DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-${DART_FILAMENT_PLATFORM_DEFAULT}}
-DART_FETCH_FILAMENT_VALUE=${DART_FETCH_FILAMENT_OVERRIDE:-}
-if [ -z "$DART_FETCH_FILAMENT_VALUE" ]; then
-  DART_FETCH_FILAMENT_VALUE=${DART_FILAMENT_PLATFORM_DEFAULT}
-fi
+DART_BUILD_GUI_VALUE=${DART_BUILD_GUI_OVERRIDE:-ON}
 DART_DISABLE_COMPILER_CACHE_VALUE=${DART_DISABLE_COMPILER_CACHE:-OFF}
 if [ "${SCCACHE_GHA_ENABLED:-}" = "false" ]; then
   DART_DISABLE_COMPILER_CACHE_VALUE=ON
@@ -2153,7 +2077,6 @@ cmake \
     -DDART_USE_SYSTEM_GOOGLEBENCHMARK=ON \
     -DDART_USE_SYSTEM_GOOGLETEST=ON \
     -DDART_USE_SYSTEM_IMGUI=ON \
-    -DDART_FETCH_FILAMENT=${DART_FETCH_FILAMENT_VALUE} \
     -DDART_USE_SYSTEM_NANOBIND=OFF \
     -DDART_USE_SYSTEM_TRACY=OFF \
     -DDART_VERBOSE=$DART_VERBOSE \
@@ -2608,9 +2531,6 @@ libglvnd = ">=1.7.0,<2"
 libgl-devel = ">=1.7.0,<2"
 libglu = ">=9.0.3,<10"
 vulkan-headers = ">=1.3.231.1,<2"
-libcxx = ">=22.1.7,<23"
-libcxxabi = ">=22.1.7,<23"
-libcxx-devel = ">=22.1.7,<23"
 
 ################################################################################
 # osx-64
@@ -3137,7 +3057,6 @@ DART_BUILD_DARTPY_OVERRIDE = "OFF"
 DART_BUILD_GUI_OVERRIDE = "OFF"
 DART_BUILD_EXAMPLES_OVERRIDE = "OFF"
 DART_BUILD_TUTORIALS_OVERRIDE = "OFF"
-DART_FETCH_FILAMENT_OVERRIDE = "OFF"
 
 [feature.cuda.dependencies]
 cuda-version = ">=13.3,<14"
@@ -3300,8 +3219,9 @@ test-gz = { cmd = """
 # - All CMake configuration MUST be done via CMAKE_ARGS environment variable
 # - DO NOT use --config-settings=cmake.define.XXX (it doesn't work reliably with scikit-build-core)
 # - DART_BUILD_GUI controls whether dartpy.gui submodule is included (see python/dartpy/CMakeLists.txt)
-# - Wheel builds enable the Filament-backed dartpy.gui surface and fetch the
-#   pinned upstream Filament SDK when a packaged Filament provider is not used.
+# - Wheel builds enable the Filament-backed dartpy.gui surface against the
+#   conda-forge `filament` package from the wheel environment; the repair step
+#   (auditwheel/delocate/delvewheel) grafts its shared libraries into the wheel.
 
 #======================
 # Feature: Python 3.14 Wheel Building

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,11 @@ build-type = "Release"
 BUILD_SHARED_LIBS = "OFF"
 DART_BUILD_DARTPY = "ON"
 DART_BUILD_GUI = "ON"
+# Plain `pip install` fetches the pinned upstream Filament archive so source
+# builds work without a packaged Filament; scripts/wheel_build.py overrides
+# this to the conda-forge `filament` package for official wheels (its shared
+# libraries are grafted during wheel repair).
 DART_USE_SYSTEM_FILAMENT = "OFF"
-DART_FETCH_FILAMENT = "ON"
 DART_BUILD_COLLISION_REFERENCE_TESTS = "OFF"
 DART_BUILD_COLLISION_REFERENCE_BENCHMARKS = "OFF"
 DART_ENABLE_SIMD = "OFF"

--- a/python/tests/unit/test_pixi_cuda_py_demos_task.py
+++ b/python/tests/unit/test_pixi_cuda_py_demos_task.py
@@ -41,8 +41,12 @@ def test_config_py_resets_stale_cuda_compiler_cache_before_cmake() -> None:
     assert "CMAKE_C_COMPILER:*)" in script
     assert "CMAKE_CXX_COMPILER:*)" in script
     assert "CMAKE_CUDA_COMPILER:*)" in script
-    assert "CMAKE_CUDA_HOST_COMPILER:*)" in script
     assert "CMAKE_CUDA_COMPILER_LAUNCHER:*)" in script
+    # The guard pins nvcc to the conda toolkit and compares the cached C/C++
+    # compilers against the active conda toolchain (CC/CXX) when set.
+    assert '[ "${cached_cuda_compiler}" != "${CONDA_PREFIX}/bin/nvcc" ]' in script
+    assert '[ "${cached_c_compiler}" != "${CC}" ]' in script
+    assert '[ "${cached_cxx_compiler}" != "${CXX}" ]' in script
     assert '[ -z "${CMAKE_CUDA_COMPILER_LAUNCHER:-}" ]' in script
     assert '[ -n "${cached_cuda_compiler_launcher}" ]' in script
     assert 'rm -f "${CMAKE_CACHE}"' in script

--- a/scripts/run_cpp_example.py
+++ b/scripts/run_cpp_example.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import platform
 import re
 import shutil
 import subprocess
@@ -329,49 +328,9 @@ def _env_option(env: dict[str, str], name: str, default: str) -> str:
     return env.get(name, default)
 
 
-def _is_linux_x86_64() -> bool:
-    machine = platform.machine().lower()
-    return sys.platform.startswith("linux") and machine in {"x86_64", "amd64"}
-
-
-def _has_filament_root(env: dict[str, str]) -> bool:
-    return bool(env.get("Filament_ROOT") or env.get("FILAMENT_ROOT"))
-
-
-def _default_fetch_filament(env: dict[str, str]) -> str:
-    if _has_filament_root(env):
-        return "OFF"
-    return "ON" if _is_linux_x86_64() else "OFF"
-
-
-def _default_use_system_filament(fetch_filament: str) -> str:
-    return "OFF" if fetch_filament.upper() == "ON" else "ON"
-
-
 def _prepend_env_path(env: dict[str, str], name: str, value: Path) -> None:
     current = env.get(name)
     env[name] = f"{value}{os.pathsep}{current}" if current else str(value)
-
-
-def _apply_libcxx_prefix(env: dict[str, str]) -> None:
-    prefix = env.get("LIBCXX_PREFIX")
-    if not prefix:
-        conda_prefix = env.get("CONDA_PREFIX")
-        if conda_prefix:
-            lib_dir = Path(conda_prefix) / "lib"
-            if any(lib_dir.glob("libc++.*")) and any(lib_dir.glob("libc++abi.*")):
-                prefix = conda_prefix
-    if not prefix:
-        return
-
-    lib_dir = Path(prefix) / "lib"
-    _prepend_env_path(env, "CMAKE_LIBRARY_PATH", lib_dir)
-    if sys.platform.startswith("linux"):
-        _prepend_env_path(env, "LD_LIBRARY_PATH", lib_dir)
-    elif sys.platform == "darwin":
-        _prepend_env_path(env, "DYLD_LIBRARY_PATH", lib_dir)
-    elif os.name == "nt":
-        _prepend_env_path(env, "PATH", Path(prefix) / "bin")
 
 
 def _configure(
@@ -390,21 +349,10 @@ def _option_override(
 
 
 def _ensure_filament(build_dir: Path, env: dict[str, str], smoke: bool) -> None:
-    fetch_filament = _env_option(
-        env, "DART_FETCH_FILAMENT_OVERRIDE", _default_fetch_filament(env)
-    )
-    use_system_filament = _env_option(
-        env,
-        "DART_USE_SYSTEM_FILAMENT_OVERRIDE",
-        _default_use_system_filament(fetch_filament),
-    )
-
     desired = {
         "DART_BUILD_GUI": "ON",
         "DART_BUILD_EXAMPLES": "ON",
         "DART_BUILD_TUTORIALS": "OFF",
-        "DART_USE_SYSTEM_FILAMENT": use_system_filament,
-        "DART_FETCH_FILAMENT": fetch_filament,
     }
     if smoke:
         desired["DART_BUILD_TESTS"] = "ON"
@@ -611,7 +559,6 @@ def _runtime_env(
     env: dict[str, str], build_dir: Path, software_gl: bool
 ) -> dict[str, str]:
     runtime_env = env.copy()
-    _apply_libcxx_prefix(runtime_env)
     _prepend_runtime_library_path(runtime_env, build_dir)
     if software_gl:
         runtime_env.setdefault("LIBGL_ALWAYS_SOFTWARE", "1")
@@ -800,7 +747,6 @@ def run(
     env = os.environ.copy()
     env["BUILD_TYPE"] = build_type
     env["CMAKE_BUILD_DIR"] = str(build_dir)
-    _apply_libcxx_prefix(env)
 
     # Pin the ImGui variant for GUI runs so a launch never inherits a stale
     # build-cache state from a previous run: the docked workspaces (editor,

--- a/scripts/wheel_build.py
+++ b/scripts/wheel_build.py
@@ -69,8 +69,9 @@ def main(argv: list[str]) -> int:
         "-DDART_BUILD_TUTORIALS=OFF",
         "-DBUILD_SHARED_LIBS=OFF",
         f"-DDART_USE_SYSTEM_IMGUI={use_system_imgui}",
-        "-DDART_USE_SYSTEM_FILAMENT=OFF",
-        "-DDART_FETCH_FILAMENT=ON",
+        # Override pyproject.toml's fetch default: official wheels link the
+        # wheel environment's conda-forge Filament, grafted during repair.
+        "-DDART_USE_SYSTEM_FILAMENT=ON",
         f"-DDART_DISABLE_COMPILER_CACHE={disable_compiler_cache}",
     ]
     cmake_args.extend(cmake_host_linker_flags())

--- a/tests/test_run_cpp_example.py
+++ b/tests/test_run_cpp_example.py
@@ -67,8 +67,6 @@ def test_filament_config_forwards_memory_diagnostics_build_override(
     monkeypatch.setattr(module, "_configure", capture_configure)
     env = {
         "DART_BUILD_DEMOS_MEMORY_DIAGNOSTICS_OVERRIDE": "ON",
-        "DART_FETCH_FILAMENT_OVERRIDE": "ON",
-        "DART_USE_SYSTEM_FILAMENT_OVERRIDE": "OFF",
     }
 
     module._ensure_filament(tmp_path, env, smoke=False)


### PR DESCRIPTION
## Summary

- The conda-forge `filament` package (1.76.x, all five workspace platforms) is
  now DART's default Filament provider, and the GUI builds by default on every
  platform: Pixi environments install Filament directly, official dartpy
  wheels link it from the wheel environment and graft its shared libraries
  during wheel repair, and `DART_BUILD_GUI` defaults to `ON` with a hard
  configure error when GUI dependencies are missing.

## Motivation / Problem

- Filament is now packaged on conda-forge, so the pinned-upstream-archive
  fetch (v1.71.3, static, libc++-built) no longer needs to be the default
  provider. That archive was the root cause of several workarounds: the
  linux-64 `libcxx`/`libcxxabi`/`libcxx-devel` pins, nm-based libc++ shims and
  `LIBCXX_PREFIX` plumbing, the CUDA host-compiler/glibc override in the cuda
  env, and a Linux-x86_64-only GUI default duplicated across four Pixi config
  tasks.

## Changes / Key Changes

- Add `filament = ">=1.76.0,<1.77"` to the Pixi `[dependencies]` (locked on
  linux-64, linux-aarch64, osx-64, osx-arm64, win-64; the pin follows the
  package's ABI run-export window).
- `DART_BUILD_GUI` is a plain boolean, default `ON` on every platform; the
  configure fails with actionable remedies when Filament/GLFW/ImGui are
  unavailable.
- Fold `DART_FETCH_FILAMENT` and `DART_FILAMENT_VERSION` into an imgui-style
  `DART_USE_SYSTEM_FILAMENT` toggle: `ON` (default) discovers a packaged
  install (conda-forge `filament` or `Filament_ROOT`); `OFF` fetches the
  pinned upstream 1.76.0 archive (per-platform SHA256 pins). Removed flags
  warn once and self-heal stale build-dir caches.
- `cmake/dart_find_filament.cmake`: prefer explicit Filament roots ahead of
  default search paths (`NO_DEFAULT_PATH` first pass) so a conda environment
  on `CMAKE_PREFIX_PATH`/`CMAKE_LIBRARY_PATH` cannot shadow `Filament_ROOT`,
  and skip the packaged-config search when the fetch provider is selected.
- Collapse the duplicated `DART_FILAMENT_PLATFORM_DEFAULT` shell blocks in the
  `config`, `config-py`, `config-coverage`, and `config-install` Pixi tasks;
  drop the fetch/system override plumbing from the GUI tasks and
  `scripts/run_cpp_example.py`.
- Remove the linux-64 libc++ pins, `LIBCXX_PREFIX` (Pixi, CI, scripts), and
  the CUDA host-compiler/glibc override — the cuda env now builds with the
  conda toolchain end to end (nvcc stays pinned to the conda toolkit, and the
  compiler-cache guard resets build dirs configured by the retired
  workaround).
- Wheels: `scripts/wheel_build.py` links the wheel environment's conda-forge
  Filament (grafted by auditwheel/delocate/delvewheel); plain `pip install`
  source builds default to the fetch provider via `pyproject.toml`, so sdist
  installs stay self-sufficient.
- Update `docs/onboarding/building.md`, `build-system.md`, `gui-rendering.md`,
  the `dartsim_gui_toolkit_decisions.md` decision log, and `CHANGELOG.md`.

## Testing

- `pixi run lint`; `pixi run test-all` (lint/build/unit/simulation/python all
  passing — the one initially failing Python test was the CUDA cache-guard
  contract test, updated to the new guard contract).
- GUI runtime on Filament 1.76.0: `pixi run test-dart-gui-smoke` (31/31) and
  `pixi run gui-offscreen-parity` (maxDelta 2, tolerance 4).
- Fetch lane end to end: configure with `DART_USE_SYSTEM_FILAMENT=OFF`
  downloads the 1.76.0 archive, verifies the SHA256 pin, links the static
  archive with the libc++ shim, and resists conda shadowing (adversarial
  `CMAKE_LIBRARY_PATH` pointing at an env that contains Filament).
- CUDA host (RTX 5000 Ada): `pixi run -e cuda test-all` (all seven suites
  passed) and `pixi run -e cuda py-demos-smoke` (155/155 scenes) — the
  CUDA-enabled dartpy + GUI builds with the pure conda toolchain, confirming
  the retired host-compiler workaround is unnecessary.
- Wheel (linux-64): `pixi run -e py314-wheel wheel-build` succeeds against
  conda Filament; the wheel's `_dartpy` links `libfilament.so`/`libutils.so`/
  `libgeometry.so` (the graft precondition). Local `auditwheel repair` cannot
  run on the dev host (glibc 2.43 exceeds auditwheel 6.8.0's newest manylinux
  policy 2_41 — pre-existing and provider-independent); the `publish_dartpy`
  PR lane validates repair/graft/test on all wheel platforms.
- Principle audit: deliverables/non-goals held; the consequential option
  design was confirmed with the maintainer; changed lines trace to the request
  or verification findings; failures were root-caused (test contract updated;
  wheel-repair limitation classified as external with evidence); all
  workflows map to `pixi run` tasks and tracked docs.

## Breaking Changes

- [ ] None
- `DART_FETCH_FILAMENT` and `DART_FILAMENT_VERSION` are removed (main-only,
  never in a DART release): use `DART_USE_SYSTEM_FILAMENT=OFF` for the fetch
  provider. Configures that cached the removed options warn once and
  self-heal. `DART_BUILD_GUI` now defaults to `ON` on every platform (was
  Linux-x86_64 only); headless builds pass `-DDART_BUILD_GUI=OFF`.

## Related Issues / PRs (backports)

- None (DART 7 main only; not a bug fix, no DART 6 LTS twin).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality (CUDA cache-guard contract test
      updated to the new guard)
- [x] Document new methods and classes (build docs + decision log)
- [ ] Add Python bindings (dartpy) if applicable (n/a)
