### PR TITLE
Align codeql-action analyze and upload-sarif with the v4.37.9 init bump

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -172,7 +172,7 @@ jobs:
             --target dartsim_engine
 
       - name: CodeQL Analyze
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           output: sarif-results
           upload: failure-only
@@ -211,7 +211,7 @@ jobs:
           done
 
       - name: Upload filtered CodeQL results
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: sarif-results
           wait-for-processing: "true"


### PR DESCRIPTION
## Summary

- Fix the repo-wide CodeQL failure: align `github/codeql-action` `analyze` and `upload-sarif` with the v4.37.9 `init` bump from #3459 so all three subactions run the same release.

## Motivation / Problem

- Dependabot bumped only `codeql-action/init` to v4.37.9; `analyze`/`upload-sarif` stayed at v4.37.8, and every CodeQL job now fails with "Loaded a configuration file for version '4.37.9', but running version '4.37.8'" (e.g. https://github.com/dartsim/dart/actions/runs/33462959740/job/99724165345 on #3465).

## Changes / Key Changes

- `.github/workflows/codeql.yml`: pin `analyze` and `upload-sarif` to the same v4.37.9 release commit as `init`.

## Testing

- YAML parse check; `pixi run lint`. This PR's own CodeQL run validates the aligned versions end to end.
- CHANGELOG: no entry — CI workflow pin fix.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3459.
