### PR TITLE
Probe: documentation-only change against the CI cache/filter branch

### DIFF
--- a/docs/dev_tasks/ci-optimization/RESUME.md
+++ b/docs/dev_tasks/ci-optimization/RESUME.md
@@ -37,6 +37,13 @@ the durable owner is [`../../onboarding/ci-cd.md`](../../onboarding/ci-cd.md).
 - Merge the latest `main` before every push; never rebase the published
   branch.
 
+## Evidence Probe
+
+This file was touched by a documentation-only pull request against the
+PR-1 branch to demonstrate that the shared code filter reports
+`code=false` and every platform and wheel job is skipped; the probe PR is
+closed without merging once the run is recorded.
+
 ## Context At Risk
 
 - The measured baseline numbers (README) come from PR #3455 and the


### PR DESCRIPTION
Evidence probe for #3485: a documentation-only change whose pull-request run must report `Filter code = false` in every `changes` job and skip every platform and wheel job while the required checks stay green. Not for merging; closed once the run is recorded.

Base: `ci/fix-compiler-cache-and-path-filter`.