### PR TITLE
Batch automated review fixes and add convergence checkpoints

### DIFF
--- a/.agents/skills/dart-manage-pr/SKILL.md
+++ b/.agents/skills/dart-manage-pr/SKILL.md
@@ -143,15 +143,19 @@ gh pr checks <PR_NUMBER>
      replies; verify claims locally; apply AI-review fixes silently).
    - For human reviewers, reply only when a response is useful after a fix or
      when a question needs clarification.
-   - After an approved push that addressed Codex comments on a PR that already
-     had a Codex review, post a fresh top-level `@codex review`; that PR comment
-     needs explicit maintainer/user approval and must not duplicate an active
-     trigger.
+   - Follow that owner's single Review-Fix Loop Workflow for completed finding
+     batches, one trigger owner, current-head evidence, and the two-round
+     strategy checkpoint. Preserve review state across handoffs; do not start
+     another manual request merely because a push completed. Every external
+     mutation still requires explicit maintainer/user approval covering its
+     action and PR.
    - For substantive code PRs, an independent review session (a human, or a
      separate agent session running the `dart-review-pr` workflow via
      `/dart-review-pr` or `$dart-review-pr`) must record its outcome —
      findings, or an explicitly clean result — before merge approval;
-     docs-only and mechanical changes are exempt.
+     docs-only and mechanical changes are exempt. Count hosted plus independent
+     coverage and revalidate fixes using `docs/ai/verification.md`; the same
+     independent lane can perform the strategy checkpoint.
 5. Mark ready or merge only when appropriate:
    - Confirm review requirements are satisfied and local validation matches the
      intended transition.
@@ -167,7 +171,8 @@ gh pr checks <PR_NUMBER>
    `pixi run -e cuda test-all`; do not substitute the default run for the CUDA
    run, and record a skip or blocker explicitly. Merge only after CI and review
    are green, the milestone is set, an independent review recorded a clean
-   result on the current post-fix head (after findings, a clean re-review;
+   result covering the current post-fix head (baseline plus delta revalidation
+   is allowed by `docs/ai/verification.md`;
    the step 4 docs-only/mechanical exemption also satisfies this), the
    PR is not draft, GitHub reports it mergeable, and explicit merge approval is
    given. PR comments, review re-triggers, thread resolution, reviewer requests,
@@ -200,6 +205,8 @@ Report:
 - PR number, URL, base, head, draft state, milestone, and merge status.
 - CI summary: passing, failing, pending, or skipped checks.
 - Review summary, independent-review status, and whether `@codex review` ran.
+- Reviewed head, completed round count, trigger/completion evidence, and any
+  strategy-checkpoint outcome or missing review coverage.
 - Local pre-merge validation state when `mode=merge` ran.
 - Commits pushed, merge action, and branch cleanup action.
 - Remaining blockers or next action.

--- a/.agents/skills/dart-pr/SKILL.md
+++ b/.agents/skills/dart-pr/SKILL.md
@@ -109,8 +109,8 @@ Use these practices:
 7. Commit only intended files with a plain descriptive commit title.
 8. Merge the latest base branch into the PR branch before any push, and follow
    the base-merge and automated-review rules in `docs/onboarding/ai-reviews.md`
-   (no inline bot replies; `@codex review` re-triggers are throttled to one per
-   approved review-fix round). Ask for explicit maintainer/user approval before
+   (no inline bot replies; one trigger owner and completed fix batches).
+   Ask for explicit maintainer/user approval before
    pushing or opening the draft PR. After approval:
    ```bash
    git push -u origin HEAD
@@ -125,7 +125,11 @@ Use these practices:
     wording, and PR-link follow-up. If `CHANGELOG.md` needs the PR number, keep
     the follow-up changelog commit local until explicit maintainer/user approval
     is given for the additional push or PR update.
-11. Monitor CI: `gh pr checks <PR_NUMBER>`.
+11. Follow the single Review-Fix Loop Workflow in
+    `docs/onboarding/ai-reviews.md`, reusing explicit approval for its action,
+    PR, and scope. Account for the initial automatic review before requesting
+    another; apply the strategy checkpoint and current-head readiness gates.
+    Monitor CI: `gh pr checks <PR_NUMBER>`.
 
 ## Output
 

--- a/.agents/skills/dart-review-pr/SKILL.md
+++ b/.agents/skills/dart-review-pr/SKILL.md
@@ -52,40 +52,31 @@ without explicit maintainer/user approval for that external mutation.
 
 ### Address Feedback
 
-```bash
-gh pr view $1 --comments
-```
+Use the paginated review/CI inspection commands and the single Review-Fix Loop
+Workflow in `docs/onboarding/ai-reviews.md`. Collect the completed batch, verify
+claims, and repair the underlying defect family. That owner defines trigger
+ownership, current-head completion, the two-round strategy checkpoint, false
+positive dispositions, blockers, and readiness; do not restart a per-comment
+fix/push/review loop here.
 
-Apply minimal fixes locally and verify. For published PRs, prefer a new
+For published PRs, prefer a new
 follow-up commit so reviewers can inspect each round; amend or force-push only
 after explicit maintainer/user approval and only when the user requests it or a
 clear reason exists (removing sensitive content, repairing branch history).
 
-1. Make the local fix silently (no reply), then run the relevant local gates,
-   including `pixi run lint` before any commit.
-2. Merge the latest base branch into the PR branch before any push, and follow
-   the base-merge, automated-review, and bot no-reply rules in
-   `docs/onboarding/ai-reviews.md`. If the push is rejected because the remote
-   head moved, fetch and compare it before retrying and validate an equivalent
-   remote fix instead of pushing a duplicate.
-3. Verify explicit maintainer/user approval covers the push, PR comment, thread
-   resolution, or review re-trigger; reuse existing authority for this PR and
-   scope, asking only where it is missing. With approval, push silently, resolve only
-   reviewed and addressed thread IDs via GraphQL, and — when the approved push
-   addressed Codex comments — re-trigger once with
-   `gh pr comment $1 --body "@codex review"`.
-4. Apply the same no-inline-reply loop to `github-code-quality[bot]` findings;
-   do not re-trigger Codex solely for non-Codex bot findings unless Codex
-   comments were also addressed.
-5. Monitor CI (`gh pr checks $1`) and repeat until no actionable comments remain.
-   For draft PRs, mark ready after explicit approval per the draft-ready
-   criteria in `docs/onboarding/ai-reviews.md`; merge still waits for required
-   hosted checks.
+Run the relevant local gates, including `pixi run lint` before every commit.
+Merge the latest base before each approved push and apply the owner's remote
+divergence recovery if the head moved. Reuse existing explicit authority for
+this PR, action, and scope; ask only where it is missing. No inline bot replies.
+Monitor CI (`gh pr checks $1`); readiness and merge remain separately gated and
+require approval for the corresponding external mutation.
 
 ## Output
 
 - PR number and whether the pass was a review or a feedback round
 - Findings or fixes applied, with file/line references
+- Reviewed head, completion/trigger evidence, completed round count, and any
+  strategy-checkpoint outcome
 - Which actions were local-only and which external mutations were explicitly
   approved
 - Codex/CI state and any remaining blocker

--- a/.claude/commands/dart-manage-pr.md
+++ b/.claude/commands/dart-manage-pr.md
@@ -122,15 +122,19 @@ gh pr checks <PR_NUMBER>
      replies; verify claims locally; apply AI-review fixes silently).
    - For human reviewers, reply only when a response is useful after a fix or
      when a question needs clarification.
-   - After an approved push that addressed Codex comments on a PR that already
-     had a Codex review, post a fresh top-level `@codex review`; that PR comment
-     needs explicit maintainer/user approval and must not duplicate an active
-     trigger.
+   - Follow that owner's single Review-Fix Loop Workflow for completed finding
+     batches, one trigger owner, current-head evidence, and the two-round
+     strategy checkpoint. Preserve review state across handoffs; do not start
+     another manual request merely because a push completed. Every external
+     mutation still requires explicit maintainer/user approval covering its
+     action and PR.
    - For substantive code PRs, an independent review session (a human, or a
      separate agent session running the `dart-review-pr` workflow via
      `/dart-review-pr` or `$dart-review-pr`) must record its outcome —
      findings, or an explicitly clean result — before merge approval;
-     docs-only and mechanical changes are exempt.
+     docs-only and mechanical changes are exempt. Count hosted plus independent
+     coverage and revalidate fixes using `docs/ai/verification.md`; the same
+     independent lane can perform the strategy checkpoint.
 5. Mark ready or merge only when appropriate:
    - Confirm review requirements are satisfied and local validation matches the
      intended transition.
@@ -146,7 +150,8 @@ gh pr checks <PR_NUMBER>
    `pixi run -e cuda test-all`; do not substitute the default run for the CUDA
    run, and record a skip or blocker explicitly. Merge only after CI and review
    are green, the milestone is set, an independent review recorded a clean
-   result on the current post-fix head (after findings, a clean re-review;
+   result covering the current post-fix head (baseline plus delta revalidation
+   is allowed by `docs/ai/verification.md`;
    the step 4 docs-only/mechanical exemption also satisfies this), the
    PR is not draft, GitHub reports it mergeable, and explicit merge approval is
    given. PR comments, review re-triggers, thread resolution, reviewer requests,
@@ -179,6 +184,8 @@ Report:
 - PR number, URL, base, head, draft state, milestone, and merge status.
 - CI summary: passing, failing, pending, or skipped checks.
 - Review summary, independent-review status, and whether `@codex review` ran.
+- Reviewed head, completed round count, trigger/completion evidence, and any
+  strategy-checkpoint outcome or missing review coverage.
 - Local pre-merge validation state when `mode=merge` ran.
 - Commits pushed, merge action, and branch cleanup action.
 - Remaining blockers or next action.

--- a/.claude/commands/dart-pr.md
+++ b/.claude/commands/dart-pr.md
@@ -88,8 +88,8 @@ Use these practices:
 7. Commit only intended files with a plain descriptive commit title.
 8. Merge the latest base branch into the PR branch before any push, and follow
    the base-merge and automated-review rules in `docs/onboarding/ai-reviews.md`
-   (no inline bot replies; `@codex review` re-triggers are throttled to one per
-   approved review-fix round). Ask for explicit maintainer/user approval before
+   (no inline bot replies; one trigger owner and completed fix batches).
+   Ask for explicit maintainer/user approval before
    pushing or opening the draft PR. After approval:
    ```bash
    git push -u origin HEAD
@@ -104,7 +104,11 @@ Use these practices:
     wording, and PR-link follow-up. If `CHANGELOG.md` needs the PR number, keep
     the follow-up changelog commit local until explicit maintainer/user approval
     is given for the additional push or PR update.
-11. Monitor CI: `gh pr checks <PR_NUMBER>`.
+11. Follow the single Review-Fix Loop Workflow in
+    `docs/onboarding/ai-reviews.md`, reusing explicit approval for its action,
+    PR, and scope. Account for the initial automatic review before requesting
+    another; apply the strategy checkpoint and current-head readiness gates.
+    Monitor CI: `gh pr checks <PR_NUMBER>`.
 
 ## Output
 

--- a/.claude/commands/dart-review-pr.md
+++ b/.claude/commands/dart-review-pr.md
@@ -31,40 +31,31 @@ without explicit maintainer/user approval for that external mutation.
 
 ### Address Feedback
 
-```bash
-gh pr view $1 --comments
-```
+Use the paginated review/CI inspection commands and the single Review-Fix Loop
+Workflow in `docs/onboarding/ai-reviews.md`. Collect the completed batch, verify
+claims, and repair the underlying defect family. That owner defines trigger
+ownership, current-head completion, the two-round strategy checkpoint, false
+positive dispositions, blockers, and readiness; do not restart a per-comment
+fix/push/review loop here.
 
-Apply minimal fixes locally and verify. For published PRs, prefer a new
+For published PRs, prefer a new
 follow-up commit so reviewers can inspect each round; amend or force-push only
 after explicit maintainer/user approval and only when the user requests it or a
 clear reason exists (removing sensitive content, repairing branch history).
 
-1. Make the local fix silently (no reply), then run the relevant local gates,
-   including `pixi run lint` before any commit.
-2. Merge the latest base branch into the PR branch before any push, and follow
-   the base-merge, automated-review, and bot no-reply rules in
-   `docs/onboarding/ai-reviews.md`. If the push is rejected because the remote
-   head moved, fetch and compare it before retrying and validate an equivalent
-   remote fix instead of pushing a duplicate.
-3. Verify explicit maintainer/user approval covers the push, PR comment, thread
-   resolution, or review re-trigger; reuse existing authority for this PR and
-   scope, asking only where it is missing. With approval, push silently, resolve only
-   reviewed and addressed thread IDs via GraphQL, and — when the approved push
-   addressed Codex comments — re-trigger once with
-   `gh pr comment $1 --body "@codex review"`.
-4. Apply the same no-inline-reply loop to `github-code-quality[bot]` findings;
-   do not re-trigger Codex solely for non-Codex bot findings unless Codex
-   comments were also addressed.
-5. Monitor CI (`gh pr checks $1`) and repeat until no actionable comments remain.
-   For draft PRs, mark ready after explicit approval per the draft-ready
-   criteria in `docs/onboarding/ai-reviews.md`; merge still waits for required
-   hosted checks.
+Run the relevant local gates, including `pixi run lint` before every commit.
+Merge the latest base before each approved push and apply the owner's remote
+divergence recovery if the head moved. Reuse existing explicit authority for
+this PR, action, and scope; ask only where it is missing. No inline bot replies.
+Monitor CI (`gh pr checks $1`); readiness and merge remain separately gated and
+require approval for the corresponding external mutation.
 
 ## Output
 
 - PR number and whether the pass was a review or a feedback round
 - Findings or fixes applied, with file/line references
+- Reviewed head, completion/trigger evidence, completed round count, and any
+  strategy-checkpoint outcome
 - Which actions were local-only and which external mutations were explicitly
   approved
 - Codex/CI state and any remaining blocker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -485,6 +485,9 @@ compatibility remains on the active DART 6 LTS branch._
 
 #### Build, Packaging, and Developer Tooling
 
+- Automated review workflows now batch related fixes, require a root-cause
+  checkpoint after two rounds still find valid issues, and track review coverage
+  on the current revision while preserving independent review and validation.
 - AI workflows now stage context by task and phase, preserve authorized model,
   effort, and action scopes across handoffs, and audit the whole harness during
   model upgrades. Consolidated session policy and removed duplicate tutorials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Automated review workflows now batch related fixes, require a root-cause
   checkpoint after two rounds still find valid issues, and track review coverage
   on the current revision while preserving independent review and validation.
+  ([#3484](https://github.com/dartsim/dart/pull/3484))
 - AI workflows now stage context by task and phase, preserve authorized model,
   effort, and action scopes across handoffs, and audit the whole harness during
   model upgrades. Consolidated session policy and removed duplicate tutorials

--- a/docs/ai/orchestration.md
+++ b/docs/ai/orchestration.md
@@ -89,7 +89,10 @@ asking again. Routine local work needs no extra approval ceremony.
 
 Review is part of the work cycle, not a final courtesy pass. For every
 meaningful implementation chunk, the orchestrator runs an independent review
-lane after verification and again after any cleanup or fixes. A packet is done
+lane after verification and revalidates cleanup or fixes using the baseline and
+delta rules in `docs/ai/verification.md`. The same lane can perform a PR's
+strategy checkpoint under `docs/onboarding/ai-reviews.md`; avoid redundant
+review sessions with identical scope. A packet is done
 only when it meets the review-pass item of the completion audit in
 `docs/ai/verification.md`, recorded in the owning plan, dev-task
 `verification.md`, or PR evidence.

--- a/docs/ai/verification.md
+++ b/docs/ai/verification.md
@@ -19,7 +19,8 @@ Before finalizing substantial AI-assisted work:
 4. Identify missing, weakly verified, or blocked requirements.
 5. Verify review evidence: at least two clean independent or role-separated
    review passes on the current post-fix state, with substantive findings
-   investigated rather than blindly accepted.
+   investigated rather than blindly accepted. Apply the coverage and
+   revalidation rules in Review Evidence below.
 6. For model/scene, behavior-bearing physics/simulation, or GUI work, verify
    `dart-verify-sim` paired a text correctness oracle with assessed claim-tied
    visual/debug evidence, or recorded a justified unavailable exception.
@@ -115,6 +116,23 @@ visual artifacts before changing behavior. Record whether the finding was fixed,
 deferred, or rejected with evidence. The review-pass requirement is item 5 of
 the completion audit above.
 
+For substantive PRs, a completed hosted review plus the independent local lane
+can satisfy those two passes; do not add a third pass just to count each policy
+wording separately. Without hosted review, local-only work can use two
+independent or role-separated passes, but this does not replace a PR's hosted
+review gate. The substantive-PR independent-session requirement and
+docs-only/mechanical exemption live in `docs/onboarding/ai-reviews.md`.
+
+Preserve the reviewed baseline, findings, and dispositions. After a fix, the
+independent reviewer can revalidate the delta and its interactions against that
+baseline and explicitly record coverage of the resulting state. Expand to a
+full review when scope, architecture, or interactions invalidate the baseline.
+Formatting-only cleanup needs an explicit no-behavior-change assessment rather
+than two new broad local reviews. Required current-head hosted review and
+validation still apply. A clean pass means no unresolved substantive issue;
+verified false positives do not require another round. Add new tests when they
+close a coverage gap, not merely to reject feedback already refuted by evidence.
+
 ## DART 7 Simulation Allocation Evidence
 
 Changes that add, migrate, or materially alter a DART 7 `World::step()` domain,
@@ -155,7 +173,7 @@ Missing or vague acceptance evidence means the task is not ready for execution.
 ## Review Safety Evidence
 
 `docs/onboarding/ai-reviews.md` owns the automated-review loop: no inline
-replies to bot accounts, local verification of each claim, a refuting test for
-false positives, and explicit approval before any push, comment, thread
+replies to bot accounts, local verification and evidence-backed disposition of
+each claim, and explicit approval before any push, comment, thread
 resolution, or re-trigger. The final response states which actions were
 local-only and which external mutations, if any, were explicitly approved.

--- a/docs/onboarding/ai-reviews.md
+++ b/docs/onboarding/ai-reviews.md
@@ -5,15 +5,15 @@ How DART agents and contributors handle review comments from AI bot accounts
 requests. Tool compatibility details live in `ai-tools.md`; the approval
 boundary itself is axiom 9 of `docs/ai/principles.md`.
 
-When AI agents (Claude Code, Codex, etc.) work on PRs, they may encounter review comments from other AI systems (e.g., Codex bot, GitHub Copilot).
-
 ## Independent Review Lane
 
 For substantive code PRs, an independent reviewer session — a human, or a
 separate agent session running `/dart-review-pr` that did not author the
 change — records findings before merge approval. Docs-only and mechanical
 changes are exempt. This complements `@codex review`; it does not replace it.
-`dart-manage-pr` checks this gate in `mode=merge`.
+`dart-manage-pr` checks this gate in `mode=merge`. Hosted review plus this
+independent lane can satisfy the two-pass requirement; see
+`docs/ai/verification.md` for baseline and delta revalidation evidence.
 
 ## Detecting AI-Generated Reviews
 
@@ -45,50 +45,62 @@ changes are exempt. This complements `@codex review`; it does not replace it.
 - Address feedback locally; reuse existing authorization for its action, PR,
   and scope, and ask before external mutations only where authority is missing
 - If the feedback is valid, implement the fix without commenting
-- If the feedback appears incorrect (false positive):
-  1. **Verify** the claim is false by running standalone tests or examining the code
-  2. **Add a test** that explicitly documents the correct behavior AND refutes the claim
-  3. Example: If Codex claims `hprod([2,3,5,7])` returns 294 instead of 210:
-     ```cpp
-     EXPECT_FLOAT_EQ(result, 210.0f);  // Verify correct behavior
-     EXPECT_NE(result, 294.0f);        // Explicitly refute false claim
-     ```
-  4. Add the test locally (no comment needed) - the test serves as permanent documentation
-- **Follow the review-fix loop** (see workflow below)
-
-This avoids noisy bot-to-bot conversations while still leveraging automated verification.
-
-> **Note**: False positives can recur across reviews. Tests that explicitly refute incorrect claims prevent future confusion and document the verification.
+- If feedback is a false positive, record its rejection with code, existing
+  tests, or other concrete evidence in the current task/PR verification notes.
+  Add a regression test only when it closes a coverage gap; do not change code
+  merely to reject a claim or obtain a clean bot verdict.
+- Treat repeated comments as claims to recheck against the current head.
+  Addressed threads can recur, but recurrence is not a product guarantee or
+  proof that a fix failed. Resolve only individually verified, addressed
+  threads with approval; thread resolution itself does not prove correctness.
+- Follow the single review-fix loop below for all automated reviewers.
 
 ## Codex Review For Draft PRs
 
-For fast-moving work, trigger the first Codex review while the PR is still a
-draft when explicit maintainer/user approval covers PR comments. Use a top-level
-comment:
+The settings and their limitations live in
+[ai-tools.md](ai-tools.md#codex-hosted-review-settings). With the recommended
+PR-open trigger, automatic review owns the initial eligible event; the agent
+owns deliberate follow-ups. Check for an automatic run, pending request, or
+completed review of the intended head before requesting one manually. Absence
+of a reaction immediately after an event does not prove no run was queued.
+
+A stable draft can receive early feedback with a top-level comment when no
+review already covers or is queued for its head and explicit maintainer/user
+approval covers PR comments:
 
 ```bash
 gh pr comment <PR> --body "@codex review"
 ```
 
-This keeps the PR draft for human readiness while getting automated feedback
-early. If a Codex activity signal or submitted review already appears, do not
-post a duplicate trigger. After posting, wait for a submitted review, a no-issues
-comment, a thumbs-up reaction, or an eyes reaction before treating the trigger as
-accepted; do not re-trigger unless there is a concrete timeout/blocker or a
-follow-up push addressed Codex findings.
+If every-push or experimental smart detection is configured instead, establish
+who owns the next request before manually triggering. Do not race an automatic
+run or rely on smart detection as proof that the current head was reviewed.
 
-After an approved follow-up push that addresses Codex review comments, request a
-fresh top-level Codex review with `@codex review`. This is the normal completion
-step for a Codex review-fix round, not an inline reply. A manual trigger is a PR
-comment and still requires explicit maintainer/user approval.
+Keep a compact record in the existing task/PR evidence: head SHA, trigger owner
+and comment/run ID, requested time, completion evidence, completed round count,
+and finding dispositions. Preserve it across handoffs; no separate review
+service or ledger is required. Poll bounded status summaries and fetch new
+findings once, rather than repeatedly loading the full history into context.
+
+An eyes reaction acknowledges a request; it is not completion. A submitted
+review, no-issues comment, or bot thumbs-up must be associated with the intended
+head. For reactions without a SHA, require an unambiguous request-to-head link
+and no intervening push; otherwise coverage is unknown. With Exhaustive enabled,
+the first posted finding or submitted review may not be the final batch: inspect
+the associated task/run completion when available. If completion cannot be
+established, record that uncertainty and monitor; do not infer completion from
+silence. Local investigation may proceed while the run finishes, but collect
+the final batch before the next approved push or review request.
 
 ## Draft Ready Fast Path
 
 To move quickly without bypassing branch protection, a draft PR can be marked
 ready for review once all of these are true on the current head:
 
-- Codex review has no unresolved actionable threads, or the latest Codex result
-  is a no-issues comment/reaction.
+- Codex review completed on the current head and all findings have verified
+  dispositions with no unresolved actionable issues. Rejected false positives
+  need evidence, not another identical review. A clean result on an older head
+  or resolving threads alone does not satisfy this gate.
 - Local validation passed after the last pushed change, and the worktree is
   clean: default `pixi run test-all`, plus `pixi run -e cuda test-all` on Linux
   hosts with a visible NVIDIA CUDA runtime.
@@ -101,24 +113,19 @@ approves a policy bypass.
 
 ## Codex Re-Trigger Cadence And Throttling
 
-After explicit maintainer/user approval for the PR comment, re-trigger Codex at
-most once per review-fix round, and only after an approved push that addressed
-its comments. Rapid, repeated `@codex review` requests across many quick rounds
-can slow or suspend Codex: observed review latency grows round over round and a
-later re-trigger can receive no review at all. If Codex stays silent well beyond
-its usual turnaround after a re-trigger, treat it as a throttle/timeout blocker,
-not a reason to re-request. Weekly usage limits are the same class of blocker:
-when quota is exhausted mid-loop, record the converged state plus local
-verification (gates, tests, and an independent or role-separated review pass)
-instead of waiting for another hosted round. Record the converged state as
-evidence — all surfaced findings fixed and their threads resolved — and report
-the throttle rather than re-spamming the PR with more triggers.
+Request at most one Codex run per intended head, after a validated fix batch or
+another change leaves the required current-head coverage missing, and only with
+approval for the PR comment. A non-Codex finding is not itself a trigger; the
+resulting change and missing review coverage determine whether one is needed.
 
-Codex re-emits every unresolved inline thread verbatim on later rounds, even
-when the current head already contains the fix. Verify each re-raised comment
-against the current head; once a thread is genuinely addressed, resolve it
-(after the approval that covers thread resolution) before the next round —
-otherwise the no-issues verdict cannot converge no matter how many rounds run.
+If Codex remains silent beyond its observed turnaround, inspect run state and
+quota before diagnosing a timeout; latency alone does not prove throttling.
+Do not spam retries. After a confirmed failed/cancelled run, retry once only
+when its cause is cleared, no run is pending, and existing approval covers it.
+Weekly quota exhaustion or inaccessible completion evidence is a blocker:
+finish useful local investigation/validation, record known findings and the
+missing hosted evidence, and report the blocker. Do not enable credits, claim a
+clean review, or bypass readiness gates to make the loop finish.
 
 ## Updating Published PRs
 
@@ -171,48 +178,66 @@ pre-retarget head; the post-merge-base push is the state that matters.
 
 ## Review-Fix Loop Workflow
 
-After identifying an AI-generated review comment to address:
+1. **Collect the completed batch.** Verify head and run completion; paginate
+   reviews, inline threads/comments, and relevant issue comments/reactions.
+   Include human feedback. Group findings by the invariant they challenge;
+   record accepted, rejected-with-evidence, or explicitly deferred dispositions.
+   Do not silently defer a valid in-scope defect to reach a clean verdict.
+2. **Check convergence before another round.** Count completed hosted runs,
+   including the initial automatic run, not individual comments or internal
+   Exhaustive passes. If the second run still leaves valid issues, perform the
+   strategy checkpoint below before requesting a third run. Keep the count
+   across pushes and handoffs; later rounds with valid issues require the same
+   checkpoint again.
+3. **Repair the defect family.** Inspect related callers, sibling cases, and
+   interactions before implementing all accepted findings as a coherent batch.
+   For parsers, cover syntax boundaries, reserved delimiters, and literal versus
+   interpreted content; for validators, define valid inputs and a negative-case
+   matrix rather than appending exclusions one at a time. Keep unrelated
+   features out of the repair batch.
+4. **Verify the batch locally.** Run focused regression gates and independent
+   delta review where required by `docs/ai/verification.md`. Fix repair-induced
+   regressions before publication. Run `pixi run lint` before every commit;
+   merge the latest base and rerun affected gates before each approved push.
+5. **Publish once the batch is ready.** Verify explicit approval covers each
+   intended push, thread resolution, and PR comment; reuse existing authority
+   for this action, PR, and scope (including `dart-manage-pr` maintenance).
+   With approval, push silently and resolve only individually verified,
+   addressed threads. Apply the trigger ownership/cadence rules above for one
+   follow-up review of the resulting head, never one request per finding.
+6. **Assess completion.** Monitor the run and CI; new findings return to batch
+   assessment and the convergence checkpoint. Apply the draft-ready and merge
+   gates, or report the specific external blocker. A round budget never grants
+   readiness or excuses a valid defect.
 
-1. **Make the code fix**
-2. **Run `pixi run lint`** — MANDATORY before every commit (auto-fixes formatting)
-3. **Verify explicit maintainer/user approval covers the intended external
-   mutations.** Reuse existing authorization for the action, PR, and scope
-   (including routine maintenance authorized by `dart-manage-pr`); ask only
-   for missing authority. Follow `docs/ai/principles.md`'s shared-state rule.
-4. **If approved, commit and push** silently (no reply to the comment)
-5. **If approved, resolve the thread** using GraphQL (see commands below)
-6. **If the addressed review was Codex, after the approved push, verify
-   approval also covers the PR comment (ask only if missing), then re-trigger the
-   review**:
-   `gh pr comment <PR> --body "@codex review"`
-7. **Monitor for results**:
-   - New review comments → repeat from step 1
-   - "No issues" or 👍 reaction + local validation on the current head: default
-     `pixi run test-all`, plus `pixi run -e cuda test-all` on Linux CUDA hosts
-     → draft PR is ready for human review
+### Strategy Checkpoint
 
-Apply the same no-inline-reply handling to `github-code-quality[bot]` findings:
-fix valid findings locally, push only after approval, and do not post an
-acknowledgment reply. The `@codex review` re-trigger is only for Codex review
-rounds.
+Pause automatic re-triggering and perform a bounded independent root-cause
+review of the affected subsystem. Use the existing independent reviewer when
+possible; this can also supply the required delta review. If an independent
+reviewer is unavailable, continue useful local investigation and validation,
+but report the missing checkpoint and hold further hosted requests. Existing
+trigger approval does not waive this checkpoint, including for docs-only PRs.
 
-**Agents MUST:**
-
-- Run `pixi run lint` before EVERY commit (CI will fail otherwise)
-- Treat PR comments, pushes, thread resolution, reviewer requests, merges, and
-  review re-triggers as external mutations that require explicit approval
-- Keep local fixes read-only with respect to GitHub until that approval exists
+Distinguish missed sibling cases, incomplete fixes, regressions introduced by
+repairs, false positives, and newly expanded scope. Record the underlying
+contract, a coherent repair approach, and regression cases that could disprove
+it in existing verification evidence. Complete those checks before the next
+approved request. Continue within existing authorization; this checkpoint is
+not a routine permission stop. Ask only when repair requires a consequential
+scope decision or missing authority. Preserve unresolved findings explicitly.
 
 ## GraphQL Commands for Thread Resolution
 
 ```bash
-# List unresolved threads (get thread IDs)
-gh api graphql -f query='
-  query {
+# List all unresolved threads; replace PR_NUMBER with the integer PR number.
+gh api graphql --paginate -f query='
+  query($endCursor: String) {
     repository(owner: "dartsim", name: "dart") {
       pullRequest(number: PR_NUMBER) {
-        reviewThreads(first: 20) {
-          nodes { id isResolved path line }
+        reviewThreads(first: 100, after: $endCursor) {
+          nodes { id isResolved isOutdated path line }
+          pageInfo { hasNextPage endCursor }
         }
       }
     }
@@ -238,44 +263,22 @@ conversation" in the UI adds no comment noise. The code change is the response;
 the resolved thread shows the fix was acknowledged after the maintainer/user
 approved the PR mutation.
 
-## Autonomous Review-Fix-Monitor Loop
-
-For agents iterating on automated reviews, the complete loop is:
-
-```
-1. Fetch latest review comments
-2. For each comment:
-   a. Implement the fix (or add a test refuting a false positive)
-   b. Run `pixi run lint` (MANDATORY)
-   c. Build and run relevant tests
-   d. Verify explicit approval covers each push or PR mutation; ask only if missing
-3. If approved, commit and push silently (no reply to bot comment)
-4. If approved, resolve addressed threads via GraphQL
-5. If the addressed review was Codex, after the approved push, verify approval
-   also covers the PR comment (ask only if missing), then re-trigger:
-   `gh pr comment <PR> --body "@codex review"`
-6. For non-Codex bot findings, including `github-code-quality[bot]`, do not
-   re-trigger Codex solely for those fixes unless Codex review comments were
-   also addressed in the same push
-7. Monitor CI: `gh pr checks <PR>`
-8. Wait for new review (poll with `gh api repos/dartsim/dart/pulls/<PR>/reviews`)
-9. If new review has comments → go to step 2
-10. If no new comments AND local validation passed on the current head (default
-    `pixi run test-all`, plus `pixi run -e cuda test-all` on Linux CUDA hosts)
-    → mark draft PRs ready for human review after approval
-11. Keep monitoring hosted CI until required checks pass before merge
-```
-
-**Checking for new reviews:**
+## Review And CI Monitoring
 
 ```bash
-# List all reviews with timestamps
-gh api repos/dartsim/dart/pulls/<PR>/reviews \
-  --jq '.[] | "ID:\(.id) User:\(.user.login) State:\(.state) At:\(.submitted_at)"'
+# List all reviews with reviewed commits and timestamps.
+gh api --paginate repos/dartsim/dart/pulls/<PR>/reviews \
+  --jq '.[] | {id, user: .user.login, state, commit_id, submitted_at}'
 
-# Fetch comments from a specific review
-gh api repos/dartsim/dart/pulls/<PR>/reviews/<REVIEW_ID>/comments \
-  --jq '.[] | "File:\(.path) Line:\(.line // .original_line) Body:\(.body)"'
+# Fetch all inline comments, including replies and review associations.
+gh api --paginate repos/dartsim/dart/pulls/<PR>/comments \
+  --jq '.[] | {id, pull_request_review_id, in_reply_to_id, user: .user.login, path, line, original_line, commit_id, body}'
+
+# Find request/completion comments, then reactions on the relevant comment.
+gh api --paginate repos/dartsim/dart/issues/<PR>/comments \
+  --jq '.[] | {id, user: .user.login, created_at, body}'
+gh api --paginate repos/dartsim/dart/issues/comments/<COMMENT_ID>/reactions \
+  --jq '.[] | {user: .user.login, content, created_at}'
 ```
 
 **Monitoring CI:**
@@ -295,12 +298,25 @@ look like completion. For long runs prefer a resilient poll that re-queries
 `gh pr checks <PR>` on an interval, tolerates transient failures, and stops only
 when nothing is pending, any check fails, or the head SHA moves.
 
-**Stop conditions:**
+Use the readiness gates above and `dart-manage-pr` for merge requirements.
+Classify pre-existing, skipped, cancelled, and external failures with evidence;
+do not treat a required check that never ran as a pass.
 
-- Codex review returns no comments (or only 👍 reactions)
-- Local validation passes on the current head for draft-ready state: default
-  `pixi run test-all`, plus `pixi run -e cuda test-all` on Linux CUDA hosts
-- All required CI checks pass for merge-ready state
-- Pre-existing failures (e.g., `simulation` "Not Run") can be ignored
+## Workflow Validation Cases
 
----
+For changes to this policy, use fresh read-only sessions with the relevant
+workflow entrypoint and hypothetical PR state. Ask for next actions and
+readiness evidence without authorizing real GitHub mutations. Evaluate decisions
+against these cases; structural routing checks alone do not exercise the loop.
+
+| Case                                                          | Expected decision                                                                         |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Automatic review queued, no reaction yet                      | Inspect/wait; no duplicate manual trigger                                                 |
+| Exhaustive run posts findings but completion is unknown       | Investigate locally; hold publication/re-trigger until final batch is established         |
+| Multiple related valid findings                               | Repair and test the underlying family in one batch                                        |
+| Second completed run finds a repair regression                | Independent strategy checkpoint before another approved request; no lowered gate          |
+| Old clean result, new head, all threads resolved              | Current-head review coverage is missing                                                   |
+| More than 100 threads/comments                                | Paginate to exhaustion; examine late human and bot findings                               |
+| Existing test disproves the only finding on the reviewed head | Record rejection; no gratuitous test, push, or repeat review                              |
+| Quota exhausted after fixes                                   | Finish local evidence, report missing hosted review; no credits change or readiness claim |
+| Clean current-head review with required local/CI evidence     | Stop reviewing; take only the authorized readiness/merge transition                       |

--- a/docs/onboarding/ai-tools.md
+++ b/docs/onboarding/ai-tools.md
@@ -174,3 +174,51 @@ the version, date, observed behavior, and untested boundaries here.
 `docs/ai/verification.md` owns gate selection and completion evidence.
 
 Automated PR review handling lives in [ai-reviews.md](ai-reviews.md).
+
+## Codex Hosted Review Settings
+
+Recommended starting configuration, based on the maintainer's settings UI
+confirmed on 2026-09-05:
+
+| Setting                | Choice                  |
+| ---------------------- | ----------------------- |
+| Auto review            | On                      |
+| Review trigger         | On PR open              |
+| Exhaustive code review | On for a measured trial |
+| Enable credits use     | Off                     |
+
+These are account/repository preferences, not local agent model or effort
+settings. Check the effective repository policy as well as personal preferences
+before relying on an automatic trigger. See the
+[official GitHub review documentation](https://learn.chatgpt.com/docs/third-party/github)
+for automatic/manual requests and scoped repository review rules.
+
+The observed UI exposes one general Exhaustive toggle. Treat it as enabled for
+follow-up reviews too; there is no observed initial-review-only or per-round
+control. Do not toggle it between rounds. Its description promises continued
+search for additional findings until no new issues are found, not defect-free
+code. Internal pass count, billing multiplier, and cost savings were not
+established. Completion must use the evidence rules in
+[ai-reviews.md](ai-reviews.md#codex-review-for-draft-prs).
+
+PR-open automation plus deliberate manual follow-ups fits batched fixes.
+Every-push automation can race those requests; experimental smart detection is
+not proof of required current-head coverage. A different chosen configuration
+must still obey the single-trigger-owner rule. Changing account settings or
+enabling credits requires separate explicit authorization.
+
+### Evaluating The Trial
+
+Evaluate the next ten representative PRs using their existing verification
+evidence, recording PR/head, settings, hosted round count, accepted/rejected
+findings, repair-induced regressions, time to readiness, and local agent tokens
+and hosted review usage where available. Compare with similar prior PRs and
+separate physics, tooling, and documentation changes; unavailable usage is
+unknown, not zero. Do not infer dollar savings from comment counts.
+
+Retain Exhaustive if broader early discovery and fewer repair cycles justify
+its review usage without degrading quality. Otherwise recommend disabling the
+general toggle while retaining batching and the strategy checkpoint. Report
+the sample and limitations; neither structural checks nor a small mixed sample
+prove causal savings. This is a trial protocol, not evidence that ten PRs have
+already been evaluated.


### PR DESCRIPTION
## Summary

Batch related automated-review fixes and require an independent root-cause checkpoint when a second hosted round still finds valid issues. Review completion stays tied to the current revision, with existing validation and approval requirements preserved.

## Motivation / Problem

Long review histories in #3445 and #3479 exposed related validation gaps and regressions introduced by narrow repairs. The current workflow repeatedly requests another hosted review after each fix, multiplying repair, validation, and context costs.

## Changes / Key Changes

- Consolidate the review loop in its handbook owner and regenerate the three affected workflow adapters.
- Collect the completed finding batch, repair related cases together, and preserve the round count and checkpoint across handoffs.
- Give each review request one owner, paginate review history, and distinguish request acknowledgement from completed current-revision evidence.
- Count hosted plus independent review coverage explicitly; permit focused delta revalidation and evidence-backed rejection of false positives.
- Document the general Exhaustive toggle and the ten-PR evaluation protocol. No per-round setting or measured cost savings are claimed.

## Before / After

| Before | After |
| --- | --- |
| Repeated fix/push/review cycles with no strategy threshold | Validated fix batches and an independent checkpoint after two problematic rounds |
| Duplicate manual/automatic requests and partial history can mislead progress | One trigger owner, paginated history, and revision-bound completion evidence |
| False positives always require new tests; review-count rules can multiply passes | Reuse sufficient evidence and revalidate changed interactions against a reviewed baseline |

## Testing

- `pixi run test-ai-infra`: 552 passed.
- `pixi run check-ai-infra`, `pixi run check-ai-commands`, `pixi run exercise-agent-scenarios`: passed; all eight routing scenarios pass.
- `pixi run check-docs-policy`, `pixi run check-lint-md`, `pixi run check-lint-spell`, `git diff --check`: passed. Docs policy reports advisory freshness notices.
- Two independent read-only review passes completed, including twelve hypothetical workflow cases. These are instruction-behavior checks, not hosted execution or a measured cost comparison.
- The paginated GraphQL example retrieved all 186 threads of #3445 across two pages.
- `pixi run test-all` and `pixi run -e cuda test-all`: both attempted and stopped in full lint, before build/tests, on twelve existing AVBD capture-source digest mismatches across three evidence packets. The checker, packets, and hashed source inputs are unchanged from base `db96472a543`. These failures were disclosed when opening the PR as a draft; neither full suite is reported as passing.
- [Hosted Lint on final head `f702e10`](https://github.com/dartsim/dart/actions/runs/33982881705/job/101351141916) independently reproduced those same twelve AVBD digest mismatches. Documentation passed; other hosted checks were still pending at the post-review verification.
- Principle audit: existing owners and gates retained; no engine/API or runtime-configuration changes. Source guidance grows to cover the new decisions; lower end-to-end cost remains a trial hypothesis. Temporary task files were removed after durable guidance moved to the handbook.

## Review / Trial Evidence

- PR/head: #3484 at `f702e10df9ec1478be53eda6a6875e6f092c5483`; documentation/contributor-workflow change.
- User-confirmed settings: Auto review on, On PR open, Exhaustive on, credits off. No account settings were changed by this PR.
- Hosted rounds: **1 completed**, with **0 findings** and no review-driven repairs. The [review result](https://github.com/dartsim/dart/pull/3484#issuecomment-5553767317) identifies the current commit; the [review activity summary](https://github.com/dartsim/dart/pull/3484#issuecomment-5553767554) explicitly reports Completed. Paginated reviews, threads, inline comments, and issue comments show no unresolved findings or human requests.
- The [single manual request](https://github.com/dartsim/dart/pull/3484#issuecomment-5553752369) was posted at 18:04:11 UTC on 2026-09-05; completion was recorded at 18:06:44 UTC, approximately 2 minutes 33 seconds later. No intervening push occurred. Accepted/rejected findings: 0/0; repair-induced regressions: none observed, with no hosted-review-driven repairs.
- The maintainer (`jslee02`) marked this PR ready at 18:10:47 UTC and merged it at 18:10:53 UTC on 2026-09-05 as `55d95ac9bafbf04e0e2094d4ab221dfbc30f4b85`, verified on `main`. Validation-based readiness was not established before merge; time to readiness is not inferred from the merge time.
- Local agent tokens and hosted review usage were not measured. This is one observation toward the ten-PR trial, not evidence of cost savings or a completed evaluation.

## Breaking Changes

- [x] None to C++, Python, or runtime APIs. The contributor review workflow now requires the documented strategy checkpoint.

## Related Issues / PRs (backports)

- Review-history examples: #3445, #3479.
- Main-only workflow revision in this PR; release-branch adaptation is separate and no backport PR is included.

---

#### Checklist

- [x] Milestone set: DART 7.0 for `main`.
- [x] CHANGELOG.md updated for the contributor workflow change.
- [x] Unit tests: N/A, no executable implementation changed; existing infrastructure tests and fresh behavioral cases were exercised.
- [x] Methods/classes: N/A; workflow documentation updated.
- [x] Python bindings: N/A.
