### PR TITLE
Keep dartpy wheels on the fetched static Filament archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,16 +440,17 @@ compatibility remains on the active DART 6 LTS branch._
 
 - Made the conda-forge `filament` package (1.76.x) the default Filament
   provider on every workspace platform: the Pixi environments install it
-  directly, official dartpy wheels link it from the wheel environment and
-  graft its shared libraries during wheel repair, and `DART_BUILD_GUI` now
-  defaults to `ON` everywhere, failing the configure when GUI dependencies
-  are missing. `DART_USE_SYSTEM_FILAMENT=OFF` fetches the pinned upstream
-  1.76.x archive (imgui-style provider toggle, replacing
-  `DART_FETCH_FILAMENT` and `DART_FILAMENT_VERSION`), which also keeps plain
-  `pip install` source builds self-sufficient. Removed the workarounds the
-  default libc++ archive fetch used to require — the linux-64 libc++ pins and
-  the CUDA host-compiler/glibc override — so CUDA builds use the conda
-  toolchain end to end. ([#3463](https://github.com/dartsim/dart/pull/3463))
+  directly, and `DART_BUILD_GUI` now defaults to `ON` everywhere, failing the
+  configure when GUI dependencies are missing. `DART_USE_SYSTEM_FILAMENT=OFF`
+  fetches the pinned upstream 1.76.x archive (imgui-style provider toggle,
+  replacing `DART_FETCH_FILAMENT` and `DART_FILAMENT_VERSION`); official
+  dartpy wheels and plain `pip install` source builds use that fetched
+  archive, whose static libraries load GL lazily — the conda-forge shared
+  build's eager libglvnd linkage cannot be vendored into manylinux wheels.
+  Removed the workarounds the default libc++ archive fetch used to require —
+  the linux-64 libc++ pins and the CUDA host-compiler/glibc override — so
+  CUDA builds use the conda toolchain end to end.
+  ([#3463](https://github.com/dartsim/dart/pull/3463))
 - Refreshed the DART 7 README and Read the Docs package guidance so the
   published install, dartpy smoke-test, and Python example paths match the
   current `package.xml`, wheel workflow, and `dart::simulation::World` API

--- a/docs/design/dartsim_gui_toolkit_decisions.md
+++ b/docs/design/dartsim_gui_toolkit_decisions.md
@@ -363,9 +363,10 @@ Scope it honestly:
 - **Update (2026-08-31): Filament provider defaults to conda-forge.** The
   `filament` package (1.76.x, all five workspace platforms, shared libs +
   `matc` + CMake package config) is the default provider
-  (`DART_USE_SYSTEM_FILAMENT=ON`), installed by the Pixi environments and
-  grafted into official dartpy wheels during wheel repair; the linux-64 libc++
-  pins and the CUDA host-compiler workaround it obsoleted were removed.
+  (`DART_USE_SYSTEM_FILAMENT=ON`), installed by the Pixi environments; the
+  linux-64 libc++ pins and the CUDA host-compiler workaround it obsoleted were
+  removed. Wheels stay on the fetched static archive: the conda shared
+  build's eager libglvnd linkage cannot be vendored into manylinux wheels.
   `DART_USE_SYSTEM_FILAMENT=OFF` fetches the pinned upstream 1.76.x archive
   (imgui-style provider toggle, replacing `DART_FETCH_FILAMENT`), keeping
   non-conda source builds and sdist `pip install` self-sufficient;

--- a/docs/onboarding/build-system.md
+++ b/docs/onboarding/build-system.md
@@ -251,10 +251,13 @@ active build.
   (`cmake/dart_find_filament.cmake` handles the upstream archive layout and
   its libc++ linkage), or set `DART_USE_SYSTEM_FILAMENT=OFF` to fetch the
   pinned upstream archive (kept on the same version line as the conda-forge
-  pin in `pixi.toml`). Official dartpy wheels link the conda-forge package
-  from the wheel environment and graft its shared libraries during wheel
-  repair; plain `pip install` source builds default to the fetch path via
-  `pyproject.toml`.
+  pin in `pixi.toml`). Official dartpy wheels and plain `pip install` source
+  builds both use the fetched archive (`DART_USE_SYSTEM_FILAMENT=OFF` via
+  `scripts/wheel_build.py` and `pyproject.toml`): the static archive loads GL
+  lazily, whereas the conda-forge shared build's eager libglvnd linkage cannot
+  be vendored into manylinux wheels — auditwheel grafts only the
+  non-whitelisted half of glvnd and `import dartpy` crashes when the grafted
+  and host copies mix.
 - **Enable:** `DART_BUILD_GUI` (`ON` by default; see above).
 - **Public build flag:** Keep `DART_BUILD_GUI` as the single public option for
   the GUI surface. Filament is the maintained backend, so do not add

--- a/pixi.lock
+++ b/pixi.lock
@@ -3977,6 +3977,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h0acdd01_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdwarf-2.1.0-h43af8da_1.conda
@@ -4169,6 +4172,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libcxx-headers-22.1.8-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
@@ -6751,6 +6755,45 @@ packages:
     - libcurl >=8.21.0,<9.0a0
   size: 484517
   timestamp: 1787183722915
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-22.1.8-ha0f52bf_0.conda
+  sha256: f2841fa52775dc54b180c7f0ba3c428926f913c43ef6d06b361489999b977ef7
+  md5: 11c6906835e2b185b77201435acda628
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libcxxabi 22.1.8 h9fd08b6_0
+  - libgcc >=15
+  constrains:
+  - sysroot_linux-64 >=2.28
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 2048158
+  timestamp: 1781673140303
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcxx-devel-22.1.8-h45a2b09_0.conda
+  sha256: e1b1e5b3acaba414612d26ca68419263cdc3ed6faf343764802b859c8652c584
+  md5: ca473af8b8425576b4c89b82a54defae
+  depends:
+  - libcxx >=22.1.8
+  - libcxx-headers >=22.1.8,<22.1.9.0a0
+  - tzdata
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 21559
+  timestamp: 1781673152667
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcxxabi-22.1.8-h9fd08b6_0.conda
+  sha256: 99c41d393a18da1054aa37cc3026e78de1a8f0a2653f2fb9b11e10ff330aefbb
+  md5: 89319eb839c438db52f61ec439baf49e
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=15
+  constrains:
+  - libcxx 22.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 168713
+  timestamp: 1781673131923
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
   sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
   md5: 40f9b31aa9cf007789867df0decd0492

--- a/pixi.toml
+++ b/pixi.toml
@@ -3220,8 +3220,10 @@ test-gz = { cmd = """
 # - DO NOT use --config-settings=cmake.define.XXX (it doesn't work reliably with scikit-build-core)
 # - DART_BUILD_GUI controls whether dartpy.gui submodule is included (see python/dartpy/CMakeLists.txt)
 # - Wheel builds enable the Filament-backed dartpy.gui surface against the
-#   conda-forge `filament` package from the wheel environment; the repair step
-#   (auditwheel/delocate/delvewheel) grafts its shared libraries into the wheel.
+#   pinned upstream Filament archive (DART_USE_SYSTEM_FILAMENT=OFF in
+#   scripts/wheel_build.py): the static archive loads GL lazily, whereas the
+#   conda-forge shared build's eager libglvnd linkage cannot be vendored into
+#   manylinux wheels (see scripts/wheel_build.py for the failure mode).
 
 #======================
 # Feature: Python 3.14 Wheel Building
@@ -3260,6 +3262,11 @@ auditwheel = ">=6.7.0,<7"
 patchelf = ">=0.17.2,<0.18"
 mesalib = ">=26.0.3,<27"
 libglvnd = ">=1.7.0,<2"
+# The pinned upstream Filament archive the wheels link against is built with
+# libc++ (see scripts/wheel_build.py); auditwheel grafts these into the wheel.
+libcxx = ">=22.1.7,<23"
+libcxxabi = ">=22.1.7,<23"
+libcxx-devel = ">=22.1.7,<23"
 
 [feature.py314-wheel.target.linux-64.tasks]
 wheel-build = { depends-on = ["wheel-build-core"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,11 @@ build-type = "Release"
 BUILD_SHARED_LIBS = "OFF"
 DART_BUILD_DARTPY = "ON"
 DART_BUILD_GUI = "ON"
-# Plain `pip install` fetches the pinned upstream Filament archive so source
-# builds work without a packaged Filament; scripts/wheel_build.py overrides
-# this to the conda-forge `filament` package for official wheels (its shared
-# libraries are grafted during wheel repair).
+# Both plain `pip install` source builds and official wheels
+# (scripts/wheel_build.py) use the pinned upstream Filament archive: it is
+# self-sufficient without a packaged Filament, and its static libraries load
+# GL lazily — the conda-forge shared build's eager libglvnd linkage cannot be
+# vendored into manylinux wheels (see scripts/wheel_build.py).
 DART_USE_SYSTEM_FILAMENT = "OFF"
 DART_BUILD_COLLISION_REFERENCE_TESTS = "OFF"
 DART_BUILD_COLLISION_REFERENCE_BENCHMARKS = "OFF"

--- a/scripts/wheel_build.py
+++ b/scripts/wheel_build.py
@@ -69,9 +69,13 @@ def main(argv: list[str]) -> int:
         "-DDART_BUILD_TUTORIALS=OFF",
         "-DBUILD_SHARED_LIBS=OFF",
         f"-DDART_USE_SYSTEM_IMGUI={use_system_imgui}",
-        # Override pyproject.toml's fetch default: official wheels link the
-        # wheel environment's conda-forge Filament, grafted during repair.
-        "-DDART_USE_SYSTEM_FILAMENT=ON",
+        # Wheels use the pinned upstream Filament archive (static, lazy GL via
+        # bluegl dlopen), not the conda-forge shared build: conda libbackend
+        # carries eager DT_NEEDED entries on the libglvnd stack, and manylinux
+        # whitelists libGL.so.1 but not libEGL/libGLdispatch, so auditwheel
+        # grafts half of glvnd into the wheel and `import dartpy` crashes in
+        # __glDispatchInit when the grafted and host/env glvnd copies mix.
+        "-DDART_USE_SYSTEM_FILAMENT=OFF",
         f"-DDART_DISABLE_COMPILER_CACHE={disable_compiler_cache}",
     ]
     cmake_args.extend(cmake_host_linker_flags())


### PR DESCRIPTION
## Summary

- Fix the Linux wheel `import dartpy` segfault from #3463 by keeping official
  dartpy wheels on the pinned upstream static Filament archive
  (`DART_USE_SYSTEM_FILAMENT=OFF` in `scripts/wheel_build.py`); the conda-forge
  shared Filament stays the default provider for Pixi/dev/CI builds.

## Motivation / Problem

- `Wheels | ubuntu-latest Py314` fails since #3463 with a SIGSEGV on bare
  `import dartpy`
  (https://github.com/dartsim/dart/actions/runs/33469594002/job/99745719814),
  and main's `Publish dartpy` will fail identically.
- Root cause (reproduced locally with gdb): conda's shared `libbackend.so`
  carries eager `DT_NEEDED` entries on the libglvnd stack; the manylinux
  policy whitelists `libGL.so.1` but not `libEGL.so.1`/`libGLdispatch.so.0`,
  so auditwheel grafts half of glvnd into the wheel, the loader mixes the
  grafted `libGLdispatch` with the host/environment `libGLX`, and glvnd's
  dispatch initialization jumps through a null table entry
  (`__glDispatchInit`).
- Excluding glvnd from the graft instead would leave eager GL `DT_NEEDED` to
  resolve on the host, breaking headless `import dartpy` on GL-less machines —
  rejected. The upstream static archive loads GL lazily through bluegl's
  `dlopen`, which is why pre-#3463 wheels shipped cleanly; this PR returns the
  wheels to that shape while keeping the #3463 conda-provider default
  everywhere else.

## Changes / Key Changes

- `scripts/wheel_build.py`: `-DDART_USE_SYSTEM_FILAMENT=OFF` with the failure
  mode documented (pyproject already defaults sdists to the fetch provider).
- `pixi.toml`: restore the `libcxx`/`libcxxabi`/`libcxx-devel` trio the static
  archive needs at link time, scoped to
  `[feature.py314-wheel.target.linux-64.dependencies]` only (the #3463
  removal from the shared linux-64 deps stands); lockfile updated.
- Correct the wheel-provider story in `pixi.toml` comments,
  `pyproject.toml`, `docs/onboarding/build-system.md`,
  `docs/design/dartsim_gui_toolkit_decisions.md`, and the #3463 CHANGELOG
  entry (still unreleased).

## Testing

- Local end-to-end reproduction and fix verification (the dev host's glibc
  2.43 exceeds auditwheel's newest policy, so a scratch auditwheel with a
  synthetic `manylinux_2_43` policy entry runs the real repair code path):
  - Before: repair of the conda-provider wheel grafts
    `libEGL`/`libGLdispatch`/filament shared libs and `import dartpy`
    segfaults (gdb: `__glDispatchInit` via mixed glvnd copies).
  - After: fetch-provider wheel builds, repair grafts only
    `libc++`/`libc++abi`/`libglfw` (no GL, no Filament shared libraries),
    clean-venv `import dartpy` passes, and the full `scripts/test_wheel.py`
    suite passes including the `dartpy.gui` scene smoke.
- `pixi run lint`.
- CHANGELOG: #3463's entry corrected in place (unreleased); no separate entry.

## Breaking Changes

- [x] None (restores the long-standing wheel shape).

## Related Issues / PRs (backports)

- Follow-up to #3463; sibling fixes: #3465 (GUI-on test failures), #3466
  (CodeQL action pins).

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [ ] Add unit tests for new functionality (n/a — provider/config fix; wheel
      CI is the regression surface)
- [x] Document new methods and classes (provider docs corrected)
- [ ] Add Python bindings (dartpy) if applicable (n/a)
