### PR TITLE
Capture Fable 5.1 upgrade retrospective learnings at their owners

### DIFF
--- a/.agents/skills/dart-model-upgrade/SKILL.md
+++ b/.agents/skills/dart-model-upgrade/SKILL.md
@@ -168,12 +168,13 @@ well it investigates simulation state with text-first and visual/debug evidence.
    Include a negative case that must retain the existing route, plus
    failure-sensitive checks for model pins, configuration aliases, generated
    parity, instruction discovery, and approval boundaries when touched. Include
-   a fresh-session case that must find current project state and the correct
+   a fresh-session case that must find current project state and the
    cross-session resume surface without hidden chat history. Include
    visual-debug failure cases for an unavailable renderer, a poor view,
    text/image disagreement, and a static geometry defect that visual-only
-   inspection must not pass. In `audit-only`, assess existing coverage and
-   report missing cases without adding them.
+   inspection must not pass and whose chosen text oracle is shown to observe
+   it. In `audit-only`, assess existing coverage and report missing cases
+   without adding them.
 9. **Verify and review.** Run focused checks, `pixi run check-ai-infra`,
    `pixi run exercise-agent-scenarios`, `pixi run test-ai-infra`, relevant
    docs/AI checks from `docs/ai/verification.md`, and
@@ -207,8 +208,7 @@ well it investigates simulation state with text-first and visual/debug evidence.
 - Comparison matrix with per-lane cost, turns, wall time, and isolation
   evidence; limitations, prompt/config changes, and unchanged choices
 - 3D physics investigation and visual/debug evaluation results, artifacts,
-  failure-boundary outcomes, and unavailable-evidence limitations
-- Direct, indirect, incomplete, non-trigger, and edge-case results
+  trigger and failure-boundary outcomes, and unavailable-evidence limitations
 - Mode, mutations performed (none for `audit-only`), gates, principle audit, two
   review passes, and blockers
 - For `audit-only`, recommendations and proposed change/validation scope; for

--- a/.agents/skills/dart-verify-sim/SKILL.md
+++ b/.agents/skills/dart-verify-sim/SKILL.md
@@ -72,12 +72,14 @@ and updates the owner, not this skill. Keep this loop capability-based.
 Text (primary):
 
 - `world.compute_step_metrics()` — energy/momentum/penetration/contacts/residual
+  (solved pairs only; static- or kinematic-only overlap needs `world.collide()`)
 - `dartpy.dump_scene_json(world)` / `dump_scene_text(world)` — "what is in this
   world?" (glTF/USD-flavored hierarchy + flat index)
 - `pixi run scene-diff` — structural JSON verdict for intended-vs-actual scene
   dumps
 - `pixi run trajectory-record` / `pixi run trajectory-compare` — per-body TSV +
-  contact JSONL; bit-exact or tolerance diff with first-divergence
+  contact JSONL; bit-exact or tolerance diff with first-divergence; scratch
+  scenes via `--factory path/to/scene.py:callable`
 
 Visual (corroboration):
 

--- a/.claude/commands/dart-model-upgrade.md
+++ b/.claude/commands/dart-model-upgrade.md
@@ -147,12 +147,13 @@ well it investigates simulation state with text-first and visual/debug evidence.
    Include a negative case that must retain the existing route, plus
    failure-sensitive checks for model pins, configuration aliases, generated
    parity, instruction discovery, and approval boundaries when touched. Include
-   a fresh-session case that must find current project state and the correct
+   a fresh-session case that must find current project state and the
    cross-session resume surface without hidden chat history. Include
    visual-debug failure cases for an unavailable renderer, a poor view,
    text/image disagreement, and a static geometry defect that visual-only
-   inspection must not pass. In `audit-only`, assess existing coverage and
-   report missing cases without adding them.
+   inspection must not pass and whose chosen text oracle is shown to observe
+   it. In `audit-only`, assess existing coverage and report missing cases
+   without adding them.
 9. **Verify and review.** Run focused checks, `pixi run check-ai-infra`,
    `pixi run exercise-agent-scenarios`, `pixi run test-ai-infra`, relevant
    docs/AI checks from `docs/ai/verification.md`, and
@@ -186,8 +187,7 @@ well it investigates simulation state with text-first and visual/debug evidence.
 - Comparison matrix with per-lane cost, turns, wall time, and isolation
   evidence; limitations, prompt/config changes, and unchanged choices
 - 3D physics investigation and visual/debug evaluation results, artifacts,
-  failure-boundary outcomes, and unavailable-evidence limitations
-- Direct, indirect, incomplete, non-trigger, and edge-case results
+  trigger and failure-boundary outcomes, and unavailable-evidence limitations
 - Mode, mutations performed (none for `audit-only`), gates, principle audit, two
   review passes, and blockers
 - For `audit-only`, recommendations and proposed change/validation scope; for

--- a/.claude/skills/dart-verify-sim/SKILL.md
+++ b/.claude/skills/dart-verify-sim/SKILL.md
@@ -67,12 +67,14 @@ and updates the owner, not this skill. Keep this loop capability-based.
 Text (primary):
 
 - `world.compute_step_metrics()` — energy/momentum/penetration/contacts/residual
+  (solved pairs only; static- or kinematic-only overlap needs `world.collide()`)
 - `dartpy.dump_scene_json(world)` / `dump_scene_text(world)` — "what is in this
   world?" (glTF/USD-flavored hierarchy + flat index)
 - `pixi run scene-diff` — structural JSON verdict for intended-vs-actual scene
   dumps
 - `pixi run trajectory-record` / `pixi run trajectory-compare` — per-body TSV +
-  contact JSONL; bit-exact or tolerance diff with first-divergence
+  contact JSONL; bit-exact or tolerance diff with first-divergence; scratch
+  scenes via `--factory path/to/scene.py:callable`
 
 Visual (corroboration):
 

--- a/.opencode/command/dart-model-upgrade.md
+++ b/.opencode/command/dart-model-upgrade.md
@@ -152,12 +152,13 @@ well it investigates simulation state with text-first and visual/debug evidence.
    Include a negative case that must retain the existing route, plus
    failure-sensitive checks for model pins, configuration aliases, generated
    parity, instruction discovery, and approval boundaries when touched. Include
-   a fresh-session case that must find current project state and the correct
+   a fresh-session case that must find current project state and the
    cross-session resume surface without hidden chat history. Include
    visual-debug failure cases for an unavailable renderer, a poor view,
    text/image disagreement, and a static geometry defect that visual-only
-   inspection must not pass. In `audit-only`, assess existing coverage and
-   report missing cases without adding them.
+   inspection must not pass and whose chosen text oracle is shown to observe
+   it. In `audit-only`, assess existing coverage and report missing cases
+   without adding them.
 9. **Verify and review.** Run focused checks, `pixi run check-ai-infra`,
    `pixi run exercise-agent-scenarios`, `pixi run test-ai-infra`, relevant
    docs/AI checks from `docs/ai/verification.md`, and
@@ -191,8 +192,7 @@ well it investigates simulation state with text-first and visual/debug evidence.
 - Comparison matrix with per-lane cost, turns, wall time, and isolation
   evidence; limitations, prompt/config changes, and unchanged choices
 - 3D physics investigation and visual/debug evaluation results, artifacts,
-  failure-boundary outcomes, and unavailable-evidence limitations
-- Direct, indirect, incomplete, non-trigger, and edge-case results
+  trigger and failure-boundary outcomes, and unavailable-evidence limitations
 - Mode, mutations performed (none for `audit-only`), gates, principle audit, two
   review passes, and blockers
 - For `audit-only`, recommendations and proposed change/validation scope; for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,6 +518,12 @@ compatibility remains on the active DART 6 LTS branch._
   versions and comparison-lane mechanics, and a harness-wide refresh fixed
   outdated, duplicated, and over-constrained AI guidance at its owners.
   ([#3473](https://github.com/dartsim/dart/pull/3473))
+- Let `pixi run trajectory-record` and `pixi run agent-capture` load a scratch
+  scene with `--factory path/to/file.py:callable`, because the Pixi task
+  environment replaces `PYTHONPATH` and a module outside the task path was not
+  importable by name; the simulation-verification guide now also states that
+  step-metrics contact count and penetration skip static/kinematic-only pairs
+  and that rest claims need an explicit criterion.
 - Fixed the trajectory recorder so its `--factory module:callable` path works
   instead of tripping its own scene/factory exclusivity guard.
   ([#3416](https://github.com/dartsim/dart/pull/3416))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,6 +524,7 @@ compatibility remains on the active DART 6 LTS branch._
   importable by name; the simulation-verification guide now also states that
   step-metrics contact count and penetration skip static/kinematic-only pairs
   and that rest claims need an explicit criterion.
+  ([#3476](https://github.com/dartsim/dart/pull/3476))
 - Fixed the trajectory recorder so its `--factory module:callable` path works
   instead of tripping its own scene/factory exclusivity guard.
   ([#3416](https://github.com/dartsim/dart/pull/3416))

--- a/docs/dev_tasks/rigid_body_dynamics_solver/RESUME.md
+++ b/docs/dev_tasks/rigid_body_dynamics_solver/RESUME.md
@@ -849,6 +849,17 @@ Rigid positional correction still runs after the unified velocity solve.
 **Missing:** remaining scaling/polish work (warm starting / friction-cone
 iteration).
 
+- **Observed resting baseline (2026-09-02, current `main`):** a 0.1 m
+  half-extent box (mass 0.5, restitution 0, `dt` 0.005) dropped 0.3 m onto a
+  static box settles to a 0.8–2 mm support gap within 0.5 s but from 1 s to
+  6 s keeps |v| ≈ 5e-3–1.3e-2 m/s and |ω| ≈ 4e-2–1e-1 rad/s with three
+  active contacts out of the four-point face manifold, and never reaches the
+  1e-3 deactivation thresholds even with `DeactivationOptions.enabled`. This
+  is the rank-deficient near-coplanar fallback described under the coupled
+  boxed-LCP increment; treat it as the baseline the warm-starting/manifold
+  polish must beat, and grade rest claims with an explicit gap/drift
+  criterion until then (`docs/onboarding/agent-sim-verification.md`).
+
 - **Pipeline ordering (done for semi-implicit):** the default semi-implicit
   `World::step` pipeline now runs `RigidBodyVelocityStage` →
   `MultibodyVelocityStage` → `UnifiedConstraintStage` →

--- a/docs/onboarding/agent-sim-verification.md
+++ b/docs/onboarding/agent-sim-verification.md
@@ -19,7 +19,17 @@ dynamic failures (explosions, tunneling); use text to decide correctness.
 - **Step metrics** — `world.compute_step_metrics()` returns a `StepMetrics`
   with kinetic/potential/total energy, linear/angular momentum, active contact
   count, max penetration depth, iterations, and residual. Watch energy and
-  momentum for conservation, penetration for contact health.
+  momentum for conservation, penetration for contact health. The contact
+  count and penetration cover solved pairs only: a contact whose two bodies
+  are both static or kinematic is skipped, so a fixture sunk into the ground
+  reports zero penetration. Check fixture geometry with `world.collide()`
+  (which reports those pairs), the scene dump, or `scene-diff`.
+- **Rest and settling claims** — state the criterion before grading, for
+  example a support-gap band with no drift over a window, or a velocity
+  bound. Deactivation is opt-in (`DeactivationOptions`, off by default), and
+  a box resting on a flat face can keep a small residual rocking velocity on
+  the default contact solver, so `is_sleeping` and a bare velocity threshold
+  are not rest oracles.
 - **Scene dump** — `dartpy.dump_scene_json(world)` / `dump_scene_text(world)`
   answer "what is in this world?": a glTF/USD-flavored hierarchy (header with
   gravity, time step, units, solver rest tolerance; bodies with mass/inertia/
@@ -33,6 +43,10 @@ dynamic failures (explosions, tunneling); use text to decide correctness.
   runs with a bit-exact checksum mode (determinism) or a per-column tolerance
   mode, reporting the first divergence. Derive an empirical drift band from
   DART's own runs rather than importing a threshold — no engine publishes one.
+  Both recorders take a built-in `--scene` or `--factory module:callable`;
+  pass a scratch scene as `--factory path/to/scene.py:callable`, because the
+  Pixi task replaces `PYTHONPATH` and a module outside `python/` or `scripts/`
+  is not importable by name.
 - **Scene diff** — `pixi run scene-diff` compares two
   `dump_scene_json` outputs structurally, with numeric tolerance and a
   machine-readable verdict. Use it when the question is "did the scene I built
@@ -98,7 +112,8 @@ debug=(...layers...))` draws world-derived overlay layers through the same
   `docs/design/agent_sim_verification.md` and `dart/gui/AGENTS.md`.
 - **Agent capture harness** — `pixi run agent-capture` renders deterministic
   stills/turntables/motion sequences (optional MP4) from the built-in scene
-  registry or a `module:callable` world factory, with explicit or
+  registry or a `module:callable` / `path/to/file.py:callable` world factory,
+  with explicit or
   auto-selected cameras, debug layers, and a sidecar JSON recording camera
   parameters, layers, view reports, and the exact reproduction command. Its
   review contract enumerates every selected still plus representative

--- a/docs/onboarding/building.md
+++ b/docs/onboarding/building.md
@@ -436,6 +436,15 @@ For more details on Python bindings architecture, see [python-bindings.md](pytho
 | `pixi run test`   | "100% tests passed" or all tests green     | Test failure summary with count    |
 | `cmake --build .` | No errors, successful compilation messages | Error messages with file:line info |
 
+**Stale build trees.** A build directory configured before a toolchain or
+dependency change (a `pixi.toml` compiler, Filament, or library update, or a
+tree older than the current lockfile) can fail at `pixi run config` — which
+also runs inside `pixi run lint` and `pixi run test-all` — or import a
+`dartpy` linked against a library version the environment no longer ships.
+Move the affected `build/<env>/cpp/<config>/` tree aside (or delete it) and
+reconfigure; the launcher from `cmake/compiler_cache.cmake` keeps the rebuild
+short when sccache or ccache is installed.
+
 ## See Also
 
 - [build-system.md](build-system.md) - Deep dive into DART's CMake architecture

--- a/python/tests/unit/test_trajectory_record_compare.py
+++ b/python/tests/unit/test_trajectory_record_compare.py
@@ -7,6 +7,8 @@ import math
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "scripts"
 if str(SCRIPTS) not in sys.path:
@@ -153,6 +155,39 @@ def test_combined_trajectory_and_contact_recording_shares_runner() -> None:
     assert trajectory_frames
     assert contact_frames
     assert contact_frames <= trajectory_frames
+
+
+def test_load_factory_accepts_python_file_path(tmp_path) -> None:
+    scene = tmp_path / "scratch_scene.py"
+    scene.write_text(
+        "class Scenes:\n"
+        "    @staticmethod\n"
+        "    def make_world():\n"
+        "        return 'scratch-world'\n"
+        "\n"
+        "def make_world():\n"
+        "    return 'scratch-world'\n",
+        encoding="utf-8",
+    )
+
+    assert trajectory_record._load_factory(f"{scene}:make_world")() == "scratch-world"
+    nested = trajectory_record._load_factory(f"{scene}:Scenes.make_world")
+    assert nested() == "scratch-world"
+
+    # A scratch file named like a package it imports must not shadow that
+    # package while it executes (it is registered under a prefixed name).
+    shadowing = tmp_path / "json.py"
+    shadowing.write_text(
+        "import json\n\ndef make_world():\n    return json.dumps({'ok': 1})\n",
+        encoding="utf-8",
+    )
+    assert trajectory_record._load_factory(f"{shadowing}:make_world")() == '{"ok": 1}'
+    assert sys.modules["json"].__file__ != str(shadowing)
+
+    with pytest.raises(FileNotFoundError):
+        trajectory_record._load_factory(f"{tmp_path / 'missing.py'}:make_world")
+    with pytest.raises(ValueError, match="path/to/file.py:callable"):
+        trajectory_record._load_factory("no_callable_separator")
 
 
 def test_main_factory_alone_does_not_trip_scene_exclusivity_guard(

--- a/scripts/agent_capture.py
+++ b/scripts/agent_capture.py
@@ -488,7 +488,11 @@ def _reproduce_command(args: argparse.Namespace) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scene", default="box_on_ground")
-    parser.add_argument("--factory", default=None, help="module:callable world factory")
+    parser.add_argument(
+        "--factory",
+        default=None,
+        help="world factory: module:callable or path/to/file.py:callable",
+    )
     parser.add_argument("--steps", type=int, default=0, help="steps before capture")
     parser.add_argument("--width", type=int, default=1280)
     parser.add_argument("--height", type=int, default=960)

--- a/scripts/trajectory_record.py
+++ b/scripts/trajectory_record.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import importlib.util
 import json
 import sys
 from dataclasses import dataclass
@@ -156,10 +157,32 @@ _BUILTIN_SCENES: dict[str, Callable[[], Any]] = {
 
 
 def _load_factory(spec: str) -> Callable[[], Any]:
+    """Resolve ``module:callable`` or ``path/to/file.py:callable``.
+
+    The Pixi tasks that call this replace ``PYTHONPATH``, so a scratch scene
+    module is usually not importable by name; the file form loads it directly.
+    """
     if ":" not in spec:
-        raise ValueError("--factory must be in module:callable form")
-    module_name, attr_path = spec.split(":", 1)
-    target: Any = importlib.import_module(module_name)
+        raise ValueError(
+            "--factory must be in module:callable or path/to/file.py:callable form"
+        )
+    module_name, attr_path = spec.rsplit(":", 1)
+    if module_name.endswith(".py"):
+        path = Path(module_name)
+        if not path.is_file():
+            raise FileNotFoundError(f"--factory file {module_name!r} does not exist")
+        # Register under a prefixed name so a scratch file called, say,
+        # ``dartpy.py`` cannot shadow the package it imports while executing.
+        registered_name = f"_dart_world_factory_{path.stem}"
+        module_spec = importlib.util.spec_from_file_location(registered_name, path)
+        if module_spec is None or module_spec.loader is None:
+            raise ImportError(f"cannot load --factory file {module_name!r}")
+        module = importlib.util.module_from_spec(module_spec)
+        sys.modules[registered_name] = module
+        module_spec.loader.exec_module(module)
+        target: Any = module
+    else:
+        target = importlib.import_module(module_name)
     for name in attr_path.split("."):
         target = getattr(target, name)
     if not callable(target):
@@ -492,7 +515,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     source = parser.add_mutually_exclusive_group()
     source.add_argument("--scene", default="box_on_ground")
-    source.add_argument("--factory", help="importable world factory: module:callable")
+    source.add_argument(
+        "--factory",
+        help="world factory: module:callable or path/to/file.py:callable",
+    )
     parser.add_argument("--steps", type=int, required=True)
     parser.add_argument(
         "--body",

--- a/tests/test_ai_infrastructure.py
+++ b/tests/test_ai_infrastructure.py
@@ -1019,10 +1019,15 @@ def test_ctest_contract_rejects_command_shadowing(tmp_path):
     _assert_ctest_lexical_contract_fails(root)
 
 
+def _flat(text: str) -> str:
+    """Collapse whitespace so Prettier line wrapping cannot split a marker."""
+    return " ".join(text.split())
+
+
 def test_model_upgrade_workflow_keeps_comparison_and_trigger_boundaries():
     path = ROOT / ".claude" / "commands" / "dart-model-upgrade.md"
-    text = path.read_text()
-    meta = sync.parse_command_frontmatter(text)
+    text = _flat(path.read_text())
+    meta = sync.parse_command_frontmatter(path.read_text())
 
     for trigger in (
         "model or coding-agent upgrades",
@@ -1061,7 +1066,7 @@ def test_model_upgrade_workflow_keeps_comparison_and_trigger_boundaries():
     lanes = [block for block in routing_section.split("\n- **")[1:]]
     assert len(lanes) >= 2
     for lane in lanes:
-        assert "accept native image input" in lane, lane[:60]
+        assert "accept native image input" in _flat(lane), lane[:60]
     families = {
         family.lower() for family in re.findall(r"claude-([a-z]+)-\d", routing_section)
     }
@@ -1078,7 +1083,7 @@ def test_model_upgrade_workflow_keeps_comparison_and_trigger_boundaries():
 
 
 def test_ultrawork_prompt_simplification_retains_critical_contracts():
-    text = (ROOT / ".claude" / "commands" / "dart-ultrawork.md").read_text()
+    text = _flat((ROOT / ".claude" / "commands" / "dart-ultrawork.md").read_text())
 
     for marker in (
         "docs/dev_tasks/<task>/",


### PR DESCRIPTION
## Summary

- Promotes the durable learnings from the Fable 5.1 model-upgrade session (#3473) into the surfaces that own them: the simulation-verification guide and `dart-verify-sim` skill, the recorder/capture tooling, the rigid-body solver dev task, the building guide, the AI-infra tests, and the `dart-model-upgrade` workflow. Affects agents and contributors who verify simulation behaviour or build scratch scenes for evidence.

## Motivation / Problem

- The controlled model comparison in #3473 exposed gaps that the merged PR only partly captured: `compute_step_metrics()` reports zero contacts and zero penetration for a fixture sunk into the ground because static/kinematic-only pairs are skipped, "comes to rest" claims could not be graded without a stated criterion (deactivation is opt-in and a resting box keeps a residual rocking velocity), a scratch scene module was not importable through the Pixi tasks because the task environment replaces `PYTHONPATH`, stale build trees from an older toolchain failed the configure step inside `pixi run lint`, and Prettier line wrapping could split the multi-word contract markers asserted by the AI-infra tests.

## Changes / Key Changes

- `scripts/trajectory_record.py` / `scripts/agent_capture.py`: `--factory` accepts `path/to/file.py:callable` in addition to `module:callable`; the file is registered under a prefixed module name so a scratch file named like a package it imports cannot shadow it. New test covers the plain, nested-attribute, shadowing, missing-file, and malformed-spec cases.
- `docs/onboarding/agent-sim-verification.md`, `.claude/skills/dart-verify-sim/SKILL.md`: step-metrics scope (solved pairs only; use `world.collide()`, the scene dump, or `scene-diff` for fixture geometry), an explicit rest/settling criterion rule, and the scratch-scene factory form.
- `docs/dev_tasks/rigid_body_dynamics_solver/RESUME.md`: measured resting-box baseline (three of four manifold contacts active, residual velocity, never sleeps even with deactivation enabled) recorded under Subsystem A as the bar for the warm-starting/manifold polish.
- `docs/onboarding/building.md`: stale build tree symptoms and recovery.
- `tests/test_ai_infrastructure.py`: contract markers are matched on whitespace-collapsed text; frontmatter parsing still receives the raw text.
- `.claude/commands/dart-model-upgrade.md` (+ generated adapters): the seeded static-defect failure case must use a text oracle shown to observe it; a duplicate Output bullet is merged so the OpenCode adapter stays at its 200-line budget.
- `CHANGELOG.md`: developer-tooling entry.

## Testing

- `pixi run lint` (twice, including after the review fix), `pixi run check-ai-commands`, `pixi run check-ai-infra`, `pixi run test-ai-infra` (540 passed), `pixi run check-docs-policy`, `pixi run check-lint-md`, `pixi run check-lint-spell`, `pixi run check-lint-py`.
- Focused `python/tests/unit/test_trajectory_record_compare.py` and `test_agent_capture.py` (18 passed), plus the new test by id.
- Both physics statements were reproduced on the current `Release-docking` build with a probe script: static crate 2 cm into the ground reports `contacts=0`, `max_pen=0` from step metrics while `world.collide()` returns four contacts of depth 0.02; a dropped box keeps |v| ≈ 5e-3–1.3e-2 m/s with three active contacts from 1 s to 6 s and never sleeps with `DeactivationOptions.enabled`.
- The file-form factory was exercised end to end through the real `pixi run trajectory-record` task from an untracked scratch directory, including a scratch file named `dartpy.py`.
- `pixi run test-all` on the rebased head: all tests passed.
- Review evidence: one independent review lane completed with no blockers, one should-fix (the `sys.modules` shadowing, fixed with a regression test and a live reproduction) and two nits (one wording fix applied, one confirmed inert). A first review lane was cut off by an API session limit; the post-fix state is verified by gates and the regression test rather than a second reviewer pass.
- Principle audit: objective and non-goals stated in the retro output; each edit traces to a session finding; mutable facts have one owner (guide, dev task, building guide, workflow source) with the skill and changelog as pointers; the workflow change is model-agnostic; no external mutation before maintainer approval.

## Breaking Changes

- [x] None

## Related Issues / PRs (backports)

- Follow-up to #3473.
- DART 6 (`release-6.20`) verdict: omit, except the stale-build-tree note in the building guide, which can be adapted in that branch's own lane.

---

#### Checklist

- [x] Milestone set (DART 7.0 for `main`, branch-matching DART 6.x release
      milestone for the active DART 6 LTS branch)
- [x] CHANGELOG.md updated per `docs/onboarding/changelog.md` if required
- [x] Add unit tests for new functionality
- [x] Document new methods and classes
- [ ] Add Python bindings (dartpy) if applicable — not applicable
