### PR TITLE
Group github/codeql-action Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # github/codeql-action/* must move as one unit. init writes a config file
+      # stamped with its own version, and analyze/upload-sarif refuse to read a
+      # config written by a different version ("Loaded a configuration file for
+      # version X, but running version Y"). Ungrouped, Dependabot opens one PR
+      # per sub-action and each one alone breaks the CodeQL workflow.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "docker"
     # Devcontainer Dockerfile lives under the hidden .devcontainer directory.


### PR DESCRIPTION
## Summary

- Group `github/codeql-action*` Dependabot updates so a single upstream release arrives as one atomic PR instead of three independent ones.

## Motivation / Problem

Dependabot treats `github/codeql-action/init`, `/analyze`, and `/upload-sarif` as three separate actions, so one upstream release opens three PRs. Those three refs cannot move independently: `init` writes a config file stamped with its own version, and `analyze`/`upload-sarif` refuse to read a config written by a different version.

The 4.37.8 -> 4.37.9 release split into #3459 (`init`), #3461 (`analyze`), and #3462 (`upload-sarif`). #3459's own CodeQL run failed with:

```
##[error]Loaded a configuration file for version '4.37.9', but running version '4.37.8'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.9', but running version '4.37.8'
CodeQL job status was configuration error.
```

Whichever of the three merges first therefore breaks the CodeQL workflow on `main` until the remaining two land. `Security | CodeQL` is not a required status check, so nothing blocks that partial merge from happening.

Grouping is also how this used to behave: #3450 ("Bump github/codeql-action from 4.37.7 to 4.37.8") landed as a single PR and its CodeQL run was green.

## Changes / Key Changes

- Add a `groups:` block to the `github-actions` ecosystem in `.github/dependabot.yml` with a `codeql-action` group matching `github/codeql-action*`.
- Comment records why the sub-actions must move together, so the grouping is not removed as redundant later.

## Testing

- `pixi run lint` — passes (pre-commit Tier-0 gate + full formatter clean).
- YAML validated: `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`, and the parsed group resolves to `{'codeql-action': {'patterns': ['github/codeql-action*']}}`.
- Config-only change; it takes effect on Dependabot's next scheduled run and cannot be exercised further in CI.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- #3459, #3461, #3462 — the split 4.37.8 -> 4.37.9 bumps that motivated this.
- #3450 — the earlier grouped bump that landed green.
