### PR TITLE
Build CUDA kernels for the GPU runner's sm_89 architecture

### DIFF
--- a/.github/workflows/ci_cuda.yml
+++ b/.github/workflows/ci_cuda.yml
@@ -70,7 +70,17 @@ jobs:
     env:
       DART_PARALLEL_JOBS: "8"
       CTEST_PARALLEL_LEVEL: "8"
-      DART_CUDA_ARCHITECTURES: "75"
+      # Must match the self-hosted GPU runner's compute capability. That runner
+      # is an RTX 5000 Ada (sm_89), so building sm_75 left the binaries with no
+      # native SASS for the device and the driver fell back to JIT-compiling the
+      # embedded compute_75 PTX — which fails, because pixi ships nvcc 13.3
+      # while the runner's driver (595.84) only supports up to CUDA 13.2:
+      #   "the provided PTX was compiled with an unsupported toolchain"
+      # Emitting sm_89 SASS directly removes the JIT step entirely, so the
+      # toolkit-vs-driver version gap no longer matters. Harmless on the
+      # GPU-less fork-PR fallback runner, which only compiles and never launches
+      # a kernel.
+      DART_CUDA_ARCHITECTURES: "89"
       # The cuda environment declares the __cuda=13 virtual package
       # (pixi.toml linux-64-cuda platform). Assume it explicitly so the
       # GPU-less fork-PR fallback runner installs without warnings; on the


### PR DESCRIPTION
## Summary

The self-hosted `ubuntu-latest-gpu` runner is an **RTX 5000 Ada (sm_89)**, but `ci_cuda.yml` hardcoded `DART_CUDA_ARCHITECTURES: "75"`. The binaries therefore carried no native SASS for the device, and the driver fell back to JIT-compiling the embedded `compute_75` PTX at kernel launch.

That JIT can't succeed on this runner: pixi installs **nvcc 13.3** while the runner's driver (**595.84**) supports only up to **CUDA 13.2**. Every kernel launch failed with:

```
the provided PTX was compiled with an unsupported toolchain
```

All 8 CUDA test binaries failed this way — 41 tests, the whole suite finishing in ~3s because nothing ever ran.

## Why this surfaced now

The GPU runner was only just brought online, so `ubuntu-latest-gpu` had no runner and these runs sat queued. The fork-PR fallback path compiles but skips the test steps, so **these kernels had never actually executed in CI before**.

## Verification

Reproduced in isolation on the runner, against the same pixi CUDA 13.3 toolchain, with a minimal kernel:

| Built for | Result on the sm_89 GPU |
|---|---|
| `sm_75` (before) | `LAUNCH ERROR: the provided PTX was compiled with an unsupported toolchain.` |
| `sm_89` (after) | `OK result=42` |

Building `sm_89` emits native SASS and removes the JIT step entirely, so the toolkit-vs-driver version gap no longer matters.

## Notes

- `89` is also what `resolve_cuda()` in `scripts/cmake_config.py` auto-detects on this hardware when the variable is left unset, so this matches the project's own detection rather than introducing a new magic number.
- The value is inert on the GPU-less fork-PR fallback runner, which only compiles and never launches a kernel — that path is unaffected.
- This pins CI to the current runner's compute capability. If the GPU runner is ever swapped for different hardware, this value needs updating (or `75;89` to cover both).