### PR TITLE
Clarify local autonomy and task completion in agent workflows

### DIFF
--- a/.agents/skills/dart-contribute/SKILL.md
+++ b/.agents/skills/dart-contribute/SKILL.md
@@ -35,9 +35,11 @@ dual-PR rule in `docs/onboarding/contributing.md`).
 ## PR Path
 
 Run `pixi run lint` before committing and the task-type gate set from
-`docs/ai/verification.md`; use `dart-pr` to commit, push, and open the PR after
-explicit maintainer/user approval, and `dart-changelog` to decide the
-`CHANGELOG.md` entry per `docs/onboarding/changelog.md`. Use plain descriptive
+`docs/ai/verification.md`; use `dart-pr` for authorized local preparation and
+commits. Before publication or another approval-gated action, verify existing
+explicit maintainer/user approval covers its action, target, and scope; ask only
+for missing authority. Use `dart-changelog` to decide the `CHANGELOG.md` entry
+per `docs/onboarding/changelog.md`. Use plain descriptive
 commit messages and PR titles without agent tags. Update published PR branches
 with additive commits after merging the target branch; never rebase or
 force-push a published PR branch unless the maintainer explicitly asks.

--- a/.agents/skills/dart-fix-ci/SKILL.md
+++ b/.agents/skills/dart-fix-ci/SKILL.md
@@ -54,10 +54,12 @@ the renderer is unavailable.
    `main`. If continuing an existing PR, fetch and check out that PR branch
    instead of creating a new one. For a `release-*` base, branch from the
    release branch and prefer cherry-picking the proven `main` fix; keep any new
-   fix release-scoped and minimal:
+   fix release-scoped and minimal. Create a uniquely named branch. If the intended
+   branch exists, inspect and resume it within the requested scope or choose a
+   fresh name; do not reset it:
    ```bash
    git fetch origin <RELEASE_BRANCH>
-   git checkout -B fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   git switch --no-track -c fix/<unique-topic>-<release-branch> origin/<RELEASE_BRANCH>
    ```
 6. Reproduce locally with the smallest relevant command:
    - formatting: `pixi run lint`

--- a/.agents/skills/dart-fix-issue/SKILL.md
+++ b/.agents/skills/dart-fix-issue/SKILL.md
@@ -46,12 +46,15 @@ exception.
    `origin/release-6.*` branch; otherwise start from `origin/main`.
 3. Fix with minimal changes + add regression test. For dual-PR bug fixes, fix
    the active DART 6 LTS branch first, then cherry-pick or reapply to `main`.
-4. `pixi run lint`, then the smallest relevant tests and the task-type gate
+4. For an intermediate commit or PR, preserve and update the active task folder.
+   In the completing change, follow `docs/dev_tasks/README.md`: complete feasible
+   work, promote durable artifacts, and remove the folder before final validation
+   and commit. Preserve its approval requirement for retiring unfinished work.
+5. `pixi run lint`, then the smallest relevant tests and the task-type gate
    set from `docs/ai/verification.md`
-5. Before PR creation, invoke the `dart-changelog` routine to decide whether
+6. Before PR creation, invoke the `dart-changelog` routine to decide whether
    `CHANGELOG.md` needs an entry, then fill `.github/PULL_REQUEST_TEMPLATE.md`.
-6. After explicit maintainer/user approval, `git push -u origin HEAD && gh pr create --base <target-branch> --milestone "<milestone>"`
-7. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
+7. After explicit maintainer/user approval, `git push -u origin HEAD && gh pr create --base <target-branch> --milestone "<milestone>"`
 
 ## CRITICAL: Dual-PR for Bug Fixes
 

--- a/.agents/skills/dart-new-task/SKILL.md
+++ b/.agents/skills/dart-new-task/SKILL.md
@@ -65,20 +65,19 @@ Then load owners when the task needs them:
      DART 6 LTS `origin/release-6.*` branch first, then cherry-pick or reapply
      to `main`
 4. **Implement** - Keep commits focused, follow code style
-5. **Verify** - Run `pixi run lint` before committing, then the gate set for
+5. **Task lifecycle** - For an intermediate commit or PR, preserve and update
+   the active task folder. In the completing change, follow
+   `docs/dev_tasks/README.md`: complete feasible work, promote durable artifacts,
+   and remove the folder before final validation and commit. Preserve the
+   owner's approval requirement for retiring unfinished work.
+6. **Verify** - Run `pixi run lint` before committing, then the gate set for
    this task type from `docs/ai/verification.md`. If the claim depends on 3D
    structure or behavior, route through `dart-verify-sim`: text oracle first,
    then assessed claim-tied visual evidence, or record why it is not applicable.
-6. **PR** - After explicit maintainer/user approval, `git push -u origin HEAD`
+7. **PR** - After explicit maintainer/user approval, `git push -u origin HEAD`
    then `gh pr create --draft --base <target-branch> --milestone "<milestone>"`
    (`DART 7.0` for `main`, branch-matching DART 6.x release milestone for the
    active DART 6 LTS branch); follow `.github/PULL_REQUEST_TEMPLATE.md`
-7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, first
-   promote durable dashboards, evidence matrices, API inventories, migration
-   maps, or long-lived decisions into the durable owner selected by the
-   placement matrix in `docs/README.md`.
-   Then remove the dev-task folder completely (include the deletion in this PR,
-   not after merge).
 
 ## Type-Specific
 

--- a/.agents/skills/dart-next/SKILL.md
+++ b/.agents/skills/dart-next/SKILL.md
@@ -48,11 +48,12 @@ Interpret `$ARGUMENTS` as optional constraints:
 - `mode=select`: choose one task and stop with evidence.
 - `mode=execute`: choose one task, make local changes, and verify locally.
   This is the default when the user asks to do the work.
-- `mode=pr`: execute locally and prepare PR text, then ask for explicit
-  maintainer/user approval before any GitHub, PR, CI, branch, or review-thread
-  mutation, including pushes, PR creation, PR comments, reviewer requests,
-  review re-triggers, thread resolution, ready-for-review transitions, merges,
-  CI reruns, or branch deletion.
+- `mode=pr`: execute locally and prepare PR text. Before an action requiring
+  explicit maintainer/user approval under `docs/ai/principles.md` and the PR
+  owner docs, verify existing authorization covers its action, target, and
+  scope; ask only for missing authority. Ordinary authorized local branch
+  creation is preparation; shared-state mutations, branch deletion, and
+  destructive Git operations retain their approval requirements.
 - `size=tiny|small|medium|large` or `days=N`: fit the chosen task to the
   requested scope. Default to `small`, meaning one focused local session.
 - `focus=<topic>`: prefer a focus area without making it the only allowed
@@ -80,9 +81,12 @@ clarifying question.
    - `docs/ai/north-star.md` gaps and readiness criteria;
    - issue, PR, or CI state named by the user or inferable from the branch.
 3. Exclude candidates that are blocked, larger than the requested size, missing
-   enough evidence to start, likely to require unapproved GitHub mutations, or
-   only bootstrap/maintain the `dart-next` workflow itself unless explicitly
-   focused.
+   enough evidence to start, or only bootstrap/maintain the `dart-next` workflow
+   itself unless explicitly focused. Missing approval excludes a candidate only
+   when it has no useful bounded deliverable within the selected mode and
+   current authorization. A later publication requirement does not disqualify
+   local preparation. Preserve explicitly named targets; report their remaining
+   approval boundary after completing authorized work.
 4. Prefer the highest-value remaining candidate in this order:
    - user-specified issue, PR, failing check, or file path;
    - candidates matching `focus=<topic>` or `area=<dimension>`;
@@ -140,10 +144,11 @@ update `docs/dev_tasks/<task>/` according to `docs/dev_tasks/README.md`.
 ## PR And Review Management
 
 Use `$dart-pr` or `/dart-pr` only after local verification is complete and the
-user requested PR preparation. Ask for explicit maintainer/user approval before
-any GitHub, PR, CI, branch, or review-thread mutation, including push, PR
-creation, PR comment, reviewer request, review re-trigger, review-thread
-resolution, ready-for-review transition, CI rerun, merge, or branch deletion.
+user requested PR preparation. Verify existing explicit maintainer/user approval
+for each approval-gated action under `docs/ai/principles.md` and the PR owner
+docs; ask only for missing or changed authority. Local branch creation and
+other authorized preparation need no extra approval. Shared-state mutations,
+branch deletion, and destructive Git operations retain their approval boundaries.
 
 After a PR exists and explicit approval covers PR management, use
 `$dart-manage-pr` or `/dart-manage-pr` for CI, review, and cleanup; the Codex

--- a/.agents/skills/dart-pr/SKILL.md
+++ b/.agents/skills/dart-pr/SKILL.md
@@ -25,8 +25,10 @@ user.
 
 ## Command Body
 
-Prepare or open a DART pull request after explicit maintainer/user approval:
-$ARGUMENTS
+Prepare the PR locally within the authorized task: $ARGUMENTS
+Before an action requiring explicit maintainer/user approval under the owner
+docs, verify that existing authorization covers its action, target, and scope.
+Ask only for missing or changed authority after completing authorized preparation.
 
 ## Required Reading
 
@@ -110,8 +112,8 @@ Use these practices:
 8. Merge the latest base branch into the PR branch before any push, and follow
    the base-merge and automated-review rules in `docs/onboarding/ai-reviews.md`
    (no inline bot replies; one trigger owner and completed fix batches).
-   Ask for explicit maintainer/user approval before
-   pushing or opening the draft PR. After approval:
+   Verify explicit maintainer/user approval covers pushing and opening the draft
+   PR; ask only for missing authority. With that approval:
    ```bash
    git push -u origin HEAD
    gh pr create --draft --base <target-branch> --milestone "<milestone>" \
@@ -123,8 +125,9 @@ Use these practices:
    repairing branch history).
 10. Invoke the `dart-changelog` routine for the changelog decision, entry
     wording, and PR-link follow-up. If `CHANGELOG.md` needs the PR number, keep
-    the follow-up changelog commit local until explicit maintainer/user approval
-    is given for the additional push or PR update.
+    the follow-up changelog commit local unless existing explicit maintainer/user
+    approval covers its push or PR update; otherwise request only the missing
+    authority.
 11. Follow the single Review-Fix Loop Workflow in
     `docs/onboarding/ai-reviews.md`, reusing explicit approval for its action,
     PR, and scope. Account for the initial automatic review before requesting

--- a/.claude/commands/dart-fix-ci.md
+++ b/.claude/commands/dart-fix-ci.md
@@ -33,10 +33,12 @@ the renderer is unavailable.
    `main`. If continuing an existing PR, fetch and check out that PR branch
    instead of creating a new one. For a `release-*` base, branch from the
    release branch and prefer cherry-picking the proven `main` fix; keep any new
-   fix release-scoped and minimal:
+   fix release-scoped and minimal. Create a uniquely named branch. If the intended
+   branch exists, inspect and resume it within the requested scope or choose a
+   fresh name; do not reset it:
    ```bash
    git fetch origin <RELEASE_BRANCH>
-   git checkout -B fix/<issue>-<release-branch> origin/<RELEASE_BRANCH>
+   git switch --no-track -c fix/<unique-topic>-<release-branch> origin/<RELEASE_BRANCH>
    ```
 6. Reproduce locally with the smallest relevant command:
    - formatting: `pixi run lint`

--- a/.claude/commands/dart-fix-issue.md
+++ b/.claude/commands/dart-fix-issue.md
@@ -25,12 +25,15 @@ exception.
    `origin/release-6.*` branch; otherwise start from `origin/main`.
 3. Fix with minimal changes + add regression test. For dual-PR bug fixes, fix
    the active DART 6 LTS branch first, then cherry-pick or reapply to `main`.
-4. `pixi run lint`, then the smallest relevant tests and the task-type gate
+4. For an intermediate commit or PR, preserve and update the active task folder.
+   In the completing change, follow `docs/dev_tasks/README.md`: complete feasible
+   work, promote durable artifacts, and remove the folder before final validation
+   and commit. Preserve its approval requirement for retiring unfinished work.
+5. `pixi run lint`, then the smallest relevant tests and the task-type gate
    set from `docs/ai/verification.md`
-5. Before PR creation, invoke the `dart-changelog` routine to decide whether
+6. Before PR creation, invoke the `dart-changelog` routine to decide whether
    `CHANGELOG.md` needs an entry, then fill `.github/PULL_REQUEST_TEMPLATE.md`.
-6. After explicit maintainer/user approval, `git push -u origin HEAD && gh pr create --base <target-branch> --milestone "<milestone>"`
-7. **Before PR**: If task used `docs/dev_tasks/<task>/`, remove the folder (include in this PR, not after merge)
+7. After explicit maintainer/user approval, `git push -u origin HEAD && gh pr create --base <target-branch> --milestone "<milestone>"`
 
 ## CRITICAL: Dual-PR for Bug Fixes
 

--- a/.claude/commands/dart-new-task.md
+++ b/.claude/commands/dart-new-task.md
@@ -44,20 +44,19 @@ Then load owners when the task needs them:
      DART 6 LTS `origin/release-6.*` branch first, then cherry-pick or reapply
      to `main`
 4. **Implement** - Keep commits focused, follow code style
-5. **Verify** - Run `pixi run lint` before committing, then the gate set for
+5. **Task lifecycle** - For an intermediate commit or PR, preserve and update
+   the active task folder. In the completing change, follow
+   `docs/dev_tasks/README.md`: complete feasible work, promote durable artifacts,
+   and remove the folder before final validation and commit. Preserve the
+   owner's approval requirement for retiring unfinished work.
+6. **Verify** - Run `pixi run lint` before committing, then the gate set for
    this task type from `docs/ai/verification.md`. If the claim depends on 3D
    structure or behavior, route through `dart-verify-sim`: text oracle first,
    then assessed claim-tied visual evidence, or record why it is not applicable.
-6. **PR** - After explicit maintainer/user approval, `git push -u origin HEAD`
+7. **PR** - After explicit maintainer/user approval, `git push -u origin HEAD`
    then `gh pr create --draft --base <target-branch> --milestone "<milestone>"`
    (`DART 7.0` for `main`, branch-matching DART 6.x release milestone for the
    active DART 6 LTS branch); follow `.github/PULL_REQUEST_TEMPLATE.md`
-7. **Cleanup** - Before PR: if task used `docs/dev_tasks/<task>/`, first
-   promote durable dashboards, evidence matrices, API inventories, migration
-   maps, or long-lived decisions into the durable owner selected by the
-   placement matrix in `docs/README.md`.
-   Then remove the dev-task folder completely (include the deletion in this PR,
-   not after merge).
 
 ## Type-Specific
 

--- a/.claude/commands/dart-next.md
+++ b/.claude/commands/dart-next.md
@@ -27,11 +27,12 @@ Interpret `$ARGUMENTS` as optional constraints:
 - `mode=select`: choose one task and stop with evidence.
 - `mode=execute`: choose one task, make local changes, and verify locally.
   This is the default when the user asks to do the work.
-- `mode=pr`: execute locally and prepare PR text, then ask for explicit
-  maintainer/user approval before any GitHub, PR, CI, branch, or review-thread
-  mutation, including pushes, PR creation, PR comments, reviewer requests,
-  review re-triggers, thread resolution, ready-for-review transitions, merges,
-  CI reruns, or branch deletion.
+- `mode=pr`: execute locally and prepare PR text. Before an action requiring
+  explicit maintainer/user approval under `docs/ai/principles.md` and the PR
+  owner docs, verify existing authorization covers its action, target, and
+  scope; ask only for missing authority. Ordinary authorized local branch
+  creation is preparation; shared-state mutations, branch deletion, and
+  destructive Git operations retain their approval requirements.
 - `size=tiny|small|medium|large` or `days=N`: fit the chosen task to the
   requested scope. Default to `small`, meaning one focused local session.
 - `focus=<topic>`: prefer a focus area without making it the only allowed
@@ -59,9 +60,12 @@ clarifying question.
    - `docs/ai/north-star.md` gaps and readiness criteria;
    - issue, PR, or CI state named by the user or inferable from the branch.
 3. Exclude candidates that are blocked, larger than the requested size, missing
-   enough evidence to start, likely to require unapproved GitHub mutations, or
-   only bootstrap/maintain the `dart-next` workflow itself unless explicitly
-   focused.
+   enough evidence to start, or only bootstrap/maintain the `dart-next` workflow
+   itself unless explicitly focused. Missing approval excludes a candidate only
+   when it has no useful bounded deliverable within the selected mode and
+   current authorization. A later publication requirement does not disqualify
+   local preparation. Preserve explicitly named targets; report their remaining
+   approval boundary after completing authorized work.
 4. Prefer the highest-value remaining candidate in this order:
    - user-specified issue, PR, failing check, or file path;
    - candidates matching `focus=<topic>` or `area=<dimension>`;
@@ -119,10 +123,11 @@ update `docs/dev_tasks/<task>/` according to `docs/dev_tasks/README.md`.
 ## PR And Review Management
 
 Use `$dart-pr` or `/dart-pr` only after local verification is complete and the
-user requested PR preparation. Ask for explicit maintainer/user approval before
-any GitHub, PR, CI, branch, or review-thread mutation, including push, PR
-creation, PR comment, reviewer request, review re-trigger, review-thread
-resolution, ready-for-review transition, CI rerun, merge, or branch deletion.
+user requested PR preparation. Verify existing explicit maintainer/user approval
+for each approval-gated action under `docs/ai/principles.md` and the PR owner
+docs; ask only for missing or changed authority. Local branch creation and
+other authorized preparation need no extra approval. Shared-state mutations,
+branch deletion, and destructive Git operations retain their approval boundaries.
 
 After a PR exists and explicit approval covers PR management, use
 `$dart-manage-pr` or `/dart-manage-pr` for CI, review, and cleanup; the Codex

--- a/.claude/commands/dart-pr.md
+++ b/.claude/commands/dart-pr.md
@@ -4,8 +4,10 @@ argument-hint: "[base=<branch>] [draft]"
 agent: build
 ---
 
-Prepare or open a DART pull request after explicit maintainer/user approval:
-$ARGUMENTS
+Prepare the PR locally within the authorized task: $ARGUMENTS
+Before an action requiring explicit maintainer/user approval under the owner
+docs, verify that existing authorization covers its action, target, and scope.
+Ask only for missing or changed authority after completing authorized preparation.
 
 ## Required Reading
 
@@ -89,8 +91,8 @@ Use these practices:
 8. Merge the latest base branch into the PR branch before any push, and follow
    the base-merge and automated-review rules in `docs/onboarding/ai-reviews.md`
    (no inline bot replies; one trigger owner and completed fix batches).
-   Ask for explicit maintainer/user approval before
-   pushing or opening the draft PR. After approval:
+   Verify explicit maintainer/user approval covers pushing and opening the draft
+   PR; ask only for missing authority. With that approval:
    ```bash
    git push -u origin HEAD
    gh pr create --draft --base <target-branch> --milestone "<milestone>" \
@@ -102,8 +104,9 @@ Use these practices:
    repairing branch history).
 10. Invoke the `dart-changelog` routine for the changelog decision, entry
     wording, and PR-link follow-up. If `CHANGELOG.md` needs the PR number, keep
-    the follow-up changelog commit local until explicit maintainer/user approval
-    is given for the additional push or PR update.
+    the follow-up changelog commit local unless existing explicit maintainer/user
+    approval covers its push or PR update; otherwise request only the missing
+    authority.
 11. Follow the single Review-Fix Loop Workflow in
     `docs/onboarding/ai-reviews.md`, reusing explicit approval for its action,
     PR, and scope. Account for the initial automatic review before requesting

--- a/.claude/skills/dart-contribute/SKILL.md
+++ b/.claude/skills/dart-contribute/SKILL.md
@@ -30,9 +30,11 @@ dual-PR rule in `docs/onboarding/contributing.md`).
 ## PR Path
 
 Run `pixi run lint` before committing and the task-type gate set from
-`docs/ai/verification.md`; use `dart-pr` to commit, push, and open the PR after
-explicit maintainer/user approval, and `dart-changelog` to decide the
-`CHANGELOG.md` entry per `docs/onboarding/changelog.md`. Use plain descriptive
+`docs/ai/verification.md`; use `dart-pr` for authorized local preparation and
+commits. Before publication or another approval-gated action, verify existing
+explicit maintainer/user approval covers its action, target, and scope; ask only
+for missing authority. Use `dart-changelog` to decide the `CHANGELOG.md` entry
+per `docs/onboarding/changelog.md`. Use plain descriptive
 commit messages and PR titles without agent tags. Update published PR branches
 with additive commits after merging the target branch; never rebase or
 force-push a published PR branch unless the maintainer explicitly asks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ are maintained sources, not generated adapters.
 - [ ] `pixi run build` — If C++/Python code changed
 - [ ] `pixi run test-unit` — If behavior could be affected
 - [ ] **CHANGELOG.md** — Use `/dart-changelog` or `$dart-changelog` to decide and update according to `docs/onboarding/changelog.md` if adding features, fixing bugs, or making breaking changes
-- [ ] **Dev task cleanup** — If task used `docs/dev_tasks/<task>/`, promote durable artifacts and remove the folder in this PR (not after merge)
+- [ ] **Dev task lifecycle** — For an intermediate commit or PR, preserve and update the active `docs/dev_tasks/<task>/` folder. In the completing change, promote durable artifacts and remove the folder before final validation and commit. Follow `docs/dev_tasks/README.md`, including approval for retiring unfinished work.
 
 Shortcut: `pixi run test-all` runs lint + build + all tests.
 On Linux hosts with a visible NVIDIA CUDA runtime, also run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -513,7 +513,7 @@ compatibility remains on the active DART 6 LTS branch._
 - Agent workflows prepare authorized local work before approval boundaries,
   preserve active task handoffs through checkpoint PRs, and avoid resetting
   existing CI-fix branches. Explicit publication approval and approval to retire
-  unfinished work remain required. ([workflow policy](docs/ai/principles.md))
+  unfinished work remain required. ([#3488](https://github.com/dartsim/dart/pull/3488))
 - Retrospectives now compare the original request with successful or
   unsatisfactory outcomes, validate reusable harness improvements, and skip
   unsupported edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,6 +510,10 @@ compatibility remains on the active DART 6 LTS branch._
   model upgrades. Consolidated session policy and removed duplicate tutorials
   and stale examples. AI diagnosis reports declared workflow reading size.
   ([#3477](https://github.com/dartsim/dart/pull/3477))
+- Agent workflows prepare authorized local work before approval boundaries,
+  preserve active task handoffs through checkpoint PRs, and avoid resetting
+  existing CI-fix branches. Explicit publication approval and approval to retire
+  unfinished work remain required. ([workflow policy](docs/ai/principles.md))
 - Retrospectives now compare the original request with successful or
   unsatisfactory outcomes, validate reusable harness improvements, and skip
   unsupported edits.

--- a/docs/onboarding/contributing.md
+++ b/docs/onboarding/contributing.md
@@ -61,6 +61,11 @@ to ensure fixes are available in both DART 6 and DART 7. Use the highest
 maintained `release-6.*` branch advertised by the upstream remote; this checkout
 currently sees `release-6.20`.
 
+If evidence shows that the release branch has no affected implementation, record
+that evidence and the unresolved release requirement. Continue authorized local
+work without inventing unrelated release changes. This finding does not by
+itself waive the dual-PR requirement; a scope exception needs maintainer direction.
+
 1. **Fix on release branch first**:
 
    ```bash


### PR DESCRIPTION
## Summary

Agents can complete authorized local preparation and preserve active task handoffs through checkpoint changes. Publication, destructive Git actions, and retirement of unfinished work retain their explicit approval requirements.

## Motivation / Problem

Some workflow entrypoints gate local preparation before there is a concrete result to approve, reject useful local tasks because publication needs later approval, or require active task tracking to be removed at every commit. These clauses conflict with their owner policies and can interrupt otherwise authorized work.

## Changes / Key Changes

- Clarify local preparation and reuse of approval covering the same action, target, and scope in `dart-pr`, `dart-contribute`, and `dart-next`.
- Preserve active task folders for intermediate changes; retire completed tracking before final validation and commit.
- Replace the resetting CI-fix branch example with unique branch creation.
- Record release applicability evidence without granting an automatic dual-PR exception.
- Regenerate the six affected Codex skill adapters and add the contributor-workflow changelog entry.

## Before / After

| Workflow | Before | After |
| --- | --- | --- |
| Local PR preparation | Opening wording can demand approval before preparation | Prepare authorized work, then ask only for missing authority at the gated action |
| Task selection | A later GitHub approval requirement can exclude a useful named task | Keep its bounded authorized local deliverable |
| Checkpoint change | Cleanup wording can delete active task tracking | Preserve and update tracking until the completing change |
| Existing CI-fix branch | Repeating `checkout -B` can reset its tip | Inspect/resume within scope or create a fresh unique branch |

## Testing

- `pixi run sync-ai-commands`, `pixi run lint-md`, `pixi run check-lint-md`, `pixi run check-ai-commands`, `pixi run check-ai-infra`, `pixi run check-docs-policy`, and `pixi run check-lint-spell` passed.
- `pixi run test-ai-infra`: 596 passed.
- Reviewed authorization, named-task selection, checkpoint/completion, branch-preservation, and release-applicability scenarios; independent final review found no unresolved in-scope issue. These are instruction reviews, not proof from every possible model run.
- An isolated Git smoke check confirmed duplicate `git switch --no-track -c` creation fails without moving the existing branch tip.
- Principle/completion audit: each change maps to the instruction audit; explicit approval and scope owners are preserved; generated adapters agree; completed temporary task tracking was removed.
- `pixi run lint` passed; the commit hook separately passed on all 15 staged paths. Existing stale AVBD evidence was reported as an advisory under the configured structural lint policy.
- `pixi run test-all` passed: Release/Debug builds, test/example builds, 229 core C++ tests, 81 simulation tests, 2,015 Python tests, and documentation. The existing configuration disabled `test_world` and `test_rigid_ipc_paper_experiments` and skipped 19 Python cases; no test-selection settings were changed.
- `CONDA_OVERRIDE_CUDA=13 PYTHONUNBUFFERED=1 pixi run --locked -e cuda --platform linux-64-cuda test-all` passed: Release/Debug builds, 213 core C++ tests, 80 enabled simulation tests, documentation, all eight dedicated GPU tests, and CUDA benchmark smoke checks. GUI, Python, and examples use the existing CUDA feature's disabled settings. Pixi 0.79.0 rejected automatic platform selection before any CUDA tests ran; selecting the existing named platform resolved startup. The override matches the existing CI setting; no manifest or driver changes were made.
- Full CPU/CUDA runs cover `89c568d9a`. The subsequent changelog-link-only change passed full lint and all listed docs/AI gates again, including 596 AI-infrastructure tests; delta review confirmed no behavior change.

## Breaking Changes

- [x] None. No C++/Python API or simulation behavior changes.

## Related Issues / PRs (backports)

- Issues/related PRs: None.
- Backports: None in this main-branch instruction audit. The dual-PR policy remains in force; release-scope exceptions still need maintainer direction.
- Follow-up: None; the changelog entry links this PR.

---

#### Checklist

- [x] Milestone: DART 7.0 for `main`
- [x] CHANGELOG.md updated under DART 7.0.0 / Build, Packaging, and Developer Tooling
- N/A: new unit tests; no product code changed, and existing AI-infrastructure tests plus instruction scenarios cover this change.
- N/A: new methods/classes; instruction documentation only.
- N/A: Python bindings and visual simulation evidence; no API, scene, or simulation changes.
